### PR TITLE
refact: launching app by dde-am tool

### DIFF
--- a/panels/dock/taskmanager/desktopfileamparser.h
+++ b/panels/dock/taskmanager/desktopfileamparser.h
@@ -46,6 +46,7 @@ private:
 private:
     QString id2dbusPath(const QString& id);
     void connectToAmDBusSignal(const QString& propertyName, const char* slot);
+    void launchByAMTool(const QString &action = QString());
 
 private Q_SLOTS:
     void updateActions();


### PR DESCRIPTION
Launching app by dde-am tools instead of calling dbus directly.
