### PR TITLE
chore: initial support for hide surface from tray

### DIFF
--- a/panels/dock/tray/package/TrayContainer.qml
+++ b/panels/dock/tray/package/TrayContainer.qml
@@ -131,6 +131,7 @@ Item {
             let isBefore = currentPosMapToItem < root.itemSize / 2
             console.log("dropped", currentItemIndex, currentPosMapToItem, isBefore)
             DDT.TraySortOrderModel.dropToDockTray(surfaceId, Math.floor(currentItemIndex), isBefore);
+            DDT.TraySortOrderModel.actionsAlwaysVisible = false
         }
     }
 

--- a/panels/dock/tray/traysortordermodel.h
+++ b/panels/dock/tray/traysortordermodel.h
@@ -50,6 +50,7 @@ public:
 
     Q_INVOKABLE bool dropToStashTray(const QString & draggedSurfaceId, int dropVisualIndex, bool isBefore);
     Q_INVOKABLE bool dropToDockTray(const QString & draggedSurfaceId, int dropVisualIndex, bool isBefore);
+    Q_INVOKABLE void setSurfaceVisible(const QString & surfaceId, bool visible);
 
 signals:
     void collapsedChanged(bool);
@@ -68,6 +69,8 @@ private:
     QStringList m_collapsableIds;
     QStringList m_pinnedIds;
     QStringList m_fixedIds;
+    // surface IDs that should be invisible/hidden from the tray area.
+    QStringList m_hiddenIds;
 
     QStandardItem * findItemByVisualIndex(int visualIndex, VisualSections visualSection) const;
     QStringList * getSection(const QString & sectionType);


### PR DESCRIPTION
Log:

-------

cc @18202781743 

是为支持从快捷面板拖拽到托盘的功能的准备。从快捷面板拖拽到tray区域时，携带 `text/x-dde-shell-tray-dnd-surfaceId` MimeType,值为`${pluginId}::${itemKey}` 即可。被拖拽到对应区域的项目若之前已被隐藏，则会被取消隐藏并移动到鼠标 drop 到的位置。若原本就已显示，则只会将原有 item （无论在哪）移动到鼠标 drop 到的位置。