### PR TITLE
fix: Solve the problem of small plugin icon in the quick panel popup …

### DIFF
--- a/panels/dock/tray/plugins/pluginmanager/standardquickitem.cpp
+++ b/panels/dock/tray/plugins/pluginmanager/standardquickitem.cpp
@@ -174,16 +174,8 @@ QPixmap StandardQuickItem::pixmap() const
 
     int pixmapWidth = ICONWIDTH;
     int pixmapHeight = ICONHEIGHT;
-    QList<QSize> iconSizes = icon.availableSizes();
-    if (iconSizes.size() > 0) {
-        QSize size = iconSizes[0];
-        if (size.isValid() && !size.isEmpty() && !size.isNull()) {
-            pixmapWidth = size.width();
-            pixmapHeight = size.height();
-        }
-    }
 
-    return icon.pixmap(pixmapWidth / qApp->devicePixelRatio(), pixmapHeight / qApp->devicePixelRatio());
+    return icon.pixmap(QSize(pixmapWidth, pixmapHeight), qApp->devicePixelRatio());
 }
 
 QLabel *StandardQuickItem::findChildLabel(QWidget *parent, const QString &childObjectName) const


### PR DESCRIPTION
…under high zoom

Solve the problem of small icons in the quick panel under high zoom.

Log: Solve the problem of small icons in the quick panel under high zoom
issue: https://github.com/linuxdeepin/developer-center/issues/8111
Influence: quick panel plugin icons size