### PR TITLE
feat: support reconnect wayland compositor

### DIFF
--- a/panels/dock/taskmanager/abstractwindowmonitor.h
+++ b/panels/dock/taskmanager/abstractwindowmonitor.h
@@ -22,6 +22,7 @@ public:
     AbstractWindowMonitor(QObject* parent = nullptr): QObject(parent){};
     virtual void start() = 0;
     virtual void stop() = 0;
+    virtual void clear() = 0;
 
     virtual QPointer<AbstractWindow> getWindowByWindowId(ulong windowId) = 0;
 

--- a/panels/dock/taskmanager/waylandwindowmonitor.cpp
+++ b/panels/dock/taskmanager/waylandwindowmonitor.cpp
@@ -88,10 +88,23 @@ void WaylandWindowMonitor::start()
 {
     m_foreignToplevelManager.reset(new ForeignToplevelManager(this));
     connect(m_foreignToplevelManager.get(), &ForeignToplevelManager::newForeignToplevelHandle, this, &WaylandWindowMonitor::handleForeignToplevelHandleAdded);
+    connect(m_foreignToplevelManager.get(), &ForeignToplevelManager::activeChanged, this, [this]{
+        if (!m_foreignToplevelManager->isActive()) {
+            clear();
+        }
+    });
 }
+
 void WaylandWindowMonitor::stop()
 {
     m_foreignToplevelManager.reset(nullptr);
+}
+
+
+void WaylandWindowMonitor::clear()
+{
+    m_windows.clear();
+    m_dockPreview.reset(nullptr);
 }
 
 QPointer<AbstractWindow> WaylandWindowMonitor::getWindowByWindowId(ulong windowId)

--- a/panels/dock/taskmanager/waylandwindowmonitor.h
+++ b/panels/dock/taskmanager/waylandwindowmonitor.h
@@ -64,6 +64,7 @@ public:
     explicit WaylandWindowMonitor(QObject* parent = nullptr);
     virtual void start() override;
     virtual void stop() override;
+    virtual void clear() override;
 
     virtual QPointer<AbstractWindow> getWindowByWindowId(ulong windowId) override;
 

--- a/panels/dock/taskmanager/x11windowmonitor.cpp
+++ b/panels/dock/taskmanager/x11windowmonitor.cpp
@@ -68,7 +68,7 @@ void X11WindowMonitor::start()
     uint32_t value_list[] = {
             0                               | XCB_EVENT_MASK_PROPERTY_CHANGE        |
             XCB_EVENT_MASK_VISIBILITY_CHANGE    | XCB_EVENT_MASK_SUBSTRUCTURE_NOTIFY    |
-            XCB_EVENT_MASK_STRUCTURE_NOTIFY     | XCB_EVENT_MASK_FOCUS_CHANGE           
+            XCB_EVENT_MASK_STRUCTURE_NOTIFY     | XCB_EVENT_MASK_FOCUS_CHANGE
     };
 
     xcb_change_window_attributes(X11->getXcbConnection(), m_rootWindow, XCB_CW_EVENT_MASK, value_list);
@@ -84,6 +84,13 @@ void X11WindowMonitor::stop()
     qApp->removeNativeEventFilter(m_xcbEventFilter.get());
     m_xcbEventFilter.reset(nullptr);
     Q_EMIT AbstractWindowMonitor::WindowMonitorShutdown();
+}
+
+
+void X11WindowMonitor::clear()
+{
+    m_windows.clear();
+    m_windowPreview.reset(nullptr);
 }
 
 QPointer<AbstractWindow> X11WindowMonitor::getWindowByWindowId(ulong windowId)

--- a/panels/dock/taskmanager/x11windowmonitor.h
+++ b/panels/dock/taskmanager/x11windowmonitor.h
@@ -34,6 +34,7 @@ public:
     explicit X11WindowMonitor(QObject* parent = nullptr);
     virtual void start() override;
     virtual void stop() override;
+    virtual void clear() override;
 
     virtual QPointer<AbstractWindow> getWindowByWindowId(ulong windowId) override;
     virtual void presentWindows(QList<uint32_t> windows) override;


### PR DESCRIPTION
When Qt program use QT_WAYLAND_RECONNECT environment, Qt will reconnect wayland compositor. We need refresh all data.
