### PR TITLE
chore: adjust package install files

### DIFF
--- a/debian/dde-shell.install
+++ b/debian/dde-shell.install
@@ -10,4 +10,4 @@ usr/lib/*/dde-shell/org.deepin.ds.notification*
 usr/share/dde-shell/org.deepin.ds.notification*/
 usr/libexec/dockplugin-loader
 usr/lib/*/qt5/plugins/wayland-shell-integration
-usr/lib/*/libdde-dockplugin-interface*
+usr/lib/*/libdde-dockplugin-interface.so.*

--- a/debian/libdde-shell.install
+++ b/debian/libdde-shell.install
@@ -1,3 +1,3 @@
-usr/lib/*/lib*.so.*
+usr/lib/*/libdde-shell.so.*
 usr/lib/*/qt6/qml/org/deepin/ds/*.so
 usr/lib/*/qt6/qml/org/deepin/ds/qmldir

--- a/panels/dock/dockplugin/plugin/CMakeLists.txt
+++ b/panels/dock/dockplugin/plugin/CMakeLists.txt
@@ -58,7 +58,10 @@ set_target_properties(dockpluginmanager PROPERTIES
 set_target_properties(dockpluginmanager-interface PROPERTIES
     LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/plugins/"
     OUTPUT_NAME dde-dockplugin-interface
+    VERSION ${CMAKE_PROJECT_VERSION}
+    SOVERSION ${CMAKE_PROJECT_VERSION_MAJOR}
 )
 
-install(TARGETS dockpluginmanager-interface DESTINATION ${CMAKE_INSTALL_LIBDIR})
+# Do not install .so development library for we don't want others to link to it.
+install(TARGETS dockpluginmanager-interface LIBRARY NAMELINK_SKIP DESTINATION ${CMAKE_INSTALL_LIBDIR})
 install(TARGETS dockpluginmanager DESTINATION ${CMAKE_INSTALL_LIBDIR}/qt5/plugins/wayland-shell-integration)


### PR DESCRIPTION
Do not install libdde-dockplugin-interface.so to any package. Just use its soname link in dde-shell.

Log: adjust package install files