### PR TITLE
feat: don't use inactive color group

### DIFF
--- a/shell/main.cpp
+++ b/shell/main.cpp
@@ -82,6 +82,7 @@ public:
 
 int main(int argc, char *argv[])
 {
+    DGuiApplicationHelper::setAttribute(DGuiApplicationHelper::UseInactiveColorGroup, false);
     QApplication a(argc, argv);
     a.setOrganizationName("deepin");
     a.setApplicationName("org.deepin.dde-shell");


### PR DESCRIPTION
Don't use inactive color group in dde-shell.

Log: don't use inactive color group in dde-shell