### PR TITLE
fix: active can't be changed for other window

### DIFF
--- a/panels/dock/taskmanager/x11windowmonitor.cpp
+++ b/panels/dock/taskmanager/x11windowmonitor.cpp
@@ -155,7 +155,11 @@ void X11WindowMonitor::onWindowMapped(xcb_window_t xcb_window)
     auto window = m_windows.value(xcb_window, nullptr);
     if (window) return;
 
-    uint32_t value_list[] = { XCB_EVENT_MASK_PROPERTY_CHANGE | XCB_EVENT_MASK_STRUCTURE_NOTIFY | XCB_EVENT_MASK_VISIBILITY_CHANGE};
+    uint32_t value_list[] = {
+        0                                   | XCB_EVENT_MASK_PROPERTY_CHANGE        |
+        XCB_EVENT_MASK_VISIBILITY_CHANGE    | XCB_EVENT_MASK_SUBSTRUCTURE_NOTIFY    |
+        XCB_EVENT_MASK_STRUCTURE_NOTIFY     | XCB_EVENT_MASK_FOCUS_CHANGE
+    };
     xcb_change_window_attributes(X11->getXcbConnection(), xcb_window, XCB_CW_EVENT_MASK, value_list);
     window = QSharedPointer<X11Window>{new X11Window(xcb_window, this)};
     m_windows.insert(xcb_window, window);


### PR DESCRIPTION
  windowMonitor changes default connection, but lossing
XCB_EVENT_MASK_FOCUS_CHANGE.
