### PR TITLE
fix: unable to launch  terminal with quake-mode by dock menu

### DIFF
--- a/panels/dock/taskmanager/desktopfileamparser.cpp
+++ b/panels/dock/taskmanager/desktopfileamparser.cpp
@@ -203,7 +203,7 @@ void DesktopFileAMParser::launchByAMTool(const QString &action)
     QProcess process;
     const auto path = m_applicationInterface->path();
     process.setProcessChannelMode(QProcess::MergedChannels);
-    process.start("dde-am", {"--by-user", path});
+    process.start("dde-am", {"--by-user", path, action});
     if (!process.waitForFinished()) {
         qWarning() << "Failed to launch the path:" << path << process.errorString();
         return;


### PR DESCRIPTION
Dock did not carry the action parameter when launching the application by clicking on the menu

Issue: https://github.com/linuxdeepin/developer-center/issues/7891