### PR TITLE
fix: fix the power icon displays incorrectly

### DIFF
--- a/panels/dock/tray/plugins/power/powerplugin.cpp
+++ b/panels/dock/tray/plugins/power/powerplugin.cpp
@@ -125,8 +125,17 @@ void PowerPlugin::setSortKey(const QString &itemKey, const int order)
 
 QIcon PowerPlugin::icon(const DockPart &dockPart, DGuiApplicationHelper::ColorType themeType)
 {
-    return QIcon::fromTheme(themeType == DGuiApplicationHelper::DarkType ? ":/batteryicons/resources/batteryicons/battery-100-symbolic.svg"
-                                                                          : ":/batteryicons/resources/batteryicons/battery-100-symbolic-dark.svg");
+    if (dockPart == DockPart::DCCSetting) {
+        return QIcon::fromTheme(themeType == DGuiApplicationHelper::DarkType ? ":/batteryicons/resources/batteryicons/battery-100-symbolic.svg"
+                                                                             : ":/batteryicons/resources/batteryicons/battery-100-symbolic-dark.svg");
+    } else {
+        const QPixmap pixmap = m_powerStatusWidget->getBatteryIcon(themeType);
+
+        QIcon batteryIcon;
+        batteryIcon.addPixmap(pixmap);
+
+        return batteryIcon;
+    }
 }
 
 PluginFlags PowerPlugin::flags() const

--- a/panels/dock/tray/plugins/power/powerstatuswidget.cpp
+++ b/panels/dock/tray/plugins/power/powerstatuswidget.cpp
@@ -103,8 +103,7 @@ QPixmap PowerStatusWidget::getBatteryIcon(int themeType)
     const auto ratio = devicePixelRatioF();
     QSize pixmapSize = QCoreApplication::testAttribute(Qt::AA_UseHighDpiPixmaps) ? QSize(20, 20) : (QSize(20, 20) * ratio);
     QIcon qrcIcon = QIcon(":/batteryicons/resources/batteryicons/" + iconStr + ".svg");
-    QPixmap pix = qrcIcon.pixmap(pixmapSize);
-    pix.setDevicePixelRatio(ratio);
+    QPixmap pix = qrcIcon.pixmap(pixmapSize, ratio);
 
     return pix;
 }


### PR DESCRIPTION
Fixed the issue where the power icon displays incorrectly

Log: fix the power icon displays incorrectly
issue: https://github.com/linuxdeepin/developer-center/issues/8347
Influence: power icon display