### PR TITLE
fix: app icon not centered

### DIFF
--- a/panels/dock/taskmanager/package/AppItem.qml
+++ b/panels/dock/taskmanager/package/AppItem.qml
@@ -54,6 +54,7 @@ Item {
             height: root.statusIndicatorSize
             anchors.centerIn: parent
             visible: root.displayMode === Dock.Efficient && root.windows.length > 0
+            anchors.alignWhenCentered: false
         }
 
         WindowIndicator {
@@ -65,6 +66,7 @@ Item {
             useColumnLayout: Panel.position % 2
             palette: itemPalette
             visible: (root.displayMode === Dock.Efficient && root.windows.length > 1) || (root.displayMode === Dock.Fashion && root.windows.length > 0)
+            anchors.alignWhenCentered: false
 
             function updateIndicatorAnchors() {
                 windowIndicator.anchors.top = undefined
@@ -147,6 +149,7 @@ Item {
             name: root.iconName
             sourceSize: Qt.size(iconSize, iconSize)
             anchors.centerIn: parent
+            anchors.alignWhenCentered: false
             scale: Panel.rootObject.itemScale
             BeatAnimation {
                 target: icon


### PR DESCRIPTION
Disable align when centered in app item.

Log: fix app icon not centered
Issue: https://github.com/linuxdeepin/developer-center/issues/7941
Depends: https://github.com/linuxdeepin/dtkdeclarative/pull/322