### PR TITLE
fix: protocol error when changing anchors

### DIFF
--- a/frame/layershell/qwaylandlayershellsurface_p.h
+++ b/frame/layershell/qwaylandlayershellsurface_p.h
@@ -33,8 +33,13 @@ private:
     void zwlr_layer_surface_v1_configure(uint32_t serial, uint32_t width, uint32_t height) override;
     void zwlr_layer_surface_v1_closed() override;
 
+    void calcAndSetRequestSize(QSize requestSize);
+    bool anchorsSizeConflict() const;
+    void trySetAnchorsAndSize();
+
     DLayerShellWindow* m_dlayerShellWindow;
     QSize m_pendingSize;
+    QSize m_requestSize;
     bool m_configured = false;
 };
 


### PR DESCRIPTION
When changing anchors, size might be invalid for a short period. This might lead to a protocol error. Cache anchors and size, commit them together.

Log: fix protocol error when changing anchors