### PR TITLE
fix: Clicking the collapse button does not collapse the tray view.

### DIFF
--- a/panels/dock/tray/frame/window/tray/widgets/expandiconwidget.cpp
+++ b/panels/dock/tray/frame/window/tray/widgets/expandiconwidget.cpp
@@ -288,8 +288,7 @@ void TrayGridWidget::initMember()
                 if (!widget)
                     continue;
 
-                QRect rectExpandWidget(widget->mapToGlobal(QPoint(0, 0)), widget->size());
-                if (rectExpandWidget.contains(mousePos))
+                if (widget->underMouse())
                     return;
             }
         }


### PR DESCRIPTION
The mapToGlobal function returns incorrect coordinates, which should be fixed by checking the underMouse status of the collapse button.

log: as title
issue: https://github.com/linuxdeepin/developer-center/issues/8175