### PR TITLE
chore: Change 'PUBLIC' to 'PRIVATE' for PkgConfig::XCB

### DIFF
--- a/frame/CMakeLists.txt
+++ b/frame/CMakeLists.txt
@@ -73,7 +73,7 @@ if (BUILD_WITH_X11)
     target_compile_definitions(dde-shell-frame PRIVATE BUILD_WITH_X11=)
     pkg_check_modules(XCB REQUIRED IMPORTED_TARGET xcb-ewmh)
     target_sources(dde-shell-frame PRIVATE layershell/x11dlayershellemulation.cpp)
-    target_link_libraries(dde-shell-frame PUBLIC PkgConfig::XCB)
+    target_link_libraries(dde-shell-frame PRIVATE PkgConfig::XCB)
 endif(BUILD_WITH_X11)
 
 target_compile_definitions(dde-shell-frame


### PR DESCRIPTION
Change 'PUBLIC' to 'PRIVATE' for PkgConfig::XCB in cmake

Log: Change 'PUBLIC' to 'PRIVATE' for PkgConfig::XCB