### PR TITLE
fix: don't save the visibility

### DIFF
--- a/panels/dock/dconfig/org.deepin.ds.dock.json
+++ b/panels/dock/dconfig/org.deepin.ds.dock.json
@@ -51,6 +51,16 @@
 			"description": "",
 			"permissions": "readwrite",
 			"visibility": "private"
-		}
+		},
+    "Plugins_Visible": {
+			"value": {},
+			"serial": 0,
+			"flags": [],
+			"name": "The visibilities of plugins",
+			"name[zh_CN]": "插件可见性",
+			"description": "The loaded plugin which is visible when dock is started.",
+			"permissions": "readwrite",
+			"visibility": "private"
+    }
 	}
 }

--- a/panels/dock/dockdbusproxy.h
+++ b/panels/dock/dockdbusproxy.h
@@ -72,6 +72,7 @@ private:
     QString getAppID(const QString &desktopfile);
     QList<DS_NAMESPACE::DApplet *> appletList(const QString &pluginId) const;
     DS_NAMESPACE::DApplet *applet(const QString &pluginId) const;
+    void setPluginVisible(const QString &pluginId, const QVariantMap &pluginsVisible);
 
     DS_NAMESPACE::DApplet *m_oldDockApplet;
     DS_NAMESPACE::DApplet *m_clipboardApplet;

--- a/panels/dock/docksettings.cpp
+++ b/panels/dock/docksettings.cpp
@@ -16,6 +16,7 @@ const static QString keyHideMode                = "Hide_Mode";
 const static QString keyDockSize                = "Dock_Size";
 const static QString keyItemAlignment           = "Item_Alignment";
 const static QString keyIndicatorStyle          = "Indicator_Style";
+const static QString keyPluginsVisible           = "Plugins_Visible";
 
 namespace dock {
 
@@ -143,6 +144,7 @@ void DockSettings::init()
         m_dockPosition = string2Position(m_dockConfig->value(keyPosition).toString());
         m_alignment = string2ItenAlignment(m_dockConfig->value(keyItemAlignment).toString());
         m_style = string2IndicatorStyle(m_dockConfig->value(keyIndicatorStyle).toString());
+        m_pluginsVisible = m_dockConfig->value(keyPluginsVisible).toMap();
 
         connect(m_dockConfig.data(), &DConfig::valueChanged, this, [this](const QString& key){
             if (keyDockSize == key) {
@@ -170,6 +172,9 @@ void DockSettings::init()
                 if (style == m_style) return;
                 m_style = style;
                 Q_EMIT indicatorStyleChanged(m_style);
+            } else if (keyPluginsVisible == key) {
+                auto pluginsVisible = m_dockConfig->value(keyPluginsVisible).toMap();
+                setPluginsVisible(pluginsVisible);
             }
         });
     } else {
@@ -245,6 +250,21 @@ void DockSettings::setIndicatorStyle(const IndicatorStyle& style)
     m_style = style;
     Q_EMIT indicatorStyleChanged(style);
     addWriteJob(indicatorStyleJob);
+}
+
+QVariantMap DockSettings::pluginsVisible()
+{
+    return m_pluginsVisible;
+}
+
+void DockSettings::setPluginsVisible(const QVariantMap & pluginsVisible)
+{
+    if (m_pluginsVisible == pluginsVisible) {
+        return; 
+    }
+    m_pluginsVisible = pluginsVisible;
+    m_dockConfig->setValue(keyPluginsVisible, QVariant::fromValue(m_pluginsVisible));
+    Q_EMIT pluginsVisibleChanged(m_pluginsVisible);
 }
 
 void DockSettings::addWriteJob(WriteJob job)

--- a/panels/dock/docksettings.h
+++ b/panels/dock/docksettings.h
@@ -24,6 +24,7 @@ class DockSettings : public QObject
     Q_PROPERTY(Position position READ position WRITE setPosition NOTIFY positionChanged FINAL)
     Q_PROPERTY(ItemAlignment itemAlignment READ itemAlignment WRITE setItemAlignment NOTIFY itemAlignmentChanged FINAL)
     Q_PROPERTY(IndicatorStyle indicatorStyle READ indicatorStyle WRITE setIndicatorStyle NOTIFY indicatorStyleChanged FINAL)
+    Q_PROPERTY(QVariantMap pluginsVisible READ pluginsVisible WRITE setPluginsVisible NOTIFY pluginsVisibleChanged FINAL)
 
 public:
     static DockSettings* instance();
@@ -33,12 +34,14 @@ public:
     Position position();
     ItemAlignment itemAlignment();
     IndicatorStyle indicatorStyle();
+    QVariantMap pluginsVisible();
 
     void setDockSize(const uint& size);
     void setHideMode(const HideMode& mode);
     void setPosition(const Position& position);
     void setItemAlignment(const ItemAlignment& alignment);
     void setIndicatorStyle(const IndicatorStyle& style);
+    void setPluginsVisible(const QVariantMap & pluginsVisible);
 
 private:
     enum WriteJob {
@@ -61,6 +64,7 @@ Q_SIGNALS:
     void positionChanged(Position position);
     void itemAlignmentChanged(ItemAlignment alignment);
     void indicatorStyleChanged(IndicatorStyle style);
+    void pluginsVisibleChanged(const QVariantMap &pluginsVisible);
 
 private:
     QScopedPointer<DConfig> m_dockConfig;
@@ -72,5 +76,6 @@ private:
     Position m_dockPosition;
     ItemAlignment m_alignment;
     IndicatorStyle m_style;
+    QVariantMap m_pluginsVisible;
 };
 }


### PR DESCRIPTION
save the visibility of a plugin item by dconfig tool

Issue: https://github.com/linuxdeepin/developer-center/issues/7959