### PR TITLE
fix: crashed when exit

### DIFF
--- a/frame/qml/PanelPopup.qml
+++ b/frame/qml/PanelPopup.qml
@@ -80,5 +80,8 @@ Item {
         // TODO dtk's blur causes blurred screen.
         background: null
     }
-    Component.onDestruction: control.close()
+    Component.onDestruction: {
+        if (popup.visible)
+            control.close()
+    }
 }


### PR DESCRIPTION
Crashed when accessing attached property in onDestruction.