### PR TITLE
fix: don't hardcode the path of lrelease

### DIFF
--- a/panels/dock/tray/translate_generation.sh
+++ b/panels/dock/tray/translate_generation.sh
@@ -7,5 +7,12 @@ ts_list=(`ls translations/*.ts`)
 for ts in "${ts_list[@]}"
 do
     printf "\nprocess ${ts}\n"
-    /usr/lib/qt6/bin/lrelease "${ts}"
+    if [ -f /usr/lib/qt6/bin/lrelease ]; then
+        /usr/lib/qt6/bin/lrelease "${ts}"
+    elif [ -f /usr/lib64/qt6/bin/lrelease ]; then
+        /usr/lib64/qt6/bin/lrelease "${ts}"
+    else
+        printf "Qt6 lrelease is not installed\n"
+        exit 1
+    fi 
 done


### PR DESCRIPTION
Support rpm base distributions.

Log: The 64bit libraries is in the /usr/lib64 in Fedora, openSUSE and other rpm base distributions. Please don't hardcode it.