### PR TITLE
fix: show-desktop shown on treeland

### DIFF
--- a/panels/dock/showdesktop/showdesktop.cpp
+++ b/panels/dock/showdesktop/showdesktop.cpp
@@ -7,6 +7,7 @@
 #include "pluginfactory.h"
 
 #include <QProcess>
+#include <QGuiApplication>
 
 DS_BEGIN_NAMESPACE
 namespace dock {
@@ -16,6 +17,11 @@ ShowDesktop::ShowDesktop(QObject *parent)
     , m_iconName("deepin-toggle-desktop")
 {
 
+}
+
+bool ShowDesktop::load()
+{
+    return QStringLiteral("xcb") == QGuiApplication::platformName();
 }
 
 bool ShowDesktop::init()

--- a/panels/dock/showdesktop/showdesktop.h
+++ b/panels/dock/showdesktop/showdesktop.h
@@ -17,6 +17,7 @@ class ShowDesktop : public DApplet
 public:
     explicit ShowDesktop(QObject *parent = nullptr);
     virtual bool init() override;
+    virtual bool load() override;
 
     QString iconName() const;
     void setIconName(const QString& iconName);


### PR DESCRIPTION
make show-desktop plugin not load on treeland

log: as title
issue: https://github.com/linuxdeepin/developer-center/issues/6909