### PR TITLE
fix: adjust indicator palette

### DIFF
--- a/panels/dock/taskmanager/package/AppItem.qml
+++ b/panels/dock/taskmanager/package/AppItem.qml
@@ -57,7 +57,7 @@ Item {
             displayMode: root.displayMode
             colorTheme: root.colorTheme
             active: root.active
-            backgroundColor: "orange"
+            backgroundColor: D.DTK.palette.highlight
         }
 
         StatusIndicator {

--- a/panels/dock/taskmanager/package/AppItemPalette.qml
+++ b/panels/dock/taskmanager/package/AppItemPalette.qml
@@ -21,7 +21,11 @@ Item {
                 return active ? Qt.rgba(0, 0, 0, 0.8) : Qt.rgba(0, 0, 0, 0.3)
             }
         } else if (displayMode === Dock.Fashion) {
-            return active ? backgroundColor : "#ffffff"
+            if (colorTheme === Dock.Dark) {
+                return active ? backgroundColor : Qt.rgba(1, 1, 1)
+            } else {
+                return active ? backgroundColor : Qt.rgba(0, 0, 0)
+            }
         } else {
             return "#00000000"
         }
@@ -29,7 +33,7 @@ Item {
 
     // Actually only in fashion mode will dot indicator have border
     property color dotIndicatorBorder: {
-        return Qt.rgba(0, 0, 0, 0.2)
+        return colorTheme === Dock.Dark ? Qt.rgba(1, 1, 1, 0.2) : Qt.rgba(0, 0, 0, 0.2)
     }
 
     property color rectIndicator: {


### PR DESCRIPTION
As title, adjust indicator palette according to design, temporarily use highlight color for active item.

Log: adjust indicator palette
Issue: https://github.com/linuxdeepin/developer-center/issues/7945