### PR TITLE
fix: When the dock is hidden, the system tray expansion box is not hi…

### DIFF
--- a/panels/dock/tray/frame/window/tray/widgets/expandiconwidget.cpp
+++ b/panels/dock/tray/frame/window/tray/widgets/expandiconwidget.cpp
@@ -85,11 +85,11 @@ void ExpandIconWidget::paintEvent(QPaintEvent *event)
 void ExpandIconWidget::moveEvent(QMoveEvent *event)
 {
     BaseTrayWidget::moveEvent(event);
-    // 当前展开按钮位置发生变化的时候，需要同时改变托盘的位置
+    // 当前展开按钮位置发生变化的时候，需要关掉托盘面板
     QMetaObject::invokeMethod(this, [] {
         TrayGridWidget *gridView = popupTrayView();
         if (gridView->isVisible())
-            gridView->resetPosition();
+            gridView->hide();
     }, Qt::QueuedConnection);
 }
 


### PR DESCRIPTION
…dden.

Hide the system tray expansion box when the system tray icon is moved.

log: as title
issue: https://github.com/linuxdeepin/developer-center/issues/8153