### PR TITLE
fix: bluetooth popup has no blur effect

### DIFF
--- a/panels/dock/tray/plugins/bluetooth/bluetoothitem.cpp
+++ b/panels/dock/tray/plugins/bluetooth/bluetoothitem.cpp
@@ -33,6 +33,7 @@ BluetoothItem::BluetoothItem(AdaptersManager *adapterManager, QWidget *parent)
     , m_devState(Device::State::StateUnavailable)
     , m_adapterPowered(m_applet->poweredInitState())
 {
+    setContentsMargins(0, 0, 0, 0);
     setAccessibleName("BluetoothPluginItem");
     m_applet->setVisible(false);
     m_tipsLabel->setVisible(false);

--- a/panels/dock/tray/plugins/bluetooth/componments/bluetoothadapteritem.cpp
+++ b/panels/dock/tray/plugins/bluetooth/componments/bluetoothadapteritem.cpp
@@ -345,11 +345,11 @@ void BluetoothAdapterItem::onDeviceNameUpdated(const Device *device)
 
 void BluetoothAdapterItem::initUi()
 {
+    setContentsMargins(0, 0, 0, 0);
     m_refreshBtn->setFixedSize(24, 24);
     m_refreshBtn->setVisible(m_adapter->powered());
 
     setAccessibleName(m_adapter->name());
-    setContentsMargins(0, 0, 0, 0);
     m_adapterLabel->setFixedSize(ItemWidth, TitleHeight);
     m_adapterLabel->addButton(m_refreshBtn, 0);
     m_adapterLabel->addButton(m_adapterStateBtn, 0);
@@ -358,7 +358,6 @@ void BluetoothAdapterItem::initUi()
     m_adapterStateBtn->setChecked(m_adapter->powered());
 
     QVBoxLayout *mainLayout = new QVBoxLayout(this);
-    mainLayout->setContentsMargins(QMargins(0, 0, 0, 0));
     mainLayout->setSpacing(0);
     mainLayout->setContentsMargins(0, 0, 0, 0);
 

--- a/panels/dock/tray/plugins/bluetooth/componments/bluetoothapplet.cpp
+++ b/panels/dock/tray/plugins/bluetooth/componments/bluetoothapplet.cpp
@@ -32,7 +32,6 @@ SettingLabel::SettingLabel(QString text, QWidget *parent)
 {
     setAccessibleName("BluetoothSettingLabel");
     setContentsMargins(0, 0, 0, 0);
-    m_layout->setContentsMargins(QMargins(0, 0, 0, 0));
     m_layout->setSpacing(4);
     m_layout->setContentsMargins(20, 0, 6, 0);
     m_layout->addWidget(m_label, 0, Qt::AlignLeft | Qt::AlignHCenter);
@@ -205,7 +204,7 @@ void BluetoothApplet::onAdapterAdded(Adapter *adapter)
     m_adapterItems.insert(adapter->id(), adapterItem);
 
     // 将最新的设备插入到蓝牙设置前面
-    m_contentLayout->insertWidget(m_contentLayout->count() - 1, adapterItem, Qt::AlignTop | Qt::AlignVCenter);
+    m_contentLayout->insertWidget(m_contentLayout->count() - 2, adapterItem, Qt::AlignTop | Qt::AlignVCenter);
     updateBluetoothPowerState();
     updateSize();
 
@@ -245,14 +244,14 @@ void BluetoothApplet::updateBluetoothPowerState()
 
 void BluetoothApplet::initUi()
 {
+    setContentsMargins(0, 0, 0, 0);
     setFixedWidth(ItemWidth);
     setAccessibleName("BluetoothApplet");
-    setContentsMargins(0, 0, 0, 0);
+    m_contentWidget->setContentsMargins(0, 0, 0, 0);
 
     m_settingLabel->setFixedHeight(DeviceItemHeight);
     DFontSizeManager::instance()->bind(m_settingLabel->label(), DFontSizeManager::T7);
 
-    m_contentLayout->setContentsMargins(QMargins(0, 0, 0, 0));
     m_contentLayout->setSpacing(0);
     m_contentLayout->setContentsMargins(0, 0, 0, 0);
     m_contentLayout->addWidget(m_seperator);
@@ -268,9 +267,8 @@ void BluetoothApplet::initUi()
     m_scroarea->setContentsMargins(0, 0, 0, 0);
     m_scroarea->setWidget(m_contentWidget);
 
-    // updateIconTheme();
+    updateIconTheme();
 
-    m_mainLayout->setContentsMargins(QMargins(0, 0, 0, 0));
     m_mainLayout->setSpacing(0);
     m_mainLayout->setContentsMargins(0, 0, 0, 0);
     m_mainLayout->addWidget(m_scroarea);
@@ -299,24 +297,24 @@ void BluetoothApplet::initConnect()
     connect(m_airPlaneModeInter, &DBusAirplaneMode::EnabledChanged, this, &BluetoothApplet::setDisabled);
 }
 
-// /**
-//  * @brief BluetoothApplet::updateIconTheme 根据主题颜色设置蓝牙界面控件背景色
-//  */
-// void BluetoothApplet::updateIconTheme()
-// {
-//     QPalette widgetBackgroud;
-//     QPalette scroareaBackgroud;
-//     if(DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::LightType)
-//         widgetBackgroud.setColor(QPalette::Window, QColor(255, 255, 255, 0.03 * 255));
-//     else
-//         widgetBackgroud.setColor(QPalette::Window, QColor(0, 0, 0, 0.03 * 255));
+ /**
+  * @brief BluetoothApplet::updateIconTheme 根据主题颜色设置蓝牙界面控件背景色
+  */
+ void BluetoothApplet::updateIconTheme()
+ {
+     QPalette widgetBackgroud;
+     QPalette scroareaBackgroud;
+     if(DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::LightType)
+         widgetBackgroud.setColor(QPalette::Window, QColor(255, 255, 255, 0.03 * 255));
+     else
+         widgetBackgroud.setColor(QPalette::Window, QColor(0, 0, 0, 0.03 * 255));
 
-//     m_contentWidget->setAutoFillBackground(true);
-//     m_contentWidget->setPalette(widgetBackgroud);
-//     scroareaBackgroud.setColor(QPalette::Window, Qt::transparent);
-//     m_scroarea->setAutoFillBackground(true);
-//     m_scroarea->setPalette(scroareaBackgroud);
-// }
+     m_contentWidget->setAutoFillBackground(true);
+     m_contentWidget->setPalette(widgetBackgroud);
+     scroareaBackgroud.setColor(QPalette::Window, Qt::transparent);
+     m_scroarea->setAutoFillBackground(true);
+     m_scroarea->setPalette(scroareaBackgroud);
+ }
 
 void BluetoothApplet::initAdapters()
 {

--- a/panels/dock/tray/plugins/bluetooth/componments/bluetoothapplet.h
+++ b/panels/dock/tray/plugins/bluetooth/componments/bluetoothapplet.h
@@ -104,7 +104,7 @@ private:
     void initConnect();
     // 更新蓝牙插件主界面大小
     void updateSize();
-    // void updateIconTheme();
+    void updateIconTheme();
     void initAdapters();
 
 private:


### PR DESCRIPTION
fix: bluetooth popup has no blur effect and wrong position of separator line 

fix bluetooth popup has no blur effect and wrong position of separator line 

Log: fix bluetooth popup has no blur effect and wrong position of separator line 
Issue: https://github.com/linuxdeepin/developer-center/issues/8494
Influence: bluetooth popup has blur effect