### PR TITLE
fix: coredump app exit after open quick panel childPage

### DIFF
--- a/panels/dock/tray/frame/util/dockpopupwindow.cpp
+++ b/panels/dock/tray/frame/util/dockpopupwindow.cpp
@@ -342,3 +342,15 @@ bool PopupSwitchWidget::eventFilter(QObject *watched, QEvent *event)
 
     return QWidget::eventFilter(watched, event);
 }
+
+void PopupSwitchWidget::hideEvent(QHideEvent *event)
+{
+    for (int i = m_containerLayout->count() - 1; i >= 0; i--) {
+        QLayoutItem *item = m_containerLayout->itemAt(i);
+        item->widget()->removeEventFilter(this);
+        m_containerLayout->removeItem(item);
+        item->widget()->setParent(nullptr);
+    }
+
+    return QWidget::hideEvent(event);
+}

--- a/panels/dock/tray/frame/util/dockpopupwindow.h
+++ b/panels/dock/tray/frame/util/dockpopupwindow.h
@@ -90,6 +90,7 @@ public:
 
 protected:
     bool eventFilter(QObject *watched, QEvent *event) override;
+    void hideEvent(QHideEvent *event) override;
 
 private:
     QVBoxLayout *m_containerLayout;

--- a/panels/dock/tray/plugins/pluginmanager/pluginchildpage.cpp
+++ b/panels/dock/tray/plugins/pluginmanager/pluginchildpage.cpp
@@ -44,10 +44,10 @@ void PluginChildPage::pushWidget(QWidget *widget)
         m_containerLayout->removeItem(item);
     }
     m_topWidget = widget;
-    if (widget) {
-        widget->installEventFilter(this);
-        m_containerLayout->addWidget(widget);
-        widget->show();
+    if (m_topWidget) {
+        m_topWidget->installEventFilter(this);
+        m_containerLayout->addWidget(m_topWidget);
+        m_topWidget->show();
     }
     QMetaObject::invokeMethod(this, &PluginChildPage::resetHeight, Qt::QueuedConnection);
 }
@@ -96,4 +96,17 @@ void PluginChildPage::resetHeight()
     QMargins m = m_containerLayout->contentsMargins();
     m_container->setFixedHeight(m.top() + m.bottom() + (m_topWidget ? m_topWidget->height() : 0));
     setFixedHeight(m_headerWidget->height() + m_container->height());
+}
+
+void PluginChildPage::hideEvent(QHideEvent *event)
+{
+    for (int i = m_containerLayout->count() - 1; i >= 0; i--) {
+        QLayoutItem *item = m_containerLayout->itemAt(i);
+        item->widget()->removeEventFilter(this);
+        m_containerLayout->removeItem(item);
+        item->widget()->setParent(nullptr);
+    }
+
+    m_topWidget = nullptr;
+    return QWidget::hideEvent(event);
 }

--- a/panels/dock/tray/plugins/pluginmanager/pluginchildpage.h
+++ b/panels/dock/tray/plugins/pluginmanager/pluginchildpage.h
@@ -30,6 +30,7 @@ Q_SIGNALS:
 
 protected:
     bool eventFilter(QObject *watched, QEvent *event) override;
+    void hideEvent(QHideEvent *event) override;
 
 private:
     void initUi();

--- a/panels/dock/tray/plugins/sound/sounddeviceswidget.cpp
+++ b/panels/dock/tray/plugins/sound/sounddeviceswidget.cpp
@@ -49,7 +49,7 @@ using namespace Dock;
 
 SoundDevicesWidget::SoundDevicesWidget(QWidget *parent)
     : QWidget(parent)
-    , m_tipsLabel(new TipsWidget(this))
+    , m_tipsLabel(new TipsWidget)
     , m_sliderContainer(new SliderContainer(this))
     , m_descriptionLabel(new QLabel(tr("Output Device"), this))
     , m_deviceList(new DListView(this))


### PR DESCRIPTION
1. childPage content widget need reset parent to null when hide
2. remove tooltip Widget parent

log: as title
Issue: https://github.com/linuxdeepin/developer-center/issues/8604