### PR TITLE
fix: dragging tray icon to dock, but show error app in dock tray area

### DIFF
--- a/panels/dock/tray/frame/window/tray/tray_gridview.cpp
+++ b/panels/dock/tray/frame/window/tray/tray_gridview.cpp
@@ -449,7 +449,8 @@ void TrayGridView::handleDropEvent(QDropEvent *e)
         TrayModel *iconModel = TrayModel::getIconModel();
         TrayModel *model = static_cast<TrayModel*>(QListView::model());
         const auto itemKey = static_cast<QString>(e->mimeData()->data("itemKey"));
-        WinInfo info = m_type == Type::DockTray ? iconModel->getWinInfo(itemKey) : dockModel->getWinInfo(itemKey);
+        const auto key = static_cast<QString>(e->mimeData()->data("key"));
+        WinInfo info = m_type == Type::DockTray ? iconModel->getWinInfo(key, itemKey) : dockModel->getWinInfo(key, itemKey);
 
         QModelIndex targetIndex = getIndexFromPos(e->pos());
         int index = -1;

--- a/panels/dock/tray/frame/window/tray/tray_model.cpp
+++ b/panels/dock/tray/frame/window/tray/tray_model.cpp
@@ -331,10 +331,10 @@ WinInfo TrayModel::getWinInfo(const QModelIndex &index)
     return m_winInfos[row];
 }
 
-WinInfo TrayModel::getWinInfo(const QString &itemKey)
+WinInfo TrayModel::getWinInfo(const QString &key, const QString &itemKey)
 {
-    auto find = std::find_if(m_winInfos.begin(), m_winInfos.end(), [itemKey](const WinInfo &info) {
-      return info.itemKey == itemKey;
+    auto find = std::find_if(m_winInfos.begin(), m_winInfos.end(), [key, itemKey](const WinInfo &info) {
+      return info.key == key && info.itemKey == itemKey;
     });
 
     if (find != m_winInfos.end()) {

--- a/panels/dock/tray/frame/window/tray/tray_model.h
+++ b/panels/dock/tray/frame/window/tray/tray_model.h
@@ -97,7 +97,7 @@ public:
 
     void clear();
     WinInfo getWinInfo(const QModelIndex &index);
-    WinInfo getWinInfo(const QString &itemKey);
+    WinInfo getWinInfo(const QString &key, const QString &itemKey);
     void saveConfig(int index, const WinInfo &winInfo);
     void removeWinInfo(WinInfo winInfo);
 


### PR DESCRIPTION
dragging an icon from the tray to dock, but show error app in dock tray area.

Log: fix dragging tray icon to dock, but show error app in dock tray area
issue: https://github.com/linuxdeepin/developer-center/issues/8480
Influence: drag tray icon to dock