### PR TITLE
fix: wrong position for PopupPanel in x11

### DIFF
--- a/frame/qml/PanelPopup.qml
+++ b/frame/qml/PanelPopup.qml
@@ -18,8 +18,8 @@ Item {
         if (!window)
             return
 
-        var rect = Qt.rect(control.x, control.y, popup.width, popup.height)
-        window.setGeometry(rect)
+        window.xOffset = control.x
+        window.yOffset = control.y
         window.show()
         popup.open()
     }

--- a/frame/qml/PanelPopupWindow.qml
+++ b/frame/qml/PanelPopupWindow.qml
@@ -7,6 +7,12 @@ import QtQuick.Window 2.15
 import org.deepin.dtk 1.0 as D
 
 Window {
+    property real xOffset: 0
+    property real yOffset: 0
+
     flags: Qt.Popup
     D.DWindow.enabled: true
+    D.DWindow.windowRadius: 18
+    x: transientParent.x + xOffset
+    y: transientParent.y + yOffset
 }

--- a/frame/qml/PanelToolTip.qml
+++ b/frame/qml/PanelToolTip.qml
@@ -11,8 +11,8 @@ Item {
     visible: false
     default property alias toolTipContent: toolTip.contentChildren
     property alias text: toolTip.text
-    Panel.toolTipWindow.width: control.width
-    Panel.toolTipWindow.height: control.height
+    Panel.toolTipWindow.width: control.width + toolTip.leftPadding + toolTip.rightPadding
+    Panel.toolTipWindow.height: control.height + toolTip.topPadding + toolTip.bottomPadding
     onVisibleChanged: {
         if (visible) {
             open()
@@ -27,10 +27,8 @@ Item {
         if (!window)
             return
 
-        var width = toolTip.width + toolTip.leftPadding + toolTip.rightPadding
-        var height = toolTip.height + toolTip.topPadding + toolTip.bottomPadding
-        var rect = Qt.rect(control.x, control.y, width, height)
-        window.setGeometry(rect)
+        window.xOffset = control.x
+        window.yOffset = control.y
         window.show()
         toolTip.open()
     }


### PR DESCRIPTION
  Using transientParent's position as PopupPanelWindow's leftTop position.
