### PR TITLE
fix: drag mark error

### DIFF
--- a/panels/dock/tray/frame/window/docktraywindow.cpp
+++ b/panels/dock/tray/frame/window/docktraywindow.cpp
@@ -196,7 +196,11 @@ bool DockTrayWindow::eventFilter(QObject *watched, QEvent *event)
         case QEvent::DragEnter: {
             QDragEnterEvent *dragEnterEvent = static_cast<QDragEnterEvent *>(event);
             dragEnterEvent->setDropAction(Qt::CopyAction);
-            dragEnterEvent->accept();
+            if (dragEnterEvent->mimeData()->formats().contains("quick_drag") || dragEnterEvent->mimeData()->formats().contains("tray_drag")) {
+                dragEnterEvent->accept();
+            } else {
+                dragEnterEvent->ignore();
+            }
             return true;
         }
         case QEvent::DragMove: {

--- a/panels/dock/tray/frame/window/quickpluginwindow.cpp
+++ b/panels/dock/tray/frame/window/quickpluginwindow.cpp
@@ -487,6 +487,7 @@ void QuickPluginWindow::startDrag()
     PluginsItemInterface *moveItem = m_dragInfo->dockItem->pluginItem();
     QDrag *drag = new QDrag(this);
     QuickPluginMimeData *mimedata = new QuickPluginMimeData(moveItem, drag);
+    mimedata->setData("quick_drag", "");
     drag->setMimeData(mimedata);
     QPixmap dragPixmap = m_dragInfo->dragPixmap();
     drag->setPixmap(dragPixmap);


### PR DESCRIPTION
仅支持托盘内部图标拖拽时显示+标志

log: as title
issue: https://github.com/linuxdeepin/developer-center/issues/8208