### PR TITLE
fix: popup window always hide

### DIFF
--- a/panels/dock/tray/frame/util/dockpopupwindow.cpp
+++ b/panels/dock/tray/frame/util/dockpopupwindow.cpp
@@ -264,7 +264,14 @@ void DockPopupWindow::onButtonPress(int type, int x, int y, const QString &key)
 {
     if (!m_enableMouseRelease)
         return;
-    QScreen *screen = DIS_INS->screen(DOCK_SCREEN->current());
+    // find the screen where dock onto
+    QScreen *screen = nullptr;
+    for (auto tw : qApp->topLevelWidgets()) {
+        if (QString(tw->metaObject()->className()) == "DockTrayWindow") {
+            screen = tw->screen();
+            break;
+        }
+    };
     if (!screen)
         return;
     QRect screenRect = screen->geometry();

--- a/panels/dock/tray/frame/window/components/datetimedisplayer.cpp
+++ b/panels/dock/tray/frame/window/components/datetimedisplayer.cpp
@@ -192,10 +192,8 @@ QSize DateTimeDisplayer::suitableSize(const Dock::Position &position) const
 
 void DateTimeDisplayer::mousePressEvent(QMouseEvent *event)
 {
-    if ((event->button() != Qt::RightButton))
-        return QWidget::mousePressEvent(event);
-
-    m_menu->exec(QCursor::pos());
+    if (event->button() == Qt::RightButton)
+        m_menu->exec(QCursor::pos());
 }
 
 void DateTimeDisplayer::mouseReleaseEvent(QMouseEvent *event)

--- a/panels/dock/tray/frame/window/systempluginwindow.cpp
+++ b/panels/dock/tray/frame/window/systempluginwindow.cpp
@@ -377,8 +377,6 @@ void StretchPluginsItem::mousePressEvent(QMouseEvent *e)
     hideNonModel();
     if (e->button() == Qt::RightButton /*&& perfectIconRect().contains(e->pos())*/)
         return showContextMenu();
-
-    DockItem::mousePressEvent(e);
 }
 
 void StretchPluginsItem::mouseReleaseEvent(QMouseEvent *e)


### PR DESCRIPTION
点击弹窗上面的内容，弹窗总会自动隐藏，原因是坐标计算错误，导致误认为是点击了窗口外部区域从而隐藏

log: as title