### PR TITLE
fix: Plugin repeatedly calls the itemAdded interface

### DIFF
--- a/panels/dock/dockplugin/loader/widgetplugin.cpp
+++ b/panels/dock/dockplugin/loader/widgetplugin.cpp
@@ -56,17 +56,19 @@ void WidgetPlugin::itemAdded(PluginsItemInterface * const itemInter, const QStri
     if (flag & Dock::Type_Quick || flag & Dock::Type_Tool ||
         flag & Dock::Type_System || flag & Dock::Type_Tray || 
         flag & Dock::Attribute_Normal) {
-        PluginItem *item = new PluginItem(itemInter, itemKey);
-        Plugin::EmbedPlugin* plugin = Plugin::EmbedPlugin::get(item->windowHandle());
-        initConnections(plugin);
-        plugin->setPluginFlags(item->flags(itemInter));
-        plugin->setPluginId(itemInter->pluginName());
-        plugin->setItemKey(itemKey);
-        plugin->setPluginType(Plugin::EmbedPlugin::Tray);
-        Q_EMIT plugin->requestMessage("plugin test message");
-        item->windowHandle()->hide();
-        item->show();
-        m_pluginItems << item;
+        if (!Plugin::EmbedPlugin::contains(itemKey, Plugin::EmbedPlugin::Tray)) {
+            PluginItem *item = new PluginItem(itemInter, itemKey);
+            Plugin::EmbedPlugin* plugin = Plugin::EmbedPlugin::get(item->windowHandle());
+            initConnections(plugin);
+            plugin->setPluginFlags(item->flags(itemInter));
+            plugin->setPluginId(itemInter->pluginName());
+            plugin->setItemKey(itemKey);
+            plugin->setPluginType(Plugin::EmbedPlugin::Tray);
+            Q_EMIT plugin->requestMessage("plugin test message");
+            item->windowHandle()->hide();
+            item->show();
+            m_pluginItems << item;
+        }
     }
     if (flag & Dock::Type_Fixed) {
         PluginItem *item = new PluginItem(itemInter, itemKey);

--- a/panels/dock/dockplugin/plugin/plugin.cpp
+++ b/panels/dock/dockplugin/plugin/plugin.cpp
@@ -127,6 +127,17 @@ bool EmbedPlugin::contains(QWindow *window)
     return s_map.keys().contains(window);
 }
 
+bool EmbedPlugin::contains(const QString &itemKey, int type)
+{
+    for (const auto *plugin : s_map.values()) {
+        if (itemKey == plugin->itemKey() && type == plugin->pluginType()) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 class PluginPopupPrivate
 {
 public:

--- a/panels/dock/dockplugin/plugin/plugin.h
+++ b/panels/dock/dockplugin/plugin/plugin.h
@@ -47,6 +47,7 @@ public:
 
     static EmbedPlugin* get(QWindow* window);
     static bool contains(QWindow* window);
+    static bool contains(const QString &itemKey, int type);
 
 Q_SIGNALS:
     void eventMessage(const QString &msg);


### PR DESCRIPTION
bluetooth has this problem.

Log: as title
Influence: tray plugin