### PR TITLE
chore: bump version to 0.0.24

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,27 @@
+dde-shell (0.0.24) unstable; urgency=medium
+
+  * chore: allow follow symlinks when init plugins
+  * feat: allow build dockplugin as toplevel project
+  * fix(taskmanager): radius of the indicators are not working (linuxdeepin/developer-center#8804)
+  * fix: Control Center has not been default docked (linuxdeepin/developer-center#8852)
+  * feat: Add support for only the primary screen in multi-screen setups.
+  * feat: drop item to dock to pin app
+  * fix: The app preview close button is not clear (https://github.com/linuxdeepin/developer-center/issues/8628)
+  * feat: support to display non window plugin
+  * fix: tooltip overlaps with dock (https://github.com/linuxdeepin/developer-center/issues/8171)
+  * fix: PluginManager and ShotStartPlugin size not same as other tray plugin
+  * fix: tray plugin size not follow PluginSizePolicy
+  * fix: x11 preview display problem
+  * refact: link dynamic networkmanagerqt instead of static
+  * fix: blurred icons during app preview (https://github.com/linuxdeepin/developer-center/issues/8649)
+  * feat: add multi screen support
+  * fix: The app launch animation exceeds the boundaries. (https://github.com/linuxdeepin/developer-center/issues/8614)
+  * fix: x11 preview content is blurry
+  * fix: coredump app exit after open quick panel childPage (https://github.com/linuxdeepin/developer-center/issues/8604)
+  * feat: support reconnect wayland compositor
+
+ -- zsien <quezhiyong@deepin.org>  Thu, 06 Jun 2024 16:52:57 +0800
+
 dde-shell (0.0.23) unstable; urgency=medium
 
   * fix: uos-ai disabled(issue: 8593)

--- a/panels/dock/package/main.qml
+++ b/panels/dock/package/main.qml
@@ -179,6 +179,7 @@ Window {
             MutuallyExclusiveMenu {
                 title: qsTr("Position")
                 EnumPropertyMenuItem {
+                    enabled: Panel.debugMode
                     name: qsTr("Top")
                     prop: "position"
                     value: Dock.Top
@@ -189,11 +190,13 @@ Window {
                     value: Dock.Bottom
                 }
                 EnumPropertyMenuItem {
+                    enabled: Panel.debugMode
                     name: qsTr("Left")
                     prop: "position"
                     value: Dock.Left
                 }
                 EnumPropertyMenuItem {
+                    enabled: Panel.debugMode
                     name: qsTr("Right")
                     prop: "position"
                     value: Dock.Right


### PR DESCRIPTION
  * chore: allow follow symlinks when init plugins
  * feat: allow build dockplugin as toplevel project
  * fix(taskmanager): radius of the indicators are not working (linuxdeepin/developer-center#8804)
  * fix: Control Center has not been default docked (linuxdeepin/developer-center#8852)
  * feat: Add support for only the primary screen in multi-screen setups.
  * feat: drop item to dock to pin app
  * fix: The app preview close button is not clear (https://github.com/linuxdeepin/developer-center/issues/8628)
  * feat: support to display non window plugin
  * fix: tooltip overlaps with dock (https://github.com/linuxdeepin/developer-center/issues/8171)
  * fix: PluginManager and ShotStartPlugin size not same as other tray plugin
  * fix: tray plugin size not follow PluginSizePolicy
  * fix: x11 preview display problem
  * refact: link dynamic networkmanagerqt instead of static
  * fix: blurred icons during app preview (https://github.com/linuxdeepin/developer-center/issues/8649)
  * feat: add multi screen support
  * fix: The app launch animation exceeds the boundaries. (https://github.com/linuxdeepin/developer-center/issues/8614)
  * fix: x11 preview content is blurry
  * fix: coredump app exit after open quick panel childPage (https://github.com/linuxdeepin/developer-center/issues/8604)
  * feat: support reconnect wayland compositor