### PR TITLE
fix: fix dock tray not show

### DIFF
--- a/panels/dock/tray/frame/dockapplet.cpp
+++ b/panels/dock/tray/frame/dockapplet.cpp
@@ -117,7 +117,14 @@ void DockApplet::initDock()
 bool DockApplet::init()
 {
     DApplet::init();
+
+    return true;
+}
+
+bool DockApplet::load()
+{
     qmlRegisterType<QuickProxyWidget>("WidgetProxy", 1, 0, "WidgetProxy");
+
     return true;
 }
 

--- a/panels/dock/tray/frame/dockapplet.h
+++ b/panels/dock/tray/frame/dockapplet.h
@@ -37,6 +37,7 @@ public:
     Q_INVOKABLE void initDock();
 
     virtual bool init() override;
+    virtual bool load() override;
 
 
     // ------------ old dbus data for other module ----------------//


### PR DESCRIPTION
Register 'WidgetProxy' in plugin load.

Log: fix dock tray not show
Influence: tray area display