### PR TITLE
fix: Control Center has not been default docked

### DIFF
--- a/panels/dock/taskmanager/dconfig/org.deepin.ds.dock.taskmanager.json
+++ b/panels/dock/taskmanager/dconfig/org.deepin.ds.dock.taskmanager.json
@@ -23,7 +23,7 @@
 			"visibility": "private"
 		},
 		"Docked_Items": {
-			"value": ["id: dde-file-manager,type: amAPP", "id: deepin-app-store,type: amAPP", "id: org.deepin.browser,type: amAPP", "id: deepin-mail,type: amAPP","id: deepin-terminal,type: amAPP","id: dde-calendar,type: amAPP","id: deepin-music,type: amAPP","id: deepin-editor,type: amAPP","id: deepin-calculator,type: amAPP","id: dde-control-center,type: amAPP","id: dde-trash,type: amAPP"],
+			"value": ["id: dde-file-manager,type: amAPP", "id: deepin-app-store,type: amAPP", "id: org.deepin.browser,type: amAPP", "id: deepin-mail,type: amAPP","id: deepin-terminal,type: amAPP","id: dde-calendar,type: amAPP","id: deepin-music,type: amAPP","id: deepin-editor,type: amAPP","id: deepin-calculator,type: amAPP", "id: org.deepin.dde.control-center, type: amAPP", "id: dde-trash,type: amAPP"],
 			"serial": 0,
 			"flags": [],
 			"name": "Docked_Items",


### PR DESCRIPTION
dde-control-center 改为 org.deepin.dde.control-center

Issues: linuxdeepin/developer-center#8852