### PR TITLE
fix: error ratio when set AA_UseHighDpiPixmaps

### DIFF
--- a/panels/dock/tray/frame/util/imageutil.cpp
+++ b/panels/dock/tray/frame/util/imageutil.cpp
@@ -26,16 +26,15 @@
 const QPixmap ImageUtil::loadSvg(const QString &iconName, const QString &localPath, const int size, const qreal ratio)
 {
     QIcon icon = QIcon::fromTheme(iconName);
-    int pixmapSize = QCoreApplication::testAttribute(Qt::AA_UseHighDpiPixmaps) ? size : int(size * ratio);
     if (!icon.isNull()) {
-        QPixmap pixmap = icon.pixmap(pixmapSize);
+        QPixmap pixmap = icon.pixmap(size);
         pixmap.setDevicePixelRatio(ratio);
         if (ratio == 1)
             return pixmap;
         return pixmap.scaled(size * ratio, size * ratio);
     }
 
-    QPixmap pixmap(pixmapSize, pixmapSize);
+    QPixmap pixmap(size, size);
     QString localIcon = QString("%1%2%3").arg(localPath).arg(iconName).arg(iconName.contains(".svg") ? "" : ".svg");
     QSvgRenderer renderer(localIcon);
     pixmap.fill(Qt::transparent);
@@ -56,7 +55,7 @@ const QPixmap ImageUtil::loadSvg(const QString &iconName, const QSize size, cons
 {
     QIcon icon = QIcon::fromTheme(iconName);
     if (!icon.isNull()) {
-        QPixmap pixmap = icon.pixmap(QCoreApplication::testAttribute(Qt::AA_UseHighDpiPixmaps) ? size : QSize(size * ratio));
+        QPixmap pixmap = icon.pixmap(size);
         pixmap.setDevicePixelRatio(ratio);
         if (ratio == 1)
             return pixmap;

--- a/panels/dock/tray/plugins/shutdown/shutdownplugin.cpp
+++ b/panels/dock/tray/plugins/shutdown/shutdownplugin.cpp
@@ -274,8 +274,8 @@ QIcon ShutdownPlugin::icon(const DockPart &dockPart, DGuiApplicationHelper::Colo
 
     const auto ratio = qApp->devicePixelRatio();
     QPixmap pixmap;
-    pixmap = QIcon::fromTheme(iconName, QIcon::fromTheme(":/icons/resources/icons/system-shutdown.svg")).pixmap(QSize(PLUGIN_ICON_MAX_SIZE, PLUGIN_ICON_MAX_SIZE) * ratio);
-    pixmap.setDevicePixelRatio(ratio);
+    QString iconFile(":/icons/resources/icons/system-shutdown.svg");
+    pixmap = ImageUtil::loadSvg(iconFile, QSize(PLUGIN_ICON_MAX_SIZE, PLUGIN_ICON_MAX_SIZE), ratio);
     return pixmap;
 }
 


### PR DESCRIPTION
log: should not init by scaled size also setDevicePixelRatio
issue: https://github.com/linuxdeepin/developer-center/issues/7859