### PR TITLE
fix: no icon when desktopfile no icon defined

### DIFF
--- a/panels/dock/taskmanager/desktopfileamparser.cpp
+++ b/panels/dock/taskmanager/desktopfileamparser.cpp
@@ -94,6 +94,8 @@ QString DesktopFileAMParser::desktopIcon()
         updateDesktopIcon();
     }
 
+    if (m_icon.isEmpty()) return DesktopfileAbstractParser::desktopIcon();
+
     return m_icon;
 }
 


### PR DESCRIPTION
return a default icon when desktopfile parser get a empty icon

log: as title