### PR TITLE
fix: can't destroy surface when widget hide

### DIFF
--- a/panels/dock/DockCompositor.qml
+++ b/panels/dock/DockCompositor.qml
@@ -73,7 +73,13 @@ Item {
 
             onPluginSurfaceDestroyed: (dockPluginSurface) => {
                 console.log("plugin surface destroyed", dockPluginSurface.pluginId, dockPluginSurface.itemKey, dockPluginSurface.pluginType)
-                removeDockPluginSurface(trayPluginSurfaces, dockPluginSurface)
+                if (dockPluginSurface.pluginType === Dock.Tray) {
+                    removeDockPluginSurface(trayPluginSurfaces, dockPluginSurface)
+                } else if (dockPluginSurface.pluginType === Dock.Quick) {
+                    removeDockPluginSurface(quickPluginSurfaces, dockPluginSurface)
+                } else if (dockPluginSurface.pluginType === Dock.Fixed) {
+                    removeDockPluginSurface(fixedPluginSurfaces, dockPluginSurface)
+                }
                 dockCompositor.pluginSurfacesUpdated()
             }
 

--- a/panels/dock/dockplugin/loader/pluginitem.cpp
+++ b/panels/dock/dockplugin/loader/pluginitem.cpp
@@ -53,7 +53,7 @@ void PluginItem::mouseLeftButtonClicked()
         }
 
         if (m_isPanelPopupShow) {
-            popup->hide();
+            popup->windowHandle()->hide();
             m_isPanelPopupShow = false;
             return;
         }
@@ -213,7 +213,7 @@ void PluginItem::showPluginTooltip()
 {
     auto popup = m_pluginsItemInterface->itemPopupApplet(m_itemKey);
     if (popup && popup->isVisible())
-        popup->hide();
+        popup->windowHandle()->hide();
 
     showTooltip(m_itemKey);
 }

--- a/panels/dock/dockplugin/loader/widgetplugin.cpp
+++ b/panels/dock/dockplugin/loader/widgetplugin.cpp
@@ -119,16 +119,16 @@ void WidgetPlugin::itemUpdate(PluginsItemInterface * const itemInter, const QStr
 void WidgetPlugin::itemRemoved(PluginsItemInterface * const itemInter, const QString &itemKey)
 {
     auto widget = m_pluginsItemInterface->itemWidget(itemKey);
-    if(widget) widget->hide();
+    if(widget) widget->windowHandle()->hide();
 
     auto quickPanel = m_pluginsItemInterface->itemWidget(Dock::QUICK_ITEM_KEY);
-    if(quickPanel) quickPanel->hide();
+    if(quickPanel) quickPanel->windowHandle()->hide();
 
     auto popupWidget = m_pluginsItemInterface->itemPopupApplet(itemKey);
-    if(popupWidget) popupWidget->hide();
+    if(popupWidget) popupWidget->windowHandle()->hide();
 
     auto tipsWidget = m_pluginsItemInterface->itemTipsWidget(itemKey);
-    if(tipsWidget) tipsWidget->hide();
+    if(tipsWidget) tipsWidget->windowHandle()->hide();
 
 }
 


### PR DESCRIPTION
Call Window's hide instead of widget.
Remove surface from models.