### PR TITLE
fix: don't emit FrontendWindowRectChanged signal

### DIFF
--- a/panels/dock/dockpanel.cpp
+++ b/panels/dock/dockpanel.cpp
@@ -69,6 +69,7 @@ bool DockPanel::init()
         });
     });
 
+    connect(this, &DockPanel::frontendWindowRectChanged, dockDaemonAdaptor, &DockDaemonAdaptor::FrontendWindowRectChanged);
     connect(SETTINGS, &DockSettings::dockSizeChanged, this, &DockPanel::dockSizeChanged);
     connect(SETTINGS, &DockSettings::hideModeChanged, this, &DockPanel::hideModeChanged);
     connect(SETTINGS, &DockSettings::itemAlignmentChanged, this, &DockPanel::itemAlignmentChanged);


### PR DESCRIPTION
don't emit FrontendWindowRectChanged signal

Issue: https://github.com/linuxdeepin/developer-center/issues/8026