### PR TITLE
fix: fix incorrect bluetooth activation status icon in the tray quick…

### DIFF
--- a/panels/dock/tray/plugins/bluetooth/bluetoothmainwidget.cpp
+++ b/panels/dock/tray/plugins/bluetooth/bluetoothmainwidget.cpp
@@ -64,7 +64,7 @@ void BluetoothMainWidget::initUi()
     m_iconButton->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
     m_iconButton->setFocusPolicy(Qt::FocusPolicy::TabFocus);
     m_iconButton->setIconSize({24, 24});
-    m_iconButton->setIcon(QIcon(bluetoothIcon(true)));
+    m_iconButton->setIcon(QIcon::fromTheme("bluetooth"));
     m_iconButton->setCheckable(true);
     m_iconButton->setChecked(isOpen());
     onPaletteChanged();


### PR DESCRIPTION
… panel

fix incorrect bluetooth activation status icon in the tray quick panel.

Log: fix incorrect bluetooth activation status icon in the tray quick panel
issue: https://github.com/linuxdeepin/developer-center/issues/8237
Influence: bluetooth activation status icon display