### PR TITLE
fix: When dragging the tray application, tray expansion box is hidden.

### DIFF
--- a/panels/dock/tray/frame/dockapplet.cpp
+++ b/panels/dock/tray/frame/dockapplet.cpp
@@ -120,6 +120,12 @@ void DockApplet::initDock()
     }
 }
 
+void DockApplet::collapseExpandedPanel()
+{
+    if (m_window)
+        m_window->collapseExpandedPanel();
+}
+
 bool DockApplet::init()
 {
     DApplet::init();

--- a/panels/dock/tray/frame/dockapplet.h
+++ b/panels/dock/tray/frame/dockapplet.h
@@ -36,6 +36,7 @@ public:
     Q_INVOKABLE void setDisplayMode(int displayMode) const;
 
     Q_INVOKABLE void initDock();
+    Q_INVOKABLE void collapseExpandedPanel();
 
     virtual bool init() override;
     virtual bool load() override;

--- a/panels/dock/tray/frame/package/tray.qml
+++ b/panels/dock/tray/frame/package/tray.qml
@@ -50,8 +50,15 @@ AppletItem {
         Applet.setDisplayMode(Panel.indicatorStyle)
         updatePanelGeometry()
     }
-    Window.onWidthChanged: updatePanelGeometry()
-    Window.onHeightChanged: updatePanelGeometry()
+    Window.onWidthChanged: {
+        Applet.collapseExpandedPanel()
+        updatePanelGeometry()
+    }
+    Window.onHeightChanged: {
+        Applet.collapseExpandedPanel()
+        updatePanelGeometry()
+    }
+
     onPositionChanged: Applet.setDockPosition(Panel.position)
     onIndicatorStyleChanged: Applet.setDisplayMode(Panel.indicatorStyle)
     onDockWidthChanged: updatePanelGeometry()

--- a/panels/dock/tray/frame/window/docktraywindow.cpp
+++ b/panels/dock/tray/frame/window/docktraywindow.cpp
@@ -149,6 +149,12 @@ void DockTrayWindow::layoutWidget()
     resizeTool();
 }
 
+void DockTrayWindow::collapseExpandedPanel()
+{
+    if (ExpandIconWidget::popupTrayView()->isVisible())
+        ExpandIconWidget::popupTrayView()->hide();
+}
+
 void DockTrayWindow::resizeEvent(QResizeEvent *event)
 {
     // 当尺寸发生变化的时候，通知托盘区域刷新尺寸，让托盘图标始终保持居中显示

--- a/panels/dock/tray/frame/window/docktraywindow.h
+++ b/panels/dock/tray/frame/window/docktraywindow.h
@@ -42,6 +42,8 @@ public:
 
     void layoutWidget();
 
+    void collapseExpandedPanel();
+
 Q_SIGNALS:
     void requestUpdate();
 

--- a/panels/dock/tray/frame/window/tray/widgets/expandiconwidget.cpp
+++ b/panels/dock/tray/frame/window/tray/widgets/expandiconwidget.cpp
@@ -85,11 +85,11 @@ void ExpandIconWidget::paintEvent(QPaintEvent *event)
 void ExpandIconWidget::moveEvent(QMoveEvent *event)
 {
     BaseTrayWidget::moveEvent(event);
-    // 当前展开按钮位置发生变化的时候，需要关掉托盘面板
+    // 当前展开按钮位置发生变化的时候，需要同时改变托盘的位置
     QMetaObject::invokeMethod(this, [] {
         TrayGridWidget *gridView = popupTrayView();
         if (gridView->isVisible())
-            gridView->hide();
+            gridView->resetPosition();
     }, Qt::QueuedConnection);
 }
 


### PR DESCRIPTION
When the dock size is changed, the tray will collapse.

log: as title
issue: https://github.com/linuxdeepin/developer-center/issues/8315