### PR TITLE
fix: window display abnormality for PanelToolTip

### DIFF
--- a/frame/qml/PanelPopupWindow.qml
+++ b/frame/qml/PanelPopupWindow.qml
@@ -28,6 +28,8 @@ Window {
     D.DWindow.windowRadius: 4 * Screen.devicePixelRatio
     D.DWindow.enableBlurWindow: true
     D.DWindow.shadowRadius: 8
+    // TODO set shadowOffset maunally.
+    D.DWindow.shadowOffset: Qt.point(0, 10)
 
     color: "transparent"
     D.StyledBehindWindowBlur {


### PR DESCRIPTION
lower window's size causes window's shadow incorrect,
and removing shadowOffset.

Issue: https://github.com/linuxdeepin/developer-center/issues/8071
