### PR TITLE
fix: dock get worng positoin when screen size changed

### DIFF
--- a/frame/layershell/x11dlayershellemulation.cpp
+++ b/frame/layershell/x11dlayershellemulation.cpp
@@ -41,6 +41,16 @@ LayerShellEmulation::LayerShellEmulation(QWindow* window, QObject *parent)
     connect(m_window, &QWindow::heightChanged, this, &LayerShellEmulation::onExclusionZoneChanged);
     connect(m_window, &QWindow::heightChanged, this, &LayerShellEmulation::onPositionChanged);
 
+    auto screen = m_window->screen();
+    connect(screen, &QScreen::geometryChanged, this, &LayerShellEmulation::onPositionChanged);
+    connect(m_window, &QWindow::screenChanged, this, [this](QScreen *nowScreen){
+        for (auto screen : qApp->screens()) {
+            screen->disconnect(this);
+        }
+
+        connect(nowScreen, &QScreen::geometryChanged, this, &LayerShellEmulation::onPositionChanged);
+    });
+
     // connect(m_dlayerShellWindow, &DS_NAMESPACE::DLayerShellWindow::keyboardInteractivityChanged, this, &LayerShellEmulation::onKeyboardInteractivityChanged);
 }
 


### PR DESCRIPTION
re calculate window size and position when screen geometry changed

log: as title