### PR TITLE
feat: add dock-shell

### DIFF
--- a/debian/dde-shell.install
+++ b/debian/dde-shell.install
@@ -6,6 +6,7 @@ usr/share/dde-shell/org.deepin.ds.osd*/
 usr/lib/*/dde-shell/org.deepin.ds.dock*
 usr/share/dde-shell/org.deepin.ds.dock*/
 usr/lib/*/qt6/qml/org/deepin/ds/dock/*
+usr/lib/*/qt6/qml/org/deepin/ds/dockshell/*
 usr/lib/*/dde-shell/org.deepin.ds.notification*
 usr/share/dde-shell/org.deepin.ds.notification*/
 usr/lib/*/dde-shell/org.deepin.ds.dde-appearance*

--- a/debian/libdde-shell.install
+++ b/debian/libdde-shell.install
@@ -1,3 +1,4 @@
 usr/lib/*/libdde-shell.so.*
+usr/lib/*/libdock-shell.so.*
 usr/lib/*/qt6/qml/org/deepin/ds/*.so
 usr/lib/*/qt6/qml/org/deepin/ds/qmldir

--- a/panels/dock/CMakeLists.txt
+++ b/panels/dock/CMakeLists.txt
@@ -78,6 +78,11 @@ endif(BUILD_WITH_X11)
 ds_install_package(PACKAGE org.deepin.ds.dock TARGET dockpanel)
 ds_handle_package_translation(PACKAGE org.deepin.ds.dock)
 
+# # dock shell
+if ((${CMAKE_BUILD_TYPE} MATCHES "Debug"))
+    add_subdirectory(dock-shell-example)
+endif ()
+
 # sub plugins
 add_subdirectory(clipboarditem)
 add_subdirectory(workspaceitem)
@@ -93,14 +98,20 @@ add_subdirectory(dockplugin)
 
 # dock qml element(include Dock.xx defines and DockCompositor)
 file(
-    GLOB dock_plugin_sources
+    GLOB dock_plugin_headers
     constants.h
+    ddockapplet.h
+)
+file(
+    GLOB dock_plugin_sources
     # dockfilterproxymodel.cpp
     # dockfilterproxymodel.h
     dockpluginmanagerextension_p.h
     dockpluginmanagerextension.cpp
     dockpluginmanagerintegration_p.h
     dockpluginmanagerintegration.cpp
+    private/ddockapplet_p.h
+    ddockapplet.cpp
 )
 
 set_source_files_properties(DockCompositor.qml PROPERTIES
@@ -117,12 +128,12 @@ set_source_files_properties(DockPalette.qml PROPERTIES
 
 qt_policy(SET QTP0001 OLD)
 qt_add_qml_module(dock-plugin
-    PLUGIN_TARGET dock-plugin
+    PLUGIN_TARGET dock-qml-plugin
     URI "org.deepin.ds.dock"
     VERSION "1.0"
     SHARED
-    SOURCES ${dock_plugin_sources}
-    QML_FILES DockCompositor.qml OverflowContainer.qml MenuHelper.qml DockPalette.qml
+    SOURCES ${dock_plugin_headers} ${dock_plugin_sources}
+    QML_FILES DockCompositor.qml OverflowContainer.qml MenuHelper.qml DockPalette.qml DockItem.qml
     OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/plugins/org/deepin/ds/dock/
 )
 
@@ -137,6 +148,7 @@ target_link_libraries(dock-plugin PUBLIC
     Qt${QT_VERSION_MAJOR}::Qml
     Qt${QT_VERSION_MAJOR}::Widgets
     Qt${QT_VERSION_MAJOR}::WaylandCompositor
+    dde-shell-frame
 PRIVATE
     PkgConfig::WaylandClient
     Qt${QT_VERSION_MAJOR}::WaylandCompositorPrivate
@@ -147,6 +159,13 @@ target_include_directories(dock-plugin
     $<TARGET_PROPERTY:dde-shell-frame,INTERFACE_INCLUDE_DIRECTORIES>
 )
 
-install(DIRECTORY "${PROJECT_BINARY_DIR}/plugins/org/deepin/ds/dock/" DESTINATION "${QML_INSTALL_DIR}/org/deepin/ds/dock/")
+target_include_directories(dock-plugin INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>
+    $<INSTALL_INTERFACE:${INCLUDE_INSTALL_DIR}/dockshell>
+)
+
+install(FILES ${dock_plugin_headers} DESTINATION "${INCLUDE_INSTALL_DIR}/dockshell")
+install(DIRECTORY "${PROJECT_BINARY_DIR}/plugins/org/deepin/ds/dock" DESTINATION "${QML_INSTALL_DIR}/org/deepin/ds/dock/")
 dtk_add_config_meta_files(APPID org.deepin.ds.dock FILES dconfig/org.deepin.ds.dock.json)
 dtk_add_config_meta_files(APPID org.deepin.ds.dock FILES dconfig/org.deepin.ds.dock.power.json)

--- a/panels/dock/DockItem.qml
+++ b/panels/dock/DockItem.qml
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+import org.deepin.ds 1.0
+import org.deepin.dtk 1.0 as D
+import org.deepin.dtk.private 1.0 as DP
+import org.deepin.ds.dock 1.0
+
+AppletItem {
+    id: root
+    property int dockOrder
+    property bool shouldVisible
+    property alias toolButtonColor: backgroundButton.color1
+    property alias toolButtonBorderColor: backgroundButton.outsideBorderColor
+    property alias toolTip: toolTip.text
+    property alias icon: button.icon.name
+
+    signal clicked
+
+    PanelToolTip {
+        id: toolTip
+    }
+    D.ToolButton {
+        id: button
+        anchors.centerIn: parent
+        width: 30
+        height: 30
+        icon.width: 16
+        icon.height: 16
+
+        display: D.IconLabel.IconOnly
+        onClicked: {
+            toolTip.close()
+            root.clicked()
+        }
+
+        onHoveredChanged: {
+            if (toolTip.text === "")
+                return
+
+            if (hovered) {
+                var point = Applet.rootObject.mapToItem(null, Applet.rootObject.width / 2, 0)
+                toolTip.toolTipX = point.x
+                toolTip.toolTipY = point.y
+                toolTip.open()
+            } else {
+                toolTip.close()
+            }
+        }
+
+        background: DP.ButtonPanel {
+            id: backgroundButton
+
+            button: button
+            color2: color1
+            insideBorderColor: null
+        }
+    }
+}

--- a/panels/dock/ddockapplet.cpp
+++ b/panels/dock/ddockapplet.cpp
@@ -1,0 +1,109 @@
+// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "ddockapplet.h"
+#include "private/ddockapplet_p.h"
+
+#include <QLoggingCategory>
+
+DS_BEGIN_NAMESPACE
+
+DCORE_USE_NAMESPACE
+
+Q_DECLARE_LOGGING_CATEGORY(dsLog)
+
+DDockAppletPrivate::DDockAppletPrivate(DDockApplet *qq)
+    : DAppletPrivate(qq)
+{
+
+}
+
+DDockAppletPrivate::~DDockAppletPrivate()
+{
+
+}
+
+DDockApplet::DDockApplet(QObject *parent)
+    : DDockApplet(*new DDockAppletPrivate(this), parent)
+{
+
+}
+
+DDockApplet::DDockApplet(DDockAppletPrivate &dd, QObject *parent)
+    : DApplet(dd, parent)
+{
+
+}
+
+DDockApplet::~DDockApplet()
+{
+    qDebug(dsLog) << "Destroyed DDockApplet:" << pluginId() << id();
+}
+
+/*!
+    A unique name that identifies the plug-in. The default implementation is `pluginId`.
+*/
+QString DDockApplet::name() const
+{
+    return DApplet::pluginId();
+}
+
+/*!
+    A name that displays a name that matches the current locale
+*/
+/**
+ * @brief DDockApplet::displayName
+ * @return
+ */
+
+/**
+ * @brief DDockApplet::itemKey
+ * @return
+ */
+
+/**
+ * @brief DDockApplet::settingKey
+ * @return
+ */
+
+/*!
+    A dci icon for display
+*/
+QString DDockApplet::icon() const
+{
+    D_DC(DDockApplet);
+
+    return d->icon;
+}
+
+void DDockApplet::setIcon(const QString &icon)
+{
+    D_D(DDockApplet);
+
+    d->icon = icon;
+    Q_EMIT iconChanged(icon);
+}
+
+/*!
+    Whether the plug-in is displayed on the panel
+*/
+bool DDockApplet::visible() const
+{
+    D_DC(DDockApplet);
+
+    return d->visible;
+}
+
+void DDockApplet::setVisible(bool visible)
+{
+    D_D(DDockApplet);
+
+    if (d->visible == visible)
+        return;
+
+    d->visible = visible;
+    Q_EMIT visibleChanged(visible);
+}
+
+DS_END_NAMESPACE

--- a/panels/dock/ddockapplet.h
+++ b/panels/dock/ddockapplet.h
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include "applet.h"
+#include "dsglobal.h"
+
+#include <DObject>
+#include <DDciIcon>
+
+#include <QVariant>
+
+DGUI_USE_NAMESPACE
+DS_BEGIN_NAMESPACE
+/**
+ * @brief You Can Used As Dock Plugins Sub Class
+ */
+class DDockAppletPrivate;
+class DS_SHARE DDockApplet : public DApplet
+{
+    Q_OBJECT
+    Q_PROPERTY(QString name READ name CONSTANT FINAL)
+    Q_PROPERTY(QString displayName READ displayName CONSTANT FINAL)
+    Q_PROPERTY(QString itemKey READ itemKey CONSTANT FINAL)
+    Q_PROPERTY(QString settingKey READ settingKey CONSTANT FINAL)
+    Q_PROPERTY(QString icon READ icon NOTIFY iconChanged FINAL)
+    Q_PROPERTY(bool visible READ visible WRITE setVisible NOTIFY visibleChanged FINAL);
+
+    D_DECLARE_PRIVATE(DDockApplet);
+
+public:
+    explicit DDockApplet(QObject *parent = nullptr);
+    virtual ~DDockApplet() override;
+
+    virtual QString name() const;
+    virtual QString displayName() const = 0;
+    virtual QString itemKey() const = 0;
+    virtual QString settingKey() const = 0;
+
+    QString icon() const;
+    void setIcon(const QString &icon);
+
+    bool visible() const;
+    void setVisible(bool visible);
+
+Q_SIGNALS:
+    void iconChanged(const QString &);
+    void visibleChanged(bool);
+
+protected:
+    explicit DDockApplet(DDockAppletPrivate &dd, QObject *parent = nullptr);
+};
+
+DS_END_NAMESPACE

--- a/panels/dock/dock-shell-example/CMakeLists.txt
+++ b/panels/dock/dock-shell-example/CMakeLists.txt
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+add_library(dock-shell-example SHARED
+    item.cpp
+    item.h
+)
+
+target_link_libraries(dock-shell-example PRIVATE
+    dock-plugin
+)
+
+ds_install_package(PACKAGE org.deepin.ds.dock.dock-shell-example TARGET dock-shell-example)

--- a/panels/dock/dock-shell-example/item.cpp
+++ b/panels/dock/dock-shell-example/item.cpp
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "item.h"
+#include "pluginfactory.h"
+
+#include <DDBusSender>
+#include <DDciIcon>
+#include <DGuiApplicationHelper>
+
+#include <QGuiApplication>
+#include <QBuffer>
+
+DGUI_USE_NAMESPACE
+
+namespace dock {
+
+Item::Item(QObject *parent)
+    : DDockApplet(parent)
+{
+    // for debug
+    setVisible(true);
+}
+
+void Item::activate()
+{
+    qDebug() << "item clicked";
+}
+
+QString Item::displayName() const
+{
+    return "dock-shell-example";
+}
+
+QString Item::itemKey() const
+{
+    return "dock-shell-example";
+}
+
+QString Item::settingKey() const
+{
+    return "dock-shell-example";
+}
+
+D_APPLET_CLASS(Item)
+}
+
+
+#include "item.moc"

--- a/panels/dock/dock-shell-example/item.h
+++ b/panels/dock/dock-shell-example/item.h
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include "ddockapplet.h"
+#include "dsglobal.h"
+
+namespace dock {
+
+class Item : public DS_NAMESPACE::DDockApplet
+{
+    Q_OBJECT
+public:
+    explicit Item(QObject *parent = nullptr);
+
+    QString displayName() const override;
+    QString itemKey() const override;
+    QString settingKey() const override;
+
+    Q_INVOKABLE void activate();
+};
+}

--- a/panels/dock/dock-shell-example/package/item.qml
+++ b/panels/dock/dock-shell-example/package/item.qml
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import org.deepin.ds 1.0
+import org.deepin.ds.dock 1.0
+// import org.deepin.ds.dockshell 1.0
+
+DockItem {
+    dockOrder: 1
+    shouldVisible: Applet.visible
+    toolButtonColor: DockPalette.toolButtonColor
+    toolButtonBorderColor: DockPalette.toolButtonBorderColor
+    toolTip: "I am tips"
+    icon: Applet.icon === "" ? "x-application-desktop" : Applet.icon
+
+    property int dockSize: Panel.rootObject.dockSize
+    implicitWidth: Panel.rootObject.useColumnLayout ? dockSize : 30
+    implicitHeight: Panel.rootObject.useColumnLayout ? 30 : dockSize
+
+    onClicked: {
+        DDockApplet.activate()
+    }
+}

--- a/panels/dock/dock-shell-example/package/metadata.json
+++ b/panels/dock/dock-shell-example/package/metadata.json
@@ -1,0 +1,8 @@
+{
+    "Plugin": {
+        "Version": "1.0",
+        "Id": "org.deepin.ds.dock.dock-shell-example",
+        "Url": "item.qml",
+        "Parent": "org.deepin.ds.dock"
+    }
+}

--- a/panels/dock/private/ddockapplet_p.h
+++ b/panels/dock/private/ddockapplet_p.h
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include "private/applet_p.h"
+#include "ddockapplet.h"
+
+#include <dobject_p.h>
+#include <QVariant>
+
+DS_BEGIN_NAMESPACE
+class DDockAppletPrivate : public DAppletPrivate
+{
+public:
+    explicit DDockAppletPrivate(DDockApplet *qq);
+    ~DDockAppletPrivate() override;
+
+    bool visible = false;
+    QString icon;
+    D_DECLARE_PUBLIC(DDockApplet);
+};
+
+DS_END_NAMESPACE

--- a/panels/dock/qmlplugin.cpp
+++ b/panels/dock/qmlplugin.cpp
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "qmlplugin.h"
+#include "ddockapplet.h"
+#include "ddockappletitem.h"
+#include "layershell/dlayershellwindow.h"
+
+#include <qqml.h>
+
+QML_DECLARE_TYPEINFO(DS_NAMESPACE::DLayerShellWindow, QML_HAS_ATTACHED_PROPERTIES)
+
+DS_BEGIN_NAMESPACE
+
+void QmlpluginPlugin::registerTypes(const char *uri)
+{
+    // @uri org.deepin.ds.dockshell
+    qmlRegisterModule(uri, 1, 0);
+
+    qmlRegisterAnonymousType<DDockApplet>(uri, 1);
+    qmlRegisterType<DDockAppletItem>(uri, 1, 0, "DDockAppletItem");
+    qmlRegisterUncreatableType<DDockAppletItem>(uri, 1, 0, "DDockApplet", "DDockApplet Attached");
+}
+
+void QmlpluginPlugin::initializeEngine(QQmlEngine *engine, const char *uri)
+{
+    QQmlExtensionPlugin::initializeEngine(engine, uri);
+}
+
+DS_END_NAMESPACE

--- a/panels/dock/qmlplugin.h
+++ b/panels/dock/qmlplugin.h
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include "dsglobal.h"
+
+#include <QQmlExtensionPlugin>
+
+DS_BEGIN_NAMESPACE
+class QmlpluginPlugin : public QQmlExtensionPlugin
+{
+    Q_OBJECT
+    // Q_PLUGIN_METADATA(IID QQmlExtensionInterface_iid)
+
+public:
+    void registerTypes(const char *uri) override;
+    void initializeEngine(QQmlEngine *engine, const char *uri) override;
+};
+DS_END_NAMESPACE


### PR DESCRIPTION
增加DockApplet类型，dock的子插件应统一继承此类，方便统一管理
TODO:
增加DockAppletItem类型，导出qml组件，提供统一视觉的的tips,icon，...

log: as title