### PR TITLE
fix: not set themeType to DWindow

### DIFF
--- a/panels/dock/package/main.qml
+++ b/panels/dock/package/main.qml
@@ -50,6 +50,7 @@ Window {
     D.DWindow.enabled: true
     D.DWindow.windowRadius: 0
     D.DWindow.enableBlurWindow: true
+    D.DWindow.themeType: Panel.colorTheme
 
     onDockSizeChanged: {
         if (dock.dockSize === Dock.MIN_DOCK_SIZE) {
@@ -482,6 +483,15 @@ Window {
         DockCompositor.dockColorTheme = Qt.binding(function(){
             return Panel.colorTheme
         })
+
+        Panel.toolTipWindow.D.DWindow.themeType = Qt.binding(function(){
+            return Panel.colorTheme
+        })
+
+        Panel.popupWindow.D.DWindow.themeType = Qt.binding(function(){
+            return Panel.colorTheme
+        })
+
         dock.itemIconSizeBase = dock.dockItemMaxSize
 
         changeDragAreaAnchor()


### PR DESCRIPTION
log: as title
issue: https://github.com/linuxdeepin/developer-center/issues/8075


TODO: popup and tooltip window colorSelector get wrong color need fix at Dtk