### PR TITLE
fix: preview window radius calculation error

### DIFF
--- a/panels/dock/taskmanager/x11preview.cpp
+++ b/panels/dock/taskmanager/x11preview.cpp
@@ -134,7 +134,6 @@ public:
 
         painter->save();
         painter->setRenderHint(QPainter::Antialiasing);
-        const auto ratio = m_listView->devicePixelRatio();
         DStyleHelper dstyle(m_listView->style());
         const int radius = dstyle.pixelMetric(DStyle::PM_FrameRadius);
 
@@ -144,7 +143,7 @@ public:
         painter->setPen(pen);
         auto hoverRect = option.rect.marginsAdded(QMargins(-2,-2,-2,-2));
         if (WM_HELPER->hasComposite()) {
-            painter->drawRoundedRect(hoverRect, radius * ratio, radius * ratio);
+            painter->drawRoundedRect(hoverRect, radius, radius);
         } else {
             painter->drawRect(hoverRect);
         }


### PR DESCRIPTION
Don't multiply by device pixel ratio.