### PR TITLE
chore: remove warning

### DIFF
--- a/frame/qml/PanelPopup.qml
+++ b/frame/qml/PanelPopup.qml
@@ -44,7 +44,7 @@ Item {
             if (!window)
                 return
             window.visibleChanged.connect(function() {
-                if (!Panel.popupWindow.visible)
+                if (Panel.popupWindow && !Panel.popupWindow.visible)
                     popup.close()
             })
         }

--- a/frame/qml/PanelToolTip.qml
+++ b/frame/qml/PanelToolTip.qml
@@ -71,7 +71,7 @@ Item {
             if (!window)
                 return
             window.visibleChanged.connect(function() {
-                if (!Panel.toolTipWindow.visible)
+                if (Panel.toolTipWindow && !Panel.toolTipWindow.visible)
                     toolTip.close()
             })
         }


### PR DESCRIPTION
TODO: why Panel.toolTipWindow is undefined.
