### PR TITLE
fix: modify the distance between app icons and indicator margins

### DIFF
--- a/panels/dock/launcherItem/package/launcheritem.qml
+++ b/panels/dock/launcherItem/package/launcheritem.qml
@@ -13,8 +13,9 @@ AppletItem {
     id: launcher
     property bool useColumnLayout: Panel.position % 2
     property int dockOrder: 12
-    implicitWidth: useColumnLayout ? Panel.rootObject.dockSize : Panel.rootObject.dockItemMaxSize
-    implicitHeight: useColumnLayout ? Panel.rootObject.dockItemMaxSize : Panel.rootObject.dockSize
+    // 1:4 the distance between app : dock height; get width/height≈0.8
+    implicitWidth: useColumnLayout ? Panel.rootObject.dockSize : Panel.rootObject.dockItemMaxSize * 0.8
+    implicitHeight: useColumnLayout ? Panel.rootObject.dockItemMaxSize * 0.8 : Panel.rootObject.dockSize
 
     Connections {
         target: Panel.rootObject
@@ -43,9 +44,9 @@ AppletItem {
         anchors.centerIn: parent
         icon.name: Applet.iconName
         scale: Panel.rootObject.itemScale
-        // 10 : 36 : 10
-        icon.height: Panel.rootObject.itemIconSizeBase * 0.64
-        icon.width: Panel.rootObject.itemIconSizeBase * 0.64
+        // 9:14 (iconSize/dockHeight)
+        icon.height: Panel.rootObject.itemIconSizeBase * 0.643
+        icon.width: Panel.rootObject.itemIconSizeBase * 0.643
         onClicked: Applet.toggleLauncher()
         onXChanged: updateLaunchpadPos()
         onYChanged: updateLaunchpadPos()

--- a/panels/dock/package/main.qml
+++ b/panels/dock/package/main.qml
@@ -33,7 +33,7 @@ Window {
     property real itemScale: 1.0
     property real draggingSize: 0.0
     property int itemIconSizeBase: 0
-    property int itemSpacing: dockItemMaxSize / 20
+    property int itemSpacing: 0
 
     property bool isDragging: false
 

--- a/panels/dock/taskmanager/package/AppItem.qml
+++ b/panels/dock/taskmanager/package/AppItem.qml
@@ -32,8 +32,9 @@ Item {
     Drag.dragType: Drag.Automatic
     Drag.mimeData: { "text/x-dde-dock-dnd-appid": itemId }
 
-    property int statusIndicatorSize: root.width * 0.8
-    property int iconSize: Panel.rootObject.itemIconSizeBase * 0.64
+    property bool useColumnLayout: Panel.position % 2
+    property int statusIndicatorSize: useColumnLayout ? root.width * 0.74 : root.height * 0.74
+    property int iconSize: Panel.rootObject.itemIconSizeBase * 0.643 // 9:14 (iconSize/dockHeight)
 
     Item {
         anchors.fill: parent
@@ -77,38 +78,31 @@ Item {
                 windowIndicator.anchors.rightMargin = 0
                 windowIndicator.anchors.horizontalCenter = undefined
                 windowIndicator.anchors.verticalCenter = undefined
+                let fixedDistance = 2
 
                 switch(Panel.position) {
                 case Dock.Top: {
                     windowIndicator.anchors.horizontalCenter = parent.horizontalCenter
                     windowIndicator.anchors.top = parent.top
-                    windowIndicator.anchors.topMargin = Qt.binding(function() {
-                        return Math.floor(root.width * 0.1) - 1
-                    })
+                    windowIndicator.anchors.topMargin = fixedDistance
                     return
                 }
                 case Dock.Bottom: {
                     windowIndicator.anchors.horizontalCenter = parent.horizontalCenter
                     windowIndicator.anchors.bottom = parent.bottom
-                    windowIndicator.anchors.bottomMargin = Qt.binding(function() {
-                        return Math.floor(root.width * 0.1) - 1
-                    })
+                    windowIndicator.anchors.bottomMargin = fixedDistance
                     return
                 }
                 case Dock.Left: {
                     windowIndicator.anchors.verticalCenter = parent.verticalCenter
                     windowIndicator.anchors.left = parent.left
-                    windowIndicator.anchors.leftMargin = Qt.binding(function() {
-                        return Math.floor(root.width * 0.1) - 1
-                    })
+                    windowIndicator.anchors.leftMargin = fixedDistance
                     return
                 }
                 case Dock.Right:{
                     windowIndicator.anchors.verticalCenter = parent.verticalCenter
                     windowIndicator.anchors.right = parent.right
-                    windowIndicator.anchors.rightMargin = Qt.binding(function() {
-                        return Math.floor(root.width * 0.1) - 1
-                    })
+                    windowIndicator.anchors.rightMargin = fixedDistance
                     return
                 }
                 }

--- a/panels/dock/taskmanager/package/TaskManager.qml
+++ b/panels/dock/taskmanager/package/TaskManager.qml
@@ -42,8 +42,9 @@ ContainmentItem {
                 required property list<string> windows
 
                 // TODO: 临时溢出逻辑，待后面修改
-                implicitWidth: Panel.rootObject.dockItemMaxSize
-                implicitHeight: Panel.rootObject.dockItemMaxSize
+                // 1:4 the distance between app : dock height; get width/height≈0.8
+                implicitWidth: useColumnLayout ? Panel.rootObject.dockItemMaxSize : Panel.rootObject.dockItemMaxSize * 0.8
+                implicitHeight: useColumnLayout ? Panel.rootObject.dockItemMaxSize * 0.8 : Panel.rootObject.dockItemMaxSize
 
                 onEntered: function(drag) {
                     visualModel.items.move((drag.source as AppItem).visualIndex, app.visualIndex)


### PR DESCRIPTION
1. 9:14 (iconSize/dockHeight)
2. 1:4 the distance between app : dock height; get width/height≈0.8
3. indicator margins = 2

Log: modify the distance between app icons
Issue: https://github.com/linuxdeepin/developer-center/issues/7969
Influence: the distance between app icons and indicator margins