### PR TITLE
fix: transparent mouse event

### DIFF
--- a/panels/dock/package/main.qml
+++ b/panels/dock/package/main.qml
@@ -17,8 +17,8 @@ Window {
     visible: true
     property bool useColumnLayout: Applet.position % 2
 
-    width: useColumnLayout ? Applet.dockSize : 0
-    height: !useColumnLayout ? Applet.dockSize : 0
+    width: Applet.dockSize
+    height: Applet.dockSize
 
     D.DWindow.enabled: true
     DLayerShellWindow.anchors: position2Anchors(Applet.position)
@@ -108,6 +108,7 @@ Window {
 
     TapHandler {
         acceptedButtons: Qt.RightButton
+        gesturePolicy: TapHandler.WithinBounds
         onTapped: function(eventPoint, button) {
             if (button === Qt.RightButton) {
                 dockMenu.open()
@@ -123,7 +124,6 @@ Window {
             delegate: Loader {
                 sourceComponent: Control {
                     contentItem: model.modelData
-                    horizontalPadding: 5
                     Component.onCompleted: {
                         contentItem.parent = this
                     }

--- a/panels/dock/taskmanager/package/AppItem.qml
+++ b/panels/dock/taskmanager/package/AppItem.qml
@@ -42,9 +42,13 @@ Item {
     }
 
     // Use TapHandler for tap screen compatibility
+    // Using TapHandler also means that we need a complete single tap to trigger menu, not just a press down
     TapHandler {
         id: tapHandler
         acceptedButtons: Qt.LeftButton | Qt.RightButton
+        // NOTICE: Setting gesturePolicy is mandatory for exclusive point event grab.
+        // Otherwise default passive grab will propagate event to parent
+        gesturePolicy: TapHandler.WithinBounds
         onPressedChanged: {
             if (pressed) {
                 // Grab icon as image in advance for drag's use
@@ -55,7 +59,6 @@ Item {
         }
         onTapped: function(eventPoint, button) {
             if (button === Qt.RightButton) {
-                console.log("Right button is clicked")
                 contextMenu.open()
             } else {
                 appItem.clickItem(itemId)

--- a/panels/dock/taskmanager/package/TaskManager.qml
+++ b/panels/dock/taskmanager/package/TaskManager.qml
@@ -18,7 +18,9 @@ AppletItem {
 
     Grid {
         id: appContainer
-        flow: useColumnLayout ? Grid.TopToBottom : Grid.LeftToRight
+        flow: useColumnLayout ? Grid.LeftToRight : Grid.TopToBottom
+        rows: useColumnLayout ? 0 : 1
+        columns: useColumnLayout ? 1 : 0
         move: Transition {
             NumberAnimation {
                 properties: "x,y"
@@ -47,6 +49,7 @@ AppletItem {
                     }
 
                     onDropped: function(drop) {
+                        // FIXME: Dragging doesn't end on dropped even if Drag.onDragFinished is executed
                         drop.accept()
                     }
 


### PR DESCRIPTION
Fix transparent mouse event delivery. Use exclusive grab to make sure mouse event is just handle by one handler.

Log: fix transparent mouse event