### PR TITLE
fix: incorrect height for quickpanel's subplugin

### DIFF
--- a/panels/dock/tray/quickpanel/QuickPanelPage.qml
+++ b/panels/dock/tray/quickpanel/QuickPanelPage.qml
@@ -34,11 +34,15 @@ Item {
 
     StackView {
         id: panelView
+        property int contentHeight: currentItem ? currentItem.height : 10
         width: currentItem ? currentItem.width : 10
-        height: currentItem ? currentItem.height : 10
+        height: panelView.contentHeight
         initialItem: PanelPluginPage {
             id: panelPage
             model: root.model
+            StackView.onActivating: {
+                panelView.contentHeight = Qt.binding(function() { return height })
+            }
             StackView.onActivated: {
                 panelPage.forceLayout()
             }
@@ -51,6 +55,9 @@ Item {
             width: panelPage.width
             onRequestBack: function () {
                 panelView.pop()
+            }
+            StackView.onActivating: {
+                panelView.contentHeight = Qt.binding(function() { return contentHeight})
             }
         }
     }

--- a/panels/dock/tray/quickpanel/SubPluginPage.qml
+++ b/panels/dock/tray/quickpanel/SubPluginPage.qml
@@ -12,8 +12,9 @@ import org.deepin.dtk 1.0
 Item {
     id: root
     implicitWidth: 330
-    height: Math.min(Math.max(subPluginMinHeight, childrenRect.height), 600)
+    implicitHeight: contentHeight
 
+    readonly property int contentHeight: Math.min(Math.max(subPluginMinHeight, subPluginView.height), 600)
     required property var pluginId
     property alias shellSurface: surfaceLayer.shellSurface
     required property var model
@@ -26,6 +27,7 @@ Item {
     }
 
     ColumnLayout {
+        id: subPluginView
         spacing: 0
         width: root.width
 
@@ -61,9 +63,8 @@ Item {
         Item { Layout.fillHeight: true; Layout.preferredWidth: 1 }
 
         // content
-        ShellSurfaceItemProxy {
+        ShellSurfaceItem {
             id: surfaceLayer
-            Layout.fillHeight: true
             Layout.fillWidth: true
         }
 


### PR DESCRIPTION
Item's height is set by StackView when pushed a Component, so we add a contentHeight as Item's implicitHeight, and we rebind StackView's height when StackView.activating.