### PR TITLE
fix: missing quickpanel's tooltip

### DIFF
--- a/frame/qml/PanelToolTip.qml
+++ b/frame/qml/PanelToolTip.qml
@@ -19,13 +19,6 @@ Item {
     property bool readyBinding: false
     width: toolTip.width
     height: toolTip.height
-    onToolTipVisibleChanged: {
-        if (toolTipVisible) {
-            open()
-        } else {
-            close()
-        }
-    }
 
     Binding {
         when: readyBinding

--- a/panels/dock/tray/package/tray.qml
+++ b/panels/dock/tray/package/tray.qml
@@ -19,6 +19,7 @@ AppletItem {
 
     property bool useColumnLayout: Panel.position % 2
     property int dockOrder: 25
+    readonly property var filterTrayPlugins: ["dde-quick-panel","sound"]
     implicitWidth: useColumnLayout ? Panel.rootObject.dockSize : overflowId.implicitWidth
     implicitHeight: useColumnLayout ? overflowId.implicitHeight : Panel.rootObject.dockSize
 
@@ -141,6 +142,8 @@ AppletItem {
             let surfacesData = []
             for (let i = 0; i < DockCompositor.trayPluginSurfaces.count; i++) {
                 let item = DockCompositor.trayPluginSurfaces.get(i).shellSurface
+                if (filterTrayPlugins.indexOf(item.pluginId) >= 0)
+                    continue;
                 let surfaceId = `${item.pluginId}::${item.itemKey}`
                 surfacesData.push({"surfaceId": surfaceId, "delegateType": "legacy-tray-plugin"})
                 console.log(surfaceId, item, item.pluginId, "surfaceId")

--- a/panels/dock/tray/quickpanel/QuickPanel.qml
+++ b/panels/dock/tray/quickpanel/QuickPanel.qml
@@ -26,6 +26,7 @@ Item {
     PanelTrayItem {
         id: panelTrayItem
         shellSurface: quickpanelModel.trayItemSurface
+        trayQuickPanelItemSurface: quickpanelModel.trayQuickPanelItemSurface
         isOpened: popup.popupVisible
         onClicked: function () {
             console.log("show quickpanel")

--- a/panels/dock/tray/quickpanel/quickpanelproxymodel.cpp
+++ b/panels/dock/tray/quickpanel/quickpanelproxymodel.cpp
@@ -263,6 +263,7 @@ QAbstractListModel *QuickPanelProxyModel::surfaceModel() const
 void QuickPanelProxyModel::updateTrayItemSurface()
 {
     emit trayItemSurfaceChanged();
+    emit trayQuickPanelItemSurfaceChanged();
     if (rowCount() > 0)
         emit dataChanged(index(0, 0), index(rowCount() - 1, 0), {TraySurface});
 }
@@ -310,6 +311,11 @@ void QuickPanelProxyModel::setTrayPluginModel(QAbstractItemModel *newTrayPluginM
     m_trayPluginModel = newTrayPluginModel;
     watchingCountChanged();
     emit trayPluginModelChanged();
+}
+
+QObject *QuickPanelProxyModel::trayQuickPanelItemSurface() const
+{
+    return traySurfaceObject("dde-quick-panel");
 }
 
 }

--- a/panels/dock/tray/quickpanel/quickpanelproxymodel.h
+++ b/panels/dock/tray/quickpanel/quickpanelproxymodel.h
@@ -15,6 +15,7 @@ class QuickPanelProxyModel : public QSortFilterProxyModel, public QQmlParserStat
     Q_OBJECT
     Q_PROPERTY(QString trayItemPluginId READ trayItemPluginId WRITE setTrayItemPluginId NOTIFY trayItemPluginIdChanged FINAL)
     Q_PROPERTY(QObject* trayItemSurface READ trayItemSurface NOTIFY trayItemSurfaceChanged FINAL)
+    Q_PROPERTY(QObject* trayQuickPanelItemSurface READ trayQuickPanelItemSurface NOTIFY trayQuickPanelItemSurfaceChanged FINAL)
     Q_PROPERTY(QAbstractItemModel* trayPluginModel READ trayPluginModel WRITE setTrayPluginModel NOTIFY trayPluginModelChanged FINAL)
     QML_NAMED_ELEMENT(QuickPanelProxyModel)
     Q_INTERFACES(QQmlParserStatus)
@@ -34,6 +35,8 @@ public:
     QString trayItemPluginId() const;
     void setTrayItemPluginId(const QString &newTrayItemPluginId);
 
+    QObject *trayQuickPanelItemSurface() const;
+
     QAbstractItemModel *trayPluginModel() const;
     void setTrayPluginModel(QAbstractItemModel *newTrayPluginModel);
 
@@ -42,6 +45,7 @@ signals:
     void trayItemPluginIdChanged();
 
     void trayPluginModelChanged();
+    void trayQuickPanelItemSurfaceChanged();
 
 public:
     void classBegin() override;


### PR DESCRIPTION
using tooltip of quickpanel's plugin.
tooltip is reopened, tooltip's visible is binding with readBinding property, and it's assigned in open function.