### PR TITLE
fix: incorrect tooltip's position in non tray area

### DIFF
--- a/frame/qml/PanelToolTip.qml
+++ b/frame/qml/PanelToolTip.qml
@@ -30,7 +30,7 @@ Item {
     Binding {
         when: readyBinding
         target: toolTipWindow; property: "width"
-        value: toolTip.width
+        value: toolTip.width + toolTip.leftPadding + toolTip.rightPadding
     }
     Binding {
         when: readyBinding
@@ -40,7 +40,7 @@ Item {
     Binding {
         when: readyBinding
         target: toolTipWindow; property: "xOffset"
-        value: control.toolTipX
+        value: control.toolTipX - (toolTip.leftPadding + toolTip.rightPadding) / 2
     }
     Binding {
         when: readyBinding
@@ -53,9 +53,12 @@ Item {
         if (!toolTipWindow)
             return
 
-        readyBinding = true
+        readyBinding = Qt.binding(function () {
+            return toolTipWindow && toolTipWindow.currentItem === control
+        })
+
+        toolTipWindow.currentItem = control
         Qt.callLater(function () {
-            toolTip.open()
             toolTipWindow.show()
         })
     }
@@ -65,8 +68,7 @@ Item {
         if (!toolTipWindow)
             return
 
-        readyBinding = false
-        toolTip.close()
+        toolTipWindow.currentItem = null
         toolTipWindow.close()
     }
     function hide()
@@ -77,6 +79,7 @@ Item {
     ToolTip {
         id: toolTip
         padding: 0
+        visible: readyBinding
         // TODO it's a bug for qt, ToolTip's text color can't change with window's palette changed.
         palette.toolTipText: toolTipWindow ? toolTipWindow.palette.toolTipText : undefined
         anchors.centerIn: parent

--- a/panels/dock/clipboarditem/package/clipboarditem.qml
+++ b/panels/dock/clipboarditem/package/clipboarditem.qml
@@ -43,8 +43,12 @@ AppletItem {
         onHoveredChanged: {
             if (hovered) {
                 var point = Applet.rootObject.mapToItem(null, Applet.rootObject.width / 2, 0)
-                toolTip.toolTipX = point.x
-                toolTip.toolTipY = point.y
+                toolTip.toolTipX = Qt.binding(function () {
+                    return point.x - toolTip.width / 2
+                })
+                toolTip.toolTipY = Qt.binding(function () {
+                    return -toolTip.height - 10
+                })
                 toolTip.open()
             } else {
                 toolTip.close()

--- a/panels/dock/launcherItem/package/launcheritem.qml
+++ b/panels/dock/launcherItem/package/launcheritem.qml
@@ -72,8 +72,12 @@ AppletItem {
             interval: 50
             onTriggered: {
                 var point = Applet.rootObject.mapToItem(null, Applet.rootObject.width / 2, 0)
-                toolTip.toolTipX = point.x
-                toolTip.toolTipY = point.y
+                toolTip.toolTipX = Qt.binding(function () {
+                    return point.x - toolTip.width / 2
+                })
+                toolTip.toolTipY = Qt.binding(function () {
+                    return -toolTip.height - 10
+                })
                 toolTip.open()
             }
         }

--- a/panels/dock/multitaskview/package/multitaskview.qml
+++ b/panels/dock/multitaskview/package/multitaskview.qml
@@ -35,8 +35,12 @@ AppletItem {
             interval: 50
             onTriggered: {
                 var point = Applet.rootObject.mapToItem(null, Applet.rootObject.width / 2, 0)
-                toolTip.toolTipX = point.x
-                toolTip.toolTipY = point.y
+                toolTip.toolTipX = Qt.binding(function () {
+                    return point.x - toolTip.width / 2
+                })
+                toolTip.toolTipY = Qt.binding(function () {
+                    return -toolTip.height - 10
+                })
                 toolTip.open()
             }
         }

--- a/panels/dock/searchitem/package/searchitem.qml
+++ b/panels/dock/searchitem/package/searchitem.qml
@@ -55,8 +55,12 @@ AppletItem {
         onHoveredChanged: {
             if (hovered) {
                 var point = Applet.rootObject.mapToItem(null, Applet.rootObject.width / 2, 0)
-                toolTip.toolTipX = point.x
-                toolTip.toolTipY = point.y
+                toolTip.toolTipX = Qt.binding(function () {
+                    return point.x - toolTip.width / 2
+                })
+                toolTip.toolTipY = Qt.binding(function () {
+                    return -toolTip.height - 10
+                })
                 toolTip.open()
             } else {
                 toolTip.close()

--- a/panels/dock/taskmanager/package/AppItem.qml
+++ b/panels/dock/taskmanager/package/AppItem.qml
@@ -308,9 +308,12 @@ Item {
             interval: 50
             onTriggered: {
                 var point = root.mapToItem(null, root.width / 2, 0)
-                var AppletPoint = Applet.rootObject.mapToItem(null, root.width / 2, 0)
-                toolTip.toolTipX = point.x
-                toolTip.toolTipY = root.useColumnLayout ? point.y : AppletPoint.y
+                toolTip.toolTipX = Qt.binding(function () {
+                    return point.x - toolTip.width / 2
+                })
+                toolTip.toolTipY = Qt.binding(function () {
+                    return -toolTip.height - 10
+                })
                 toolTip.open()
             }
         }


### PR DESCRIPTION
adjust tooltip's position.
only show one tooltip.
adjust ToolTipPanel's width.