### PR TITLE
fix: can't connect wifi for tray

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -4,6 +4,13 @@ include /usr/share/dpkg/default.mk
 
 DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 
+DISTRO = $(shell lsb_release -is)
+ifeq ($(DISTRO),Deepin)
+	ENABLE_DEEPIN_NMQT=ON
+else
+	ENABLE_DEEPIN_NMQT=OFF
+endif
+
 VERSION = $(DEB_VERSION_UPSTREAM)
 PACK_VER = $(shell echo $(VERSION) | awk -F'[+_~-]' '{print $$1}')
 # Fix: invalid digit "8" in octal constant. e.g.  u008 ==> 008 ==> 8
@@ -13,4 +20,4 @@ BUILD_VER = $(shell echo $(VERSION) | awk -F'[+_~-]' '{print $$2}' | sed 's/[^0-
 	dh $@
 
 override_dh_auto_configure:
-	dh_auto_configure -- -DDS_VERSION=${PACK_VER}
+	dh_auto_configure -- -DDS_VERSION=${PACK_VER} -DENABLE_DEEPIN_NMQT=${ENABLE_DEEPIN_NMQT}

--- a/panels/dock/tray/networkmanager-qt/src/CMakeLists.txt
+++ b/panels/dock/tray/networkmanager-qt/src/CMakeLists.txt
@@ -163,7 +163,7 @@ set_target_properties(KF5NetworkManagerQt PROPERTIES VERSION ${NETWORKMANAGERQT_
 
 ########### static lib for tests  ###############
 add_library(KF5NetworkManagerQt_static STATIC ${NetworkManagerQt_PART_SRCS} ${NetworkManagerQt_SETTINGS_SRCS} ${DBUS_INTERFACE_SRCS})
-set_target_properties(KF5NetworkManagerQt_static PROPERTIES COMPILE_FLAGS -DNMQT_STATIC=1)
+# set_target_properties(KF5NetworkManagerQt_static PROPERTIES COMPILE_FLAGS -DNMQT_STATIC=1)
 set_target_properties(KF5NetworkManagerQt_static PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 target_link_libraries(KF5NetworkManagerQt_static PUBLIC Qt${QT_MAJOR_VERSION}::Core Qt${QT_MAJOR_VERSION}::Network Qt${QT_MAJOR_VERSION}::DBus PkgConfig::NetworkManager PkgConfig::Gio)

--- a/panels/dock/tray/plugins/dde-network-core/dock-network-plugin/CMakeLists.txt
+++ b/panels/dock/tray/plugins/dde-network-core/dock-network-plugin/CMakeLists.txt
@@ -21,6 +21,7 @@ add_custom_target(language ALL DEPENDS ${QM_FILES})
 
 add_definitions("${QT_DEFINITIONS} -DQT_PLUGIN")
 add_library(${PLUGIN_NAME} SHARED ${SRCS} ../common-plugin/network.qrc)
+set_target_properties(${PLUGIN_NAME} PROPERTIES LIBRARY_OUTPUT_DIRECTORY ../../quick-trays)
 
 target_include_directories(${PLUGIN_NAME} PUBLIC
     ${NETINTERFACEINCLUDE}


### PR DESCRIPTION
Remove NMQT_STATIC, it's used in test.
Add ENABLE_DEEPIN_NMQT in rules.

issue: https://github.com/linuxdeepin/developer-center/issues/7880
