### PR TITLE
fix: tooltip overlaps with dock

### DIFF
--- a/panels/dock/taskmanager/package/AppItem.qml
+++ b/panels/dock/taskmanager/package/AppItem.qml
@@ -308,8 +308,9 @@ Item {
             interval: 50
             onTriggered: {
                 var point = root.mapToItem(null, root.width / 2, 0)
+                var AppletPoint = Applet.rootObject.mapToItem(null, root.width / 2, 0)
                 toolTip.toolTipX = point.x
-                toolTip.toolTipY = point.y
+                toolTip.toolTipY = root.useColumnLayout ? point.y : AppletPoint.y
                 toolTip.open()
             }
         }


### PR DESCRIPTION
When the dock triggers overflow, the tooltip overlaps with the dock.

Log: fix tooltip overlaps with dock
issue: https://github.com/linuxdeepin/developer-center/issues/8171
Influence: tooltip display