### PR TITLE
fix: hover预览窗口模糊背景时，预览窗口才出现关闭按钮

### DIFF
--- a/panels/dock/taskmanager/x11preview.cpp
+++ b/panels/dock/taskmanager/x11preview.cpp
@@ -478,12 +478,14 @@ void X11WindowPreviewContainer::leaveEvent(QEvent* event)
 {
     m_isPreviewEntered = false;
     m_hideTimer->start();
+    m_closeAllButton->setVisible(false);
     return DBlurEffectWidget::leaveEvent(event);
 }
 
 void X11WindowPreviewContainer::showEvent(QShowEvent *event)
 {
     updateOrientation();
+    m_closeAllButton->setVisible(false);
     return DBlurEffectWidget::showEvent(event);
 }
 


### PR DESCRIPTION
Issue: https://github.com/linuxdeepin/developer-center/issues/8630
Log: hover预览窗口模糊背景时，预览窗口才出现关闭按钮