### PR TITLE
fix: debugMode get wrong

### DIFF
--- a/panels/dock/dockpanel.cpp
+++ b/panels/dock/dockpanel.cpp
@@ -221,7 +221,7 @@ void DockPanel::callShow()
 
 bool DockPanel::debugMode() const
 {
-#ifdef NDEBUG
+#ifndef QT_DEBUG
     return false;
 #else
     return true;


### PR DESCRIPTION
since NDEBUG not existed, use QT_DEBUG instead

log: remove NDEBUG and use QT_DEBUG