### PR TITLE
fix: fix the size of app icon when resizing dock size by dcc

### DIFF
--- a/panels/dock/taskmanager/package/AppItem.qml
+++ b/panels/dock/taskmanager/package/AppItem.qml
@@ -179,7 +179,9 @@ Item {
                 function onPressedAndDragging(isDragging) {
                     if (isDragging) {
                         beatAnimation.stop()
-                        icon.scale = root.iconScale
+                        icon.scale = Qt.binding(function() {
+                            return root.iconScale
+                        })
                     } else {
                         beatAnimation.running = Qt.binding(function() {
                             return root.attention


### PR DESCRIPTION
rebind icon scale

Log: fix the size of app icon when resizing dock size by dcc
issue: https://github.com/linuxdeepin/developer-center/issues/8401
Influence: icon size