### PR TITLE
fix: missing backing lib for quickpanel

### DIFF
--- a/panels/dock/tray/quickpanel/CMakeLists.txt
+++ b/panels/dock/tray/quickpanel/CMakeLists.txt
@@ -2,8 +2,8 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-qt_add_qml_module(
-    tray-quickpanel
+qt_add_qml_module(tray-quickpanel
+    PLUGIN_TARGET tray-quickpanel
     URI "org.deepin.ds.dock.tray.quickpanel"
     VERSION "1.0"
     SOURCES


### PR DESCRIPTION
The plugin target with no backing target, so we use PLUGIN_TARGET same with target.