### PR TITLE
fix: "showtimetofull" option didn't work

### DIFF
--- a/panels/dock/CMakeLists.txt
+++ b/panels/dock/CMakeLists.txt
@@ -149,3 +149,4 @@ target_include_directories(dock-plugin
 
 install(DIRECTORY "${PROJECT_BINARY_DIR}/plugins/org/deepin/ds/dock/" DESTINATION "${QML_INSTALL_DIR}/org/deepin/ds/dock/")
 dtk_add_config_meta_files(APPID org.deepin.ds.dock FILES dconfig/org.deepin.ds.dock.json)
+dtk_add_config_meta_files(APPID org.deepin.ds.dock FILES dconfig/org.deepin.ds.dock.power.json)

--- a/panels/dock/dconfig/org.deepin.ds.dock.power.json
+++ b/panels/dock/dconfig/org.deepin.ds.dock.power.json
@@ -1,0 +1,46 @@
+{
+    "magic": "dsg.config.meta",
+    "version": "1.0",
+    "contents": {
+        "control": {
+            "value": false,
+            "serial": 0,
+            "flags": [],
+            "name": "contorl",
+            "name[zh_CN]": "控制",
+            "description": "阻止鼠标事件",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "enable": {
+            "value": true,
+            "serial": 0,
+            "flags": [],
+            "name": "enable",
+            "name[zh_CN]": "使能",
+            "description": "使能电源管理模块。",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "showtimetofull":{
+            "value": true,
+            "serial": 0,
+            "flags": [],
+            "name": "showtimetofull",
+            "name[zh_CN]": "显示完整时间",
+            "description": "是否显示电池使用时间/剩余充电时间。",
+            "permissions": "readwrite",
+            "visibility": "public"
+        },
+        "menu-enable":{
+            "value": true,
+            "serial": 0,
+            "flags": [],
+            "name": "menu-enable",
+            "name[zh_CN]": "使能菜单",
+            "description": "使能菜单。",
+            "permissions": "readwrite",
+            "visibility": "private"
+        }
+    }
+}

--- a/panels/dock/tray/plugins/power/powerplugin.cpp
+++ b/panels/dock/tray/plugins/power/powerplugin.cpp
@@ -26,7 +26,7 @@ PowerPlugin::PowerPlugin(QObject *parent)
     , m_tipsLabel(new TipsWidget)
     , m_systemPowerInter(nullptr)
     , m_powerInter(nullptr)
-    , m_dconfig(new DConfig(QString("org.deepin.dde.dock.power"), QString()))
+    , m_dconfig(DConfig::create(QLatin1String("org.deepin.ds.dock"), QLatin1String("org.deepin.ds.dock.power"), QString(), this))
     , m_preChargeTimer(new QTimer(this))
     , m_quickPanel(nullptr)
 {


### PR DESCRIPTION
Corrected the way of fetching DConfig configurations so that it will get the same config as dde-control-center

Issue: https://github.com/linuxdeepin/developer-center/issues/8144
Log: "showtimetofull" option didn't work