### PR TITLE
fix: crashed when open dock's menu

### DIFF
--- a/panels/dock/package/main.qml
+++ b/panels/dock/package/main.qml
@@ -142,85 +142,89 @@ Window {
         dockRightPartModel.update()
     }
 
-    LP.Menu {
-        id: dockMenu
-        MutuallyExclusiveMenu {
-            visible: Panel.debugMode
-            title: qsTr("Indicator Style")
-            EnumPropertyMenuItem {
-                name: qsTr("Fashion Mode")
-                prop: "indicatorStyle"
-                value: Dock.Fashion
+    Loader {
+        id: dockMenuLoader
+        active: false
+        sourceComponent: LP.Menu {
+            id: dockMenu
+            MutuallyExclusiveMenu {
+                visible: Panel.debugMode
+                title: qsTr("Indicator Style")
+                EnumPropertyMenuItem {
+                    name: qsTr("Fashion Mode")
+                    prop: "indicatorStyle"
+                    value: Dock.Fashion
+                }
+                EnumPropertyMenuItem {
+                    name: qsTr("Efficient Mode")
+                    prop: "indicatorStyle"
+                    value: Dock.Efficient
+                }
             }
-            EnumPropertyMenuItem {
-                name: qsTr("Efficient Mode")
-                prop: "indicatorStyle"
-                value: Dock.Efficient
+            MutuallyExclusiveMenu {
+                title: qsTr("Alignment")
+                EnumPropertyMenuItem {
+                    name: qsTr("Align Left")
+                    prop: "itemAlignment"
+                    value: Dock.LeftAlignment
+                }
+                EnumPropertyMenuItem {
+                    name: qsTr("Align Center")
+                    prop: "itemAlignment"
+                    value: Dock.CenterAlignment
+                }
             }
-        }
-        MutuallyExclusiveMenu {
-            title: qsTr("Alignment")
-            EnumPropertyMenuItem {
-                name: qsTr("Align Left")
-                prop: "itemAlignment"
-                value: Dock.LeftAlignment
+            MutuallyExclusiveMenu {
+                title: qsTr("Position")
+                EnumPropertyMenuItem {
+                    enabled: Panel.debugMode
+                    name: qsTr("Top")
+                    prop: "position"
+                    value: Dock.Top
+                }
+                EnumPropertyMenuItem {
+                    name: qsTr("Bottom")
+                    prop: "position"
+                    value: Dock.Bottom
+                }
+                EnumPropertyMenuItem {
+                    enabled: Panel.debugMode
+                    name: qsTr("Left")
+                    prop: "position"
+                    value: Dock.Left
+                }
+                EnumPropertyMenuItem {
+                    enabled: Panel.debugMode
+                    name: qsTr("Right")
+                    prop: "position"
+                    value: Dock.Right
+                }
             }
-            EnumPropertyMenuItem {
-                name: qsTr("Align Center")
-                prop: "itemAlignment"
-                value: Dock.CenterAlignment
+            MutuallyExclusiveMenu {
+                title: qsTr("Status")
+                EnumPropertyMenuItem {
+                    name: qsTr("Keep Shown")
+                    prop: "hideMode"
+                    value: Dock.KeepShowing
+                }
+                EnumPropertyMenuItem {
+                    name: qsTr("Keep Hidden")
+                    prop: "hideMode"
+                    value: Dock.KeepHidden
+                }
+                EnumPropertyMenuItem {
+                    enabled: Panel.debugMode
+                    name: qsTr("Smart Hide")
+                    prop: "hideMode"
+                    value: Dock.SmartHide
+                }
             }
-        }
-        MutuallyExclusiveMenu {
-            title: qsTr("Position")
-            EnumPropertyMenuItem {
-                enabled: Panel.debugMode
-                name: qsTr("Top")
-                prop: "position"
-                value: Dock.Top
-            }
-            EnumPropertyMenuItem {
-                name: qsTr("Bottom")
-                prop: "position"
-                value: Dock.Bottom
-            }
-            EnumPropertyMenuItem {
-                enabled: Panel.debugMode
-                name: qsTr("Left")
-                prop: "position"
-                value: Dock.Left
-            }
-            EnumPropertyMenuItem {
-                enabled: Panel.debugMode
-                name: qsTr("Right")
-                prop: "position"
-                value: Dock.Right
-            }
-        }
-        MutuallyExclusiveMenu {
-            title: qsTr("Status")
-            EnumPropertyMenuItem {
-                name: qsTr("Keep Shown")
-                prop: "hideMode"
-                value: Dock.KeepShowing
-            }
-            EnumPropertyMenuItem {
-                name: qsTr("Keep Hidden")
-                prop: "hideMode"
-                value: Dock.KeepHidden
-            }
-            EnumPropertyMenuItem {
-                enabled: Panel.debugMode
-                name: qsTr("Smart Hide")
-                prop: "hideMode"
-                value: Dock.SmartHide
-            }
-        }
 
-        LP.MenuItem {
-            text: qsTr("Dock Settings")
-            onTriggered: {
-                Panel.openDockSettings()
+            LP.MenuItem {
+                text: qsTr("Dock Settings")
+                onTriggered: {
+                    Panel.openDockSettings()
+                }
             }
         }
     }
@@ -231,8 +235,9 @@ Window {
         onTapped: function(eventPoint, button) {
             let lastActive = MenuHelper.activeMenu
             MenuHelper.closeCurrent()
-            if (button === Qt.RightButton && lastActive !== dockMenu) {
-                MenuHelper.openMenu(dockMenu)
+            dockMenuLoader.active = true
+            if (button === Qt.RightButton && lastActive !== dockMenuLoader.item) {
+                MenuHelper.openMenu(dockMenuLoader.item)
             }
         }
     }

--- a/panels/dock/searchitem/package/searchitem.qml
+++ b/panels/dock/searchitem/package/searchitem.qml
@@ -76,15 +76,22 @@ AppletItem {
         id: mouseArea
         anchors.fill: parent
         acceptedButtons: Qt.RightButton
-        onClicked: platformMenu.open()
+        onClicked: {
+            platformMenuLoader.active = true
+            platformMenuLoader.item.open()
+        }
     }
 
-    LP.Menu {
-        id: platformMenu
-        LP.MenuItem {
-            text: qsTr("SearchConfig")
-            onTriggered: {
-                Applet.toggleGrandSearchConfig()
+    Loader {
+        id: platformMenuLoader
+        active: false
+        sourceComponent: LP.Menu {
+            id: platformMenu
+            LP.MenuItem {
+                text: qsTr("SearchConfig")
+                onTriggered: {
+                    Applet.toggleGrandSearchConfig()
+                }
             }
         }
     }

--- a/panels/dock/taskmanager/package/AppItem.qml
+++ b/panels/dock/taskmanager/package/AppItem.qml
@@ -133,19 +133,23 @@ Item {
             target: Panel
         }
 
-        LP.Menu {
-            id: contextMenu
-            Instantiator {
-                id: menuItemInstantiator
-                model: JSON.parse(menus)
-                delegate: LP.MenuItem {
-                    text: modelData.name
-                    onTriggered: {
-                        root.clickItem(root.itemId, modelData.id)
+        Loader {
+            id: contextMenuLoader
+            active: false
+            sourceComponent: LP.Menu {
+                id: contextMenu
+                Instantiator {
+                    id: menuItemInstantiator
+                    model: JSON.parse(menus)
+                    delegate: LP.MenuItem {
+                        text: modelData.name
+                        onTriggered: {
+                            root.clickItem(root.itemId, modelData.id)
+                        }
                     }
+                    onObjectAdded: (index, object) => contextMenu.insertItem(index, object)
+                    onObjectRemoved: (index, object) => contextMenu.removeItem(object)
                 }
-                onObjectAdded: (index, object) => contextMenu.insertItem(index, object)
-                onObjectRemoved: (index, object) => contextMenu.removeItem(object)
             }
         }
 
@@ -226,7 +230,8 @@ Item {
         }
         onClicked: function (mouse) {
             if (mouse.button === Qt.RightButton) {
-                MenuHelper.openMenu(contextMenu)
+                contextMenuLoader.active = true
+                MenuHelper.openMenu(contextMenuLoader.item)
             } else {
                 if (root.windows.length === 0) {
                     launchAnimation.start()


### PR DESCRIPTION
It's crashed in DPlatformWindowHelper's eventFilter, it should use
DNoTitlebarWindowHelper when dxcb is loaded.
Delay to create Menu avoid to applied an DPlatformWindowHelper in dxcb
when WM is not ready.

Issue: https://github.com/linuxdeepin/developer-center/issues/8243
