### PR TITLE
fix: plugin theme not followed dock

### DIFF
--- a/panels/dock/DockCompositor.qml
+++ b/panels/dock/DockCompositor.qml
@@ -15,6 +15,10 @@ import org.deepin.ds.dock 1.0
 Item {
     id: dockCompositor
 
+    property alias dockPosition: pluginManager.dockPosition
+    property alias dockColorTheme: pluginManager.dockColorTheme
+    property alias dockDisplayMode: pluginManager.dockDisplayMode
+
     property var tooltipMap: ({})
     property var popupMap: ({})
 
@@ -26,6 +30,15 @@ Item {
     property ListModel slidingPanelPluginSurfaces: ListModel {}
 
     property var compositor: waylandCompositor
+
+    function removeDockPluginSurface(model, object) {
+        for (var i = 0; i < model.count; ++i) {
+            if (object === model.get(i).shellSurface) {
+                model.remove(i)
+                break
+            }
+        }
+    }
 
     function handlePluginTooltipSurfaceAdded(shellSurface) {
         tooltipMap[shellSurface.pluginId] = (shellSurface)
@@ -64,32 +77,71 @@ Item {
         socketName: "dockplugin"
 
         DockPluginManager {
+            id: pluginManager
+
             onPluginSurfaceCreated: (dockPluginSurface) => {
                 switch(dockPluginSurface.surfaceType) {
                 case DockPluginManager.Tooltip:
                     dockCompositor.handlePluginTooltipSurfaceAdded(dockPluginSurface)
-                    break;
+                    break
                 case DockPluginManager.Popup:
                     dockCompositor.handleTrayPopupSurfaceAdded(dockPluginSurface)
-                    break;
+                    break
                 case DockPluginManager.Tray:
                     dockCompositor.handleDockTrayIconSurfaceAdded(dockPluginSurface)
-                    break;
+                    break
                 case DockPluginManager.Fixed:
                     dockCompositor.handleDockFixedPluginSurfaceAdded(dockPluginSurface)
-                    break;
+                    break
                 case DockPluginManager.System:
                     dockCompositor.handleDockSystemPluginSurfacesAdded(dockPluginSurface)
-                    break;
+                    break
                 case DockPluginManager.Tool:
                     dockCompositor.handleDockToolPluginSurfaceAdded(dockPluginSurface)
-                    break;
+                    break
                 case DockPluginManager.Quick:
                     dockCompositor.handleDockQuickPluginSurfaceAdded(dockPluginSurface)
-                    break;
+                    break
                 case DockPluginManager.SlidingPanel:
                     dockCompositor.handleDockSlidingPanelPluginSurfaceAdded(dockPluginSurface)
-                    break;
+                    break
+                }
+            }
+
+            onPluginSurfaceDestroyed: (dockPluginSurface) => {
+                switch(dockPluginSurface.surfaceType) {
+                case DockPluginManager.Tooltip: {
+                    delete dockCompositor.tooltipMap[dockPluginSurface.pluginId]
+                    break
+                }
+                case DockPluginManager.Popup: {
+                    delete dockCompositor.popupMap[dockPluginSurface.pluginId]
+                    break
+                }
+                case DockPluginManager.Tray: {
+                    removeDockPluginSurface(dockCompositor.trayPluginSurfaces, dockPluginSurface)
+                    break
+                }
+                case DockPluginManager.Fixed: {
+                    removeDockPluginSurface(dockCompositor.fixedPluginSurfaces, dockPluginSurface)
+                    break
+                }
+                case DockPluginManager.System: {
+                    removeDockPluginSurface(dockCompositor.systemPluginSurfaces, dockPluginSurface)
+                    break
+                }
+                case DockPluginManager.Tool: {
+                    removeDockPluginSurface(dockCompositor.toolPluginSurfaces, dockPluginSurface)
+                    break
+                }
+                case DockPluginManager.Quick: {
+                    removeDockPluginSurface(dockCompositor.quickPluginSurfaces, dockPluginSurface)
+                    break
+                }
+                case DockPluginManager.SlidingPanel: {
+                    removeDockPluginSurface(dockCompositor.slidingPanelPluginSurfaces, dockPluginSurface)
+                    break
+                }
                 }
             }
         }

--- a/panels/dock/dockplugin/loader/main.cpp
+++ b/panels/dock/dockplugin/loader/main.cpp
@@ -51,7 +51,7 @@ int main(int argc, char *argv[], char *envp[])
 #endif
 
     init_setproctitle(argv, envp);
-    qputenv("DSG_APP_ID", "deepin-terminal");
+    qputenv("DSG_APP_ID", "dde-dock");
     qputenv("WAYLAND_DISPLAY", "dockplugin");
     qputenv("QT_WAYLAND_SHELL_INTEGRATION", "dockplugin-shell");
 

--- a/panels/dock/dockplugin/plugin/dockplugin.h
+++ b/panels/dock/dockplugin/plugin/dockplugin.h
@@ -59,6 +59,9 @@ public:
 
 Q_SIGNALS:
     void clicked(const QString&, bool);
+    void dockPositionChanged(uint32_t position);
+    void dockColorThemeChanged(uint32_t colorType);
+    void dockDisplayModeChanged(uint32_t displayMode);
 
 Q_SIGNALS:
     void pluginTypeChanged();

--- a/panels/dock/dockplugin/plugin/dockpluginmanager.cpp
+++ b/panels/dock/dockplugin/plugin/dockpluginmanager.cpp
@@ -29,15 +29,15 @@ void DockPluginManager::dock_plugin_manager_v1_display_mode_changed(uint32_t doc
 {
     if (dockDisplayMode != m_dockDisplayMode) {
         m_dockDisplayMode = dockDisplayMode;
-        Q_EMIT dockDisplayModeChnaged(m_dockDisplayMode);
+        Q_EMIT dockDisplayModeChanged(m_dockDisplayMode);
     }
 }
 
-void DockPluginManager::dock_plugin_manager_v1_hide_state_changed(uint32_t dockHideState)
+void DockPluginManager::dock_plugin_manager_v1_color_theme_changed(uint32_t dockColorType)
 {
-    if (dockHideState != m_dockHideState) {
-        m_dockHideState = dockHideState;
-        Q_EMIT dockHideStateChanged(m_dockHideState);
+    if (dockColorType != m_dockColorType) {
+        m_dockColorType = dockColorType;
+        Q_EMIT dockColorThemeChanged(m_dockColorType);
     }
 }
 

--- a/panels/dock/dockplugin/plugin/dockpluginmanager_p.h
+++ b/panels/dock/dockplugin/plugin/dockpluginmanager_p.h
@@ -25,17 +25,17 @@ public:
 
 Q_SIGNALS:
     void dockPositionChnaged(uint32_t position);
-    void dockDisplayModeChnaged(uint32_t displayMode);
-    void dockHideStateChanged(uint32_t hideState);
+    void dockDisplayModeChanged(uint32_t displayMode);
+    void dockColorThemeChanged(uint32_t colorType);
 
 protected:
     void dock_plugin_manager_v1_position_changed(uint32_t dockPosition) override;
     void dock_plugin_manager_v1_display_mode_changed(uint32_t dockDisplayMode) override;
-    void dock_plugin_manager_v1_hide_state_changed(uint32_t dockHideState) override;
+    void dock_plugin_manager_v1_color_theme_changed(uint32_t dockColorType) override;
 
 private:
     uint32_t m_dockPosition;
     uint32_t m_dockDisplayMode;
-    uint32_t m_dockHideState;
+    uint32_t m_dockColorType;
 };
 }

--- a/panels/dock/dockplugin/plugin/dockpluginsurface.cpp
+++ b/panels/dock/dockplugin/plugin/dockpluginsurface.cpp
@@ -15,6 +15,9 @@ DockPluginSurface::DockPluginSurface(DockPluginManager *manager, QtWaylandClient
     , m_plugin(DockPlugin::get(window->window()))
 {
     init(manager->create_plugin_surface(m_plugin->pluginId(), m_plugin->itemKey(), m_plugin->pluginType(), window->wlSurface()));
+    connect(manager, &DockPluginManager::dockPositionChnaged, m_plugin, &DockPlugin::dockPositionChanged);
+    connect(manager, &DockPluginManager::dockColorThemeChanged, m_plugin, &DockPlugin::dockColorThemeChanged);
+    connect(manager, &DockPluginManager::dockDisplayModeChanged, m_plugin, &DockPlugin::dockDisplayModeChanged);
 }
 
 DockPluginSurface::~DockPluginSurface()

--- a/panels/dock/dockplugin/protocol/dock-plugin-manager-v1.xml
+++ b/panels/dock/dockplugin/protocol/dock-plugin-manager-v1.xml
@@ -49,8 +49,8 @@
       <arg name="dock_display_mode" type="uint"/>
     </event>
 
-    <event name="hide_state_changed">
-      <arg name="dock_hide_state" type="uint"/>
+    <event name="color_theme_changed">
+      <arg name="dock_color_theme" type="uint"/>
     </event>
 
     <request name="create_plugin_surface">

--- a/panels/dock/dockpluginmanagerextension_p.h
+++ b/panels/dock/dockpluginmanagerextension_p.h
@@ -20,6 +20,7 @@ class DockPluginManager : public QWaylandCompositorExtensionTemplate<DockPluginM
 
     Q_PROPERTY(uint32_t dockPosition READ dockPosition WRITE setDockPosition)
     Q_PROPERTY(uint32_t dockDisplayMode READ dockDisplayMode WRITE setDockDisplayMode)
+    Q_PROPERTY(uint32_t dockColorTheme READ dockColorTheme WRITE setDockColorTheme)
 
 public:
     enum SurfaceType {
@@ -43,15 +44,20 @@ public:
     uint32_t dockDisplayMode() const;
     void setDockDisplayMode(uint32_t dockDisplayMode);
 
+    uint32_t dockColorTheme() const;
+    void setDockColorTheme(uint32_t type);
+
 Q_SIGNALS:
     void pluginSurfaceCreated(PluginSurface*);
-    void pluginSurfaceDestoried(PluginSurface*);
+    void pluginSurfaceDestroyed(PluginSurface*);
 
 protected:
     void dock_plugin_manager_v1_create_plugin_surface(Resource *resource, const QString &pluginId, const QString &itemKey, uint32_t surfaceType, struct ::wl_resource *surface, uint32_t id) override;
 
 private:
+    QList<QWaylandSurface*> m_pluginSurfaces;
     uint32_t m_dockPosition;
+    uint32_t m_dockColorTheme;
     uint32_t m_dockDisplayMode;
 };
 

--- a/panels/dock/package/main.qml
+++ b/panels/dock/package/main.qml
@@ -226,4 +226,18 @@ Window {
         value: DockCompositor.compositor.created
         when: DockCompositor.compositor.created
     }
+
+    Component.onCompleted: {
+        DockCompositor.dockPosition = Qt.binding(function() {
+            return Panel.position
+        })
+
+        DockCompositor.dockDisplayMode = Qt.binding(function(){
+            return Panel.displayMode
+        })
+
+        DockCompositor.dockColorTheme = Qt.binding(function(){
+            return Panel.colorTheme
+        })
+    }
 }

--- a/panels/dock/tray/package/tray.qml
+++ b/panels/dock/tray/package/tray.qml
@@ -58,11 +58,6 @@ AppletItem {
                 width: 28
                 height: 28
                 shellSurface: plugin
-                onSurfaceDestroyed: {
-                    delete DockCompositor.tooltipMap[plugin.pluginId]
-                    delete DockCompositor.popupMap[plugin.pluginId]
-                    DockCompositor.trayPluginSurfaces.remove(index)
-                }
 
                 MouseArea {
                     anchors.fill: parent


### PR DESCRIPTION
1. wayland compositor send event, need to specify the client to receive the message default client is null which will make assert invalid.
2. forward surface destory signal, and remove saved surface in DockCompositor

log: fix dock plugin theme not follow dock
issue: https://github.com/linuxdeepin/developer-center/issues/6879