### PR TITLE
fix: release rootObject when delete Applet

### DIFF
--- a/example/containment-example/examplecontainment.cpp
+++ b/example/containment-example/examplecontainment.cpp
@@ -61,7 +61,11 @@ bool ExampleContainment::load(const DAppletData &data)
         groups << DAppletData::fromPluginMetaData(item);
     }
     for (const auto &group : groups) {
-        createApplet(group);
+        if (auto applet = createApplet(group)) {
+            if (!applet->load(group)) {
+                removeApplet(applet);
+            }
+        }
     }
     return DApplet::load(data);
 }

--- a/example/containment-example/package/main.qml
+++ b/example/containment-example/package/main.qml
@@ -13,7 +13,7 @@ ContainmentItem {
     objectName: "containment item"
     RowLayout {
         Repeater {
-            model: Applet.appletItems
+            model: Containment.appletItems
             delegate: Control {
                 contentItem: modelData
             }

--- a/frame/applet.cpp
+++ b/frame/applet.cpp
@@ -19,6 +19,13 @@ DAppletPrivate::DAppletPrivate(DApplet *qq)
 {
 }
 
+DAppletPrivate::~DAppletPrivate()
+{
+    if (m_rootObject) {
+        m_rootObject->deleteLater();
+    }
+}
+
 DApplet::DApplet(QObject *parent)
     : DApplet(*new DAppletPrivate(this), parent)
 {

--- a/frame/panel.cpp
+++ b/frame/panel.cpp
@@ -45,7 +45,7 @@ bool DPanel::init()
 
     auto applet = this;
 
-    DQmlEngine *engine = new DQmlEngine(applet, applet);
+    std::unique_ptr<DQmlEngine> engine(new DQmlEngine(applet, applet));
 
     auto rootObject = engine->beginCreate();
 
@@ -57,7 +57,10 @@ bool DPanel::init()
 
     bool res = DContainment::init();
 
-    engine->completeCreate();
+    if (res) {
+        engine->completeCreate();
+        d->m_engine = engine.release();
+    }
 
     return res;
 }

--- a/frame/pluginloader.cpp
+++ b/frame/pluginloader.cpp
@@ -8,6 +8,7 @@
 #include "containment.h"
 #include "pluginmetadata.h"
 #include "pluginfactory.h"
+#include "panel.h"
 
 #include <dobject_p.h>
 #include <QCoreApplication>
@@ -284,8 +285,13 @@ DApplet *DPluginLoader::loadApplet(const QString &pluginId, const QString &id)
         applet = factory->create();
     }
     if (!applet) {
-        if (metaData.value("ContainmentType").isValid()) {
-            applet = new DContainment();
+        const auto containmentType = metaData.value("ContainmentType");
+        if (containmentType.isValid()) {
+            if (containmentType == "Panel") {
+                applet = new DPanel();
+            } else {
+                applet = new DContainment();
+            }
         }
     }
 

--- a/frame/pluginmetadata.cpp
+++ b/frame/pluginmetadata.cpp
@@ -91,6 +91,7 @@ DPluginMetaData DPluginMetaData::fromJsonFile(const QString &file)
     const QJsonObject metaData = QJsonDocument::fromJson(f.readAll(), &error).object();
     if (error.error) {
         qCWarning(dsLog) << "error parsing" << file << error.errorString();
+        return DPluginMetaData();
     }
 
     DPluginMetaData result;

--- a/frame/private/applet_p.h
+++ b/frame/private/applet_p.h
@@ -17,6 +17,7 @@ class DAppletPrivate : public DTK_CORE_NAMESPACE::DObjectPrivate
 {
 public:
     explicit DAppletPrivate(DApplet *qq);
+    ~DAppletPrivate() override;
 
     DPluginMetaData m_metaData;
     QString m_id;

--- a/frame/private/panel_p.h
+++ b/frame/private/panel_p.h
@@ -6,6 +6,7 @@
 
 #include "containment_p.h"
 #include "panel.h"
+#include "qmlengine.h"
 
 #include <dobject_p.h>
 #include <QVariant>
@@ -24,6 +25,7 @@ public:
     }
 
     void initDciSearchPaths();
+    DQmlEngine *m_engine = nullptr;
 
     D_DECLARE_PUBLIC(DPanel)
 };

--- a/shell/main.cpp
+++ b/shell/main.cpp
@@ -113,18 +113,27 @@ int main(int argc, char *argv[])
         }
         applets << applet;
     }
+
+    QList<DApplet *> failedApplets;
     for (auto applet : applets) {
         if (!applet->load()) {
             qWarning() << "Plugin load failed:" << applet->pluginId();
+            failedApplets << applet;
             continue;
         }
         if (!applet->init()) {
             qWarning() << "Plugin init failed:" << applet->pluginId();
+            failedApplets << applet;
             continue;
         }
     }
 
-    QObject::connect(qApp, &QCoreApplication::aboutToQuit, [applets]() {
+    for (auto item : std::as_const(failedApplets)) {
+        applets.removeOne(item);
+        item->deleteLater();
+    }
+
+    QObject::connect(qApp, &QCoreApplication::aboutToQuit, qApp, [applets]() {
         qInfo() << "Exit dde-shell.";
         for (auto item : applets) {
             item->deleteLater();


### PR DESCRIPTION
  we should release rootObject when removeApplet.
  `load` doesn't be called in createApplet, it should be called
manually like `init` function.