### PR TITLE
fix: system-monitor set error ratio for icon in QuickShow

### DIFF
--- a/panels/dock/tray/plugins/system-monitor/gui/monitor_plugin.cpp
+++ b/panels/dock/tray/plugins/system-monitor/gui/monitor_plugin.cpp
@@ -219,12 +219,10 @@ QIcon MonitorPlugin::icon(const DockPart &dockPart, DGuiApplicationHelper::Color
     QIcon icon = QIcon::fromTheme(iconName);
     if (!icon.isNull()) {
         const qreal ratio = m_itemWidget->devicePixelRatioF();
-        QSize pixmapSize = QCoreApplication::testAttribute(Qt::AA_UseHighDpiPixmaps) ? size : size * ratio;
-        QPixmap pixmap = icon.pixmap(pixmapSize);
+        QPixmap pixmap = icon.pixmap(size);
         pixmap.setDevicePixelRatio(ratio);
         if (dockPart == DockPart::QuickShow) {
             QPixmap curPixmap(size*ratio);
-            pixmap.setDevicePixelRatio(ratio);
             curPixmap.fill(Qt::transparent);
             QPainter painter;
             painter.begin(&curPixmap);


### PR DESCRIPTION
log: should not do resize as there is setting setDevicePixelRatio