### PR TITLE
fix: tray plugin mouse right click cause dock crash

### DIFF
--- a/panels/dock/tray/frame/window/quickpluginwindow.cpp
+++ b/panels/dock/tray/frame/window/quickpluginwindow.cpp
@@ -921,10 +921,15 @@ void QuickDockItem::mousePressEvent(QMouseEvent *event)
     }
 
     if (!m_contextMenu->actions().isEmpty()) {
-        m_contextMenu->popup(QCursor::pos());
-    }
+        QTimer::singleShot(0, this, [this]() {
+            QMenu contextMenu(this);
+            contextMenu.addActions(m_contextMenu->actions());
+            contextMenu.exec(QCursor::pos());
+        });
 
-    return QWidget::mousePressEvent(event);
+        // Fixme: Can cause crash in some cases
+        //m_contextMenu->popup(QCursor::pos());
+    }
 }
 
 void QuickDockItem::enterEvent(QEnterEvent *event)


### PR DESCRIPTION
1.double screen and set extended mode
2.adjust dock height size
3.logout computer and then click the tray plugin right-click menu when the dock comes out

Log: fix tray plugin mouse right click cause dock crash
Issue: https://github.com/linuxdeepin/developer-center/issues/8506
Influence: tray plugin menu display