### PR TITLE
feat: initial drag'n'drop support for new dock tray

### DIFF
--- a/panels/dock/tray/package/ActionLegacyTrayPluginDelegate.qml
+++ b/panels/dock/tray/package/ActionLegacyTrayPluginDelegate.qml
@@ -68,4 +68,21 @@ Button {
             updatePluginItemGeometryTimer.start()
         }
     }
+
+    Drag.active: dragHandler.active
+    Drag.dragType: Drag.Automatic
+    Drag.mimeData: {
+        "text/x-dde-shell-tray-dnd-surfaceId": model.surfaceId
+    }
+    Drag.supportedActions: Qt.MoveAction
+    Drag.onActiveChanged: {
+        DDT.TraySortOrderModel.actionsAlwaysVisible = Drag.active
+        if (!Drag.active) {
+            // reset position on drop
+            Qt.callLater(() => { x = 0; y = 0; });
+        }
+    }
+    DragHandler {
+        id: dragHandler
+    }
 }

--- a/panels/dock/tray/package/DummyDelegate.qml
+++ b/panels/dock/tray/package/DummyDelegate.qml
@@ -4,7 +4,7 @@
 
 import QtQuick
 import QtQuick.Controls
-import Qt.labs.platform 1.1 as LP
+import org.deepin.ds.dock.tray 1.0 as DDT
 
 Button {
     icon.name: model.surfaceId
@@ -12,4 +12,24 @@ Button {
     icon.height: 16
     width: 16
     height: 16
+
+    Drag.active: dragHandler.active
+    Drag.dragType: Drag.Automatic
+    Drag.mimeData: {
+        "text/x-dde-shell-tray-dnd-surfaceId": model.surfaceId
+    }
+    Drag.supportedActions: Qt.MoveAction
+    Drag.onActiveChanged: {
+        DDT.TraySortOrderModel.actionsAlwaysVisible = Drag.active
+        if (!Drag.active) {
+            // reset position on drop
+            Qt.callLater(() => { x = 0; y = 0; });
+        }
+    }
+    contentItem: Rectangle {
+        color: "grey"
+    }
+    DragHandler {
+        id: dragHandler
+    }
 }

--- a/panels/dock/tray/package/StashContainer.qml
+++ b/panels/dock/tray/package/StashContainer.qml
@@ -57,6 +57,22 @@ Item {
         anchors.fill: parent
     }
 
+    DropArea {
+        anchors.fill: parent
+        keys: ["text/x-dde-shell-tray-dnd-surfaceId"]
+        onEntered: function (dragEvent) {
+            console.log(dragEvent.getDataAsString("text/x-dde-shell-tray-dnd-surfaceId"))
+        }
+        onPositionChanged: function (dragEvent) {
+            let surfaceId = dragEvent.getDataAsString("text/x-dde-shell-tray-dnd-surfaceId")
+            console.log("dragging", surfaceId)
+        }
+        onDropped: function (dropEvent) {
+            let surfaceId = dropEvent.getDataAsString("text/x-dde-shell-tray-dnd-surfaceId")
+            DDT.TraySortOrderModel.dropToStashTray(surfaceId, 0, false);
+        }
+    }
+
     // Tray items
     Repeater {
         anchors.fill: parent

--- a/panels/dock/tray/package/StashedItemDelegateChooser.qml
+++ b/panels/dock/tray/package/StashedItemDelegateChooser.qml
@@ -25,9 +25,7 @@ LQM.DelegateChooser {
     LQM.DelegateChoice {
         roleValue: "legacy-tray-plugin"
         StashedItemPositioner {
-            contentItem: ActionLegacyTrayPluginDelegate {
-                inputEventsEnabled: false // temporary
-            }
+            contentItem: ActionLegacyTrayPluginDelegate {}
         }
     }
     LQM.DelegateChoice {

--- a/panels/dock/tray/package/TrayContainer.qml
+++ b/panels/dock/tray/package/TrayContainer.qml
@@ -108,6 +108,32 @@ Item {
         anchors.fill: parent
     }
 
+    DropArea {
+        anchors.fill: parent
+        keys: ["text/x-dde-shell-tray-dnd-surfaceId"]
+        onEntered: function (dragEvent) {
+            console.log(dragEvent.getDataAsString("text/x-dde-shell-tray-dnd-surfaceId"))
+        }
+        onPositionChanged: function (dragEvent) {
+            let surfaceId = dragEvent.getDataAsString("text/x-dde-shell-tray-dnd-surfaceId")
+            let pos = root.isHorizontal ? drag.x : drag.y
+            let currentItemIndex = pos / (root.itemSize + root.itemSpacing)
+            let currentPosMapToItem = pos % (root.itemSize + root.itemSpacing)
+            let isBefore = currentPosMapToItem < root.itemSize / 2
+            console.log("dragging", surfaceId, Math.floor(currentItemIndex), currentPosMapToItem, isBefore)
+            // DDT.TraySortOrderModel.dropToDockTray(surfaceId, Math.floor(currentItemIndex), isBefore);
+        }
+        onDropped: function (dropEvent) {
+            let surfaceId = dropEvent.getDataAsString("text/x-dde-shell-tray-dnd-surfaceId")
+            let pos = root.isHorizontal ? drag.x : drag.y
+            let currentItemIndex = pos / (root.itemSize + root.itemSpacing)
+            let currentPosMapToItem = pos % (root.itemSize + root.itemSpacing)
+            let isBefore = currentPosMapToItem < root.itemSize / 2
+            console.log("dropped", currentItemIndex, currentPosMapToItem, isBefore)
+            DDT.TraySortOrderModel.dropToDockTray(surfaceId, Math.floor(currentItemIndex), isBefore);
+        }
+    }
+
     // Tray items
     Repeater {
         anchors.fill: parent

--- a/panels/dock/tray/package/TrayItemPositioner.qml
+++ b/panels/dock/tray/package/TrayItemPositioner.qml
@@ -9,7 +9,7 @@ Control {
     id: root
     property bool itemVisible: {
         if (model.sectionType === "collapsable") return !collapsed
-        return model.sectionType !== "stashed"
+        return model.sectionType !== "stashed" && model.visibility
     }
 
     width: 16

--- a/panels/dock/tray/traysortordermodel.h
+++ b/panels/dock/tray/traysortordermodel.h
@@ -17,6 +17,7 @@ class TraySortOrderModel : public QStandardItemModel
 
     Q_PROPERTY(int visualItemCount MEMBER m_visualItemCount NOTIFY visualItemCountChanged)
     Q_PROPERTY(bool collapsed MEMBER m_collapsed NOTIFY collapsedChanged)
+    Q_PROPERTY(bool actionsAlwaysVisible MEMBER m_actionsAlwaysVisible NOTIFY actionsAlwaysVisibleChanged)
     Q_PROPERTY(QList<QVariantMap> availableSurfaces MEMBER m_availableSurfaces NOTIFY availableSurfacesChanged)
 public:
     // enum SectionTypes {
@@ -38,17 +39,28 @@ public:
     };
     Q_ENUM(Roles)
 
+    enum VisualSections {
+        DockTraySection,
+        StashedSection
+    };
+    Q_ENUM(VisualSections)
+
     explicit TraySortOrderModel(QObject *parent = nullptr);
     ~TraySortOrderModel();
 
+    Q_INVOKABLE bool dropToStashTray(const QString & draggedSurfaceId, int dropVisualIndex, bool isBefore);
+    Q_INVOKABLE bool dropToDockTray(const QString & draggedSurfaceId, int dropVisualIndex, bool isBefore);
+
 signals:
     void collapsedChanged(bool);
+    void actionsAlwaysVisibleChanged(bool);
     void visualItemCountChanged(int);
     void availableSurfacesChanged(const QList<QVariantMap> &);
 
 private:
     int m_visualItemCount = 0;
     bool m_collapsed = false;
+    bool m_actionsAlwaysVisible = false;
     // this is for the plugins that currently available.
     QList<QVariantMap> m_availableSurfaces;
     // these are the sort order data source, it might contain items that are no longer existed.
@@ -57,6 +69,8 @@ private:
     QStringList m_pinnedIds;
     QStringList m_fixedIds;
 
+    QStandardItem * findItemByVisualIndex(int visualIndex, VisualSections visualSection) const;
+    QStringList * getSection(const QString & sectionType);
     QString findSection(const QString & surfaceId, const QString & fallback);
     void registerToSection(const QString & surfaceId, const QString & sectionType);
     QStandardItem * createTrayItem(const QString & name, const QString & sectionType, const QString & delegateType);


### PR DESCRIPTION
为新托盘实现初步拖拽支持。

Log:

----------

注：

1. 当前拖拽仅为非常初步的支持，允许从各个区域拖拽到其它区域，仅在鼠标释放时应用拖拽动作，且拖拽时鼠标无图标指示。
2. 暂未添加对显示/隐藏项目的控制逻辑，后续会另外单独实现/PR。所以快捷面板的拖拽应该要等下一个PR。
3. 向上托盘隐藏区域（StashContainer）目前只是可以拖进去，无法调整顺序/拖拽到指定位置。