### PR TITLE
fix: some icon too large

### DIFF
--- a/panels/dock/tray/frame/window/tray/widgets/xembedtrayitemwidget.cpp
+++ b/panels/dock/tray/frame/window/tray/widgets/xembedtrayitemwidget.cpp
@@ -420,8 +420,8 @@ void XEmbedTrayItemWidget::refershIconImage()
 
     m_image = qimage.scaled(iconSize * ratio, iconSize * ratio, Qt::KeepAspectRatio, Qt::SmoothTransformation);
 
-    // FIXME: qimage looks smaller then what it should be
-    // m_image.setDevicePixelRatio(ratio);
+    // NOTE: the icons of some versions of WeChat(work) are too small, and it`s not our problem
+    m_image.setDevicePixelRatio(ratio);
 
     update();
     Q_EMIT iconChanged();


### PR DESCRIPTION
企业微信、向日葵这类应用在高倍缩放情况下，在任务栏上显示的图标太大

log: as title
issue: https://github.com/linuxdeepin/developer-center/issues/8372