### PR TITLE
fix: tray plugin mouse right click menu causing dock to crash

### DIFF
--- a/panels/dock/tray/frame/window/quickpluginwindow.cpp
+++ b/panels/dock/tray/frame/window/quickpluginwindow.cpp
@@ -921,7 +921,7 @@ void QuickDockItem::mousePressEvent(QMouseEvent *event)
     }
 
     if (!m_contextMenu->actions().isEmpty()) {
-        m_contextMenu->exec(QCursor::pos());
+        m_contextMenu->popup(QCursor::pos());
     }
 
     return QWidget::mousePressEvent(event);


### PR DESCRIPTION
use menu popup

Log: tray plugin mouse right click menu causing dock to crash
Issue: https://github.com/linuxdeepin/developer-center/issues/8506
Influence: tray plugin mouse right click menu