### PR TITLE
fix warning

### DIFF
--- a/panels/dock/tray/frame/controller/quicksettingcontroller.cpp
+++ b/panels/dock/tray/frame/controller/quicksettingcontroller.cpp
@@ -128,8 +128,14 @@ QString QuickSettingController::itemKey(PluginsItemInterface *pluginItem) const
 
 QuickSettingController *QuickSettingController::instance()
 {
-    static QuickSettingController instance;
-    return &instance;
+    static QuickSettingController *g_instance = nullptr;
+    if (!g_instance) {
+        g_instance = new QuickSettingController();
+        QObject::connect(qGuiApp, &QGuiApplication::aboutToQuit, g_instance, [] () {
+            g_instance->deleteLater();
+        });
+    }
+    return g_instance;
 }
 
 QList<PluginsItemInterface *> QuickSettingController::pluginItems(const PluginAttribute &pluginClass) const


### PR DESCRIPTION
QQuickSettingController is static variable, and it is destroyed
after QApplication, it causes some widgets is released too late,
e.g LargerQuickItem update widget's parent to null during destruction,
it will call QApplication::font.