### PR TITLE
fix: dock network plugin not update

### DIFF
--- a/panels/dock/dockplugin/loader/widgetplugin.cpp
+++ b/panels/dock/dockplugin/loader/widgetplugin.cpp
@@ -175,8 +175,32 @@ void WidgetPlugin::removeValue(PluginsItemInterface *const itemInter, const QStr
 {
 }
 
-void WidgetPlugin::updateDockInfo(PluginsItemInterface *const, const DockPart &)
+void WidgetPlugin::updateDockInfo(PluginsItemInterface *const, const DockPart &part)
 {
+    switch (part) {
+        case DockPart::QuickShow: {
+            if (m_widget) {
+                m_widget->update();
+
+                auto plugin = getPlugin(m_widget.get());
+                plugin->setContextMenu(m_pluginItem->itemContextMenu(plugin->itemKey()));
+            }
+            break;
+        }
+
+        // TODO: implement below cases
+        case DockPart::QuickPanel: {
+            break;
+        }
+
+        case DockPart::SystemPanel: {
+            break;
+        }
+
+        case DockPart::DCCSetting: {
+            break;
+        }
+    }
 }
 
 


### PR DESCRIPTION
network use updateDockInfo ti update it's icon

log: update plugin tray icon when call updateDockInfo