### PR TITLE
fix: error palette when get pixmap form dci

### DIFF
--- a/panels/dock/clipboarditem/clipboarditem.cpp
+++ b/panels/dock/clipboarditem/clipboarditem.cpp
@@ -8,6 +8,7 @@
 
 #include <DDBusSender>
 #include <DDciIcon>
+#include <DGuiApplicationHelper>
 
 #include <QGuiApplication>
 #include <QBuffer>
@@ -44,14 +45,28 @@ DockItemInfo ClipboardItem::dockItemInfo()
     info.settingKey = "clipboard";
     info.visible = m_visible;
     {
-        auto lightPixmap = DDciIcon::fromTheme("clipboard").pixmap(qApp->devicePixelRatio(), 30, DDciIcon::Light);
+        const auto lightPalette = DGuiApplicationHelper::instance()->applicationPalette(DGuiApplicationHelper::LightType);
+        auto lightPixmap = DDciIcon::fromTheme("clipboard").pixmap(
+            qApp->devicePixelRatio(),
+            30,
+            DDciIcon::Light,
+            DDciIcon::Normal,
+            DDciIconPalette::fromQPalette(lightPalette)
+            );
         QBuffer buffer(&info.iconLight);
         if (buffer.open(QIODevice::WriteOnly)) {
             lightPixmap.save(&buffer, "png");
         }
     }
     {
-        auto darkPixmap = DDciIcon::fromTheme("clipboard").pixmap(qApp->devicePixelRatio(), 30, DDciIcon::Dark);
+        const auto darkPalette = DGuiApplicationHelper::instance()->applicationPalette(DGuiApplicationHelper::DarkType);
+        auto darkPixmap = DDciIcon::fromTheme("clipboard").pixmap(
+            qApp->devicePixelRatio(),
+            30,
+            DDciIcon::Dark,
+            DDciIcon::Normal,
+            DDciIconPalette::fromQPalette(darkPalette)
+            );
         QBuffer buffer(&info.iconDark);
         if (buffer.open(QIODevice::WriteOnly)) {
             darkPixmap.save(&buffer, "png");

--- a/panels/dock/clipboarditem/clipboarditem.h
+++ b/panels/dock/clipboarditem/clipboarditem.h
@@ -24,7 +24,6 @@ public:
     inline bool visible() const { return m_visible;}
     Q_INVOKABLE void setVisible(bool visible);
 
-
 Q_SIGNALS:
     void visibleChanged(bool);
 

--- a/panels/dock/searchitem/searchitem.cpp
+++ b/panels/dock/searchitem/searchitem.cpp
@@ -8,6 +8,7 @@
 
 #include <DDBusSender>
 #include <DDciIcon>
+#include <DGuiApplicationHelper>
 
 #include <QProcess>
 #include <QBuffer>
@@ -48,15 +49,30 @@ DockItemInfo SearchItem::dockItemInfo()
     info.itemKey = "search";
     info.settingKey = "search";
     info.visible = m_visible;
+
     {
-        auto lightPixmap = DDciIcon::fromTheme("search").pixmap(qApp->devicePixelRatio(), 30, DDciIcon::Light);
+        const auto lightPalette = DGuiApplicationHelper::instance()->applicationPalette(DGuiApplicationHelper::LightType);
+        auto lightPixmap = DDciIcon::fromTheme("search").pixmap(
+            qApp->devicePixelRatio(),
+            30,
+            DDciIcon::Light,
+            DDciIcon::Normal,
+            DDciIconPalette::fromQPalette(lightPalette)
+            );
         QBuffer buffer(&info.iconLight);
         if (buffer.open(QIODevice::WriteOnly)) {
             lightPixmap.save(&buffer, "png");
         }
     }
     {
-        auto darkPixmap = DDciIcon::fromTheme("search").pixmap(qApp->devicePixelRatio(), 30, DDciIcon::Dark);
+        const auto darkPalette = DGuiApplicationHelper::instance()->applicationPalette(DGuiApplicationHelper::DarkType);
+        auto darkPixmap = DDciIcon::fromTheme("search").pixmap(
+            qApp->devicePixelRatio(),
+            30,
+            DDciIcon::Dark,
+            DDciIcon::Normal,
+            DDciIconPalette::fromQPalette(darkPalette)
+            );
         QBuffer buffer(&info.iconDark);
         if (buffer.open(QIODevice::WriteOnly)) {
             darkPixmap.save(&buffer, "png");


### PR DESCRIPTION
log: 插件 dci 图标以前景色填充，使用默认 palette 暗亮色可能会有问题
https://desktopspec.org/unstable/%E5%9B%BE%E6%A0%87%E6%96%87%E4%BB%B6%E8%A7%84%E8%8C%83.html