### PR TITLE
feat: support to set PanelPopup's window

### DIFF
--- a/frame/qml/PanelPopup.qml
+++ b/frame/qml/PanelPopup.qml
@@ -11,6 +11,7 @@ Item {
     visible: false
     default property alias popupContent: popup.contentChildren
     property alias popupVisible: popup.visible
+    property var popupWindow: Panel.popupWindow
 
     property int margins: 10
     property int popupX: 0
@@ -23,7 +24,7 @@ Item {
             return
         }
 
-        var window = Panel.popupWindow
+        var window = popupWindow
         if (!window)
             return
 
@@ -46,7 +47,7 @@ Item {
     }
     function close()
     {
-        var window = Panel.popupWindow
+        var window = popupWindow
         if (!window)
             return
 
@@ -55,14 +56,14 @@ Item {
     }
 
     Connections {
-        target: Panel.popupWindow
+        target: popupWindow
         function onActiveChanged()
         {
-            var window = Panel.popupWindow
+            var window = popupWindow
             if (!window)
                 return
             // TODO why activeChanged is not emit.
-            if (Panel.popupWindow && !Panel.popupWindow.active) {
+            if (popupWindow && !popupWindow.active) {
                 control.close()
             }
         }
@@ -73,13 +74,13 @@ Item {
         padding: 0
         width: control.width
         height: control.height
-        parent: Panel.popupWindow ? Panel.popupWindow.contentItem : undefined
+        parent: popupWindow ? popupWindow.contentItem : undefined
         onParentChanged: function() {
-            var window = Panel.popupWindow
+            var window = popupWindow
             if (!window)
                 return
             window.visibleChanged.connect(function() {
-                if (Panel.popupWindow && !Panel.popupWindow.visible)
+                if (popupWindow && !popupWindow.visible)
                     control.close()
             })
         }

--- a/frame/qml/PanelToolTip.qml
+++ b/frame/qml/PanelToolTip.qml
@@ -13,6 +13,7 @@ Item {
     default property alias toolTipContentItem: toolTip.contentItem
     property alias text: toolTip.text
     property alias toolTipVisible: toolTip.visible
+    property var toolTipWindow: Panel.toolTipWindow
     property int toolTipX: 0
     property int toolTipY: 0
     property int margins: 10
@@ -26,7 +27,7 @@ Item {
 
     function open()
     {
-        var window = Panel.toolTipWindow
+        var window = toolTipWindow
         if (!window)
             return
         window.width = Qt.binding(function() {
@@ -48,7 +49,7 @@ Item {
     
     function close()
     {
-        var window = Panel.toolTipWindow
+        var window = toolTipWindow
         if (!window)
             return
 
@@ -64,17 +65,17 @@ Item {
         id: toolTip
         padding: 0
         // TODO it's a bug for qt, ToolTip's text color can't change with window's palette changed.
-        palette.toolTipText: Panel.toolTipWindow ? Panel.toolTipWindow.palette.toolTipText : undefined
+        palette.toolTipText: toolTipWindow ? toolTipWindow.palette.toolTipText : undefined
         anchors.centerIn: parent
         topPadding: 0
         bottomPadding: 0
-        parent: Panel.toolTipWindow ? Panel.toolTipWindow.contentItem : undefined
+        parent: toolTipWindow ? toolTipWindow.contentItem : undefined
         onParentChanged: function() {
-            var window = Panel.toolTipWindow
+            var window = toolTipWindow
             if (!window)
                 return
             window.visibleChanged.connect(function() {
-                if (Panel.toolTipWindow && !Panel.toolTipWindow.visible)
+                if (toolTipWindow && !toolTipWindow.visible)
                     toolTip.close()
             })
         }


### PR DESCRIPTION
We can set PanelPopup's window, in somecase, we need output other window instead of default Popup's window.