### PR TITLE
fix: fix no distance between dateTime and showDesktop

### DIFF
--- a/panels/dock/tray/frame/package/tray.qml
+++ b/panels/dock/tray/frame/package/tray.qml
@@ -22,8 +22,9 @@ AppletItem {
     property int dockOrder: 25
     property var position: Panel.position
     property var indicatorStyle: Panel.indicatorStyle
-    property var dockWidth: Applet.dockWidth
-    property var dockHeight: Applet.dockHeight
+    // '12' is the distance between dateTime and showDesktop
+    property var dockWidth: Applet.dockWidth + (useColumnLayout ? 0 : 12)
+    property var dockHeight: Applet.dockHeight + (useColumnLayout ? 12 : 0)
 
     WidgetProxy {
         anchors.centerIn: parent


### PR DESCRIPTION
Add 12 pixels to the width or height of the tray area according to the design

Log: fix no distance between dateTime and showDesktop
Influence: distance between dateTime and showDesktop