### PR TITLE
fix: button's icon is not clear

### DIFF
--- a/panels/dock/clipboarditem/package/clipboarditem.qml
+++ b/panels/dock/clipboarditem/package/clipboarditem.qml
@@ -34,6 +34,7 @@ AppletItem {
         icon.width: 16
         icon.height: 16
 
+        display: D.IconLabel.IconOnly
         onClicked: {
             Applet.toggleClipboard()
             toolTip.close()

--- a/panels/dock/searchitem/package/searchitem.qml
+++ b/panels/dock/searchitem/package/searchitem.qml
@@ -47,6 +47,7 @@ AppletItem {
         icon.name: "search"
         icon.width: 16
         icon.height: 16
+        display: D.IconLabel.IconOnly
         onClicked: {
             toolTip.close()
             Applet.toggleGrandSearch()


### PR DESCRIPTION
it's a bug for dtk, we use IconOnly to avoid the bug.

Issue: https://github.com/linuxdeepin/developer-center/issues/8409
