### PR TITLE
fix: crashed by tipWidget when exit

### DIFF
--- a/panels/dock/tray/frame/window/quickpluginwindow.cpp
+++ b/panels/dock/tray/frame/window/quickpluginwindow.cpp
@@ -764,10 +764,6 @@ QuickDockItem::QuickDockItem(PluginsItemInterface *pluginItem, const QString &it
 
 QuickDockItem::~QuickDockItem()
 {
-    QWidget *tipWidget = m_pluginItem->itemTipsWidget(m_itemKey);
-    if (tipWidget && (tipWidget->parentWidget() == m_popupWindow || tipWidget->parentWidget() == this))
-        tipWidget->setParent(m_tipParent);
-
     QWidget *itemWidget = m_pluginItem->itemWidget(m_itemKey);
     if (itemWidget) {
         itemWidget->setParent(nullptr);
@@ -944,6 +940,11 @@ void QuickDockItem::leaveEvent(QEvent *event)
 {
     m_isEnter = false;
     update();
+
+    if (QWidget *tipWidget = m_pluginItem->itemTipsWidget(m_itemKey)) {
+        if (m_tipParent != tipWidget->parentWidget())
+            tipWidget->setParent(m_tipParent);
+    }
 
     QWidget::leaveEvent(event);
     m_popupWindow->hide();


### PR DESCRIPTION
tipWidget is release by plugin instead of tray frame in previous code.
We reset tipWidget's parent when leaveEvent instead of deconstruction.
