### PR TITLE
fix: some 1070 tray plugins tooltip not show

### DIFF
--- a/panels/dock/dockplugin/loader/pluginitem.cpp
+++ b/panels/dock/dockplugin/loader/pluginitem.cpp
@@ -153,6 +153,7 @@ void PluginItem::enterEvent(QEvent *event)
             return;
         }
 
+        toolTip->setParent(nullptr);
         toolTip->setAttribute(Qt::WA_TranslucentBackground);
         toolTip->winId();
 
@@ -160,7 +161,9 @@ void PluginItem::enterEvent(QEvent *event)
         auto pluginPopup = Plugin::PluginPopup::get(toolTip->windowHandle());
         pluginPopup->setPopupType(Plugin::PluginPopup::PopupTypeTooltip);
         pluginPopup->setX(geometry.x() + geometry.width() / 2), pluginPopup->setY(geometry.y() + geometry.height() / 2);
-        toolTip->setFixedSize(toolTip->sizeHint());
+        if (toolTip->sizeHint().width() > 0 && toolTip->sizeHint().height() > 0) {
+            toolTip->setFixedSize(toolTip->sizeHint());
+        }
         toolTip->show();
     });
 }


### PR DESCRIPTION
1.tooltip widget has parent widget
2.plugin's has error sizeHint

Log: as title
Influence: tray plugin