### PR TITLE
fix: menu not closed when popup second one

### DIFF
--- a/panels/dock/CMakeLists.txt
+++ b/panels/dock/CMakeLists.txt
@@ -34,6 +34,7 @@ qt_add_dbus_adaptor(dock_sources
     DockAdaptor
 )
 
+set_source_files_properties(MenuHelper.qml PROPERTIES QT_QML_SINGLETON_TYPE TRUE)
 qt_policy(SET QTP0001 OLD)
 qt_add_qml_module(dockpanel
     PLUGIN_TARGET dockpanel-plugin
@@ -41,7 +42,7 @@ qt_add_qml_module(dockpanel
     VERSION "1.0"
     SHARED
     SOURCES ${dock_sources}
-    QML_FILES OverflowContainer.qml
+    QML_FILES OverflowContainer.qml MenuHelper.qml
     OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/plugins/org/deepin/ds/dock
 )
 

--- a/panels/dock/MenuHelper.qml
+++ b/panels/dock/MenuHelper.qml
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma Singleton
+import QtQuick
+import Qt.labs.platform
+
+Item {
+    property Menu activeMenu: null
+    function openMenu(menu: Menu) {
+        if (activeMenu) {
+            activeMenu.close()
+        }
+        menu.open()
+        menu.aboutToHide.connect(() => { activeMenu = null })
+        activeMenu = menu
+    }
+    function closeMenu(menu: Menu) {
+        menu.close()
+    }
+    function closeCurrent() {
+        if (activeMenu) {
+           closeMenu(activeMenu)
+        }
+    }
+}

--- a/panels/dock/package/main.qml
+++ b/panels/dock/package/main.qml
@@ -107,11 +107,13 @@ Window {
     }
 
     TapHandler {
-        acceptedButtons: Qt.RightButton
+        acceptedButtons: Qt.LeftButton | Qt.RightButton
         gesturePolicy: TapHandler.WithinBounds
         onTapped: function(eventPoint, button) {
-            if (button === Qt.RightButton) {
-                dockMenu.open()
+            let lastActive = MenuHelper.activeMenu
+            MenuHelper.closeCurrent()
+            if (button === Qt.RightButton && lastActive !== dockMenu) {
+                MenuHelper.openMenu(dockMenu)
             }
         }
     }

--- a/panels/dock/taskmanager/package/AppItem.qml
+++ b/panels/dock/taskmanager/package/AppItem.qml
@@ -56,7 +56,7 @@ Item {
         }
         onTapped: function(eventPoint, button) {
             if (button === Qt.RightButton) {
-                contextMenu.open()
+                MenuHelper.openMenu(contextMenu)
             } else {
                 appItem.clickItem(itemId)
             }


### PR DESCRIPTION
Cause native popup is a xdg_popup, and layer shell surface is not managed by xdg-shell. We manually manage the focus of menu by introducing a MenuHelper Singleton.

Log: fix menu not closed when popup second one