### PR TITLE
refact: use Binding instead of Qt.binding

### DIFF
--- a/panels/dock/package/main.qml
+++ b/panels/dock/package/main.qml
@@ -218,9 +218,12 @@ Window {
         }
     }
 
-    Component.onCompleted: {
-        Panel.compositorReady = Qt.binding(function() {
-            return DockCompositor.compositor.created
-        })
+    // can not move into DockCompositor
+    // Panel get a object instead of ds::dock::DockPanel during DockCompositor creating
+    Binding {
+        target: Panel
+        property: "compositorReady"
+        value: DockCompositor.compositor.created
+        when: DockCompositor.compositor.created
     }
 }


### PR DESCRIPTION
use Binding instead of Qt.binding for loading plugins early

log: as title