### PR TITLE
refactor: tray area support custom sized items

### DIFF
--- a/panels/dock/tray/CMakeLists.txt
+++ b/panels/dock/tray/CMakeLists.txt
@@ -18,8 +18,12 @@ qt_add_qml_module(dock-tray
     SOURCES
         traysortordermodel.cpp
         traysortordermodel.h
-        ksortfilterproxymodel.h
+        trayitempositionregister.cpp
+        trayitempositionregister.h
+        trayitempositionmanager.cpp
+        trayitempositionmanager.h
         ksortfilterproxymodel.cpp
+        ksortfilterproxymodel.h
     OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/plugins/org/deepin/ds/dock/tray/
 )
 target_link_libraries(dock-tray PUBLIC

--- a/panels/dock/tray/package/ActionLegacyTrayPluginDelegate.qml
+++ b/panels/dock/tray/package/ActionLegacyTrayPluginDelegate.qml
@@ -18,10 +18,11 @@ Button {
 
     x: isHorizontal ? (model.visualIndex * (16 + 10)) : 0
     y: !isHorizontal ? (model.visualIndex * (16 + 10)) : 0
-    icon.width: 16
-    icon.height: 16
-    width: 16
-    height: 16
+
+    property size visualSize: Qt.size(pluginItem.implicitWidth, pluginItem.implicitHeight)
+
+    readonly property int itemWidth: isHorizontal ? 0 : DDT.TrayItemPositionManager.dockHeight
+    readonly property int itemHeight: isHorizontal ? DDT.TrayItemPositionManager.dockHeight : 0
 
     contentItem: Item {
         id: pluginItem
@@ -49,7 +50,7 @@ Button {
         }
 
         Component.onCompleted: {
-            pluginItem.plugin.updatePluginGeometry(Qt.rect(pluginItem.itemGlobalPoint.x, pluginItem.itemGlobalPoint.y, 16, 16))
+            pluginItem.plugin.updatePluginGeometry(Qt.rect(pluginItem.itemGlobalPoint.x, pluginItem.itemGlobalPoint.y, itemWidth, itemHeight))
         }
 
         Timer {
@@ -59,7 +60,7 @@ Button {
             repeat: false
             onTriggered: {
                 if (pluginItem.itemGlobalPoint.x > 0 && pluginItem.itemGlobalPoint.y > 0) {
-                    pluginItem.plugin.updatePluginGeometry(Qt.rect(pluginItem.itemGlobalPoint.x, pluginItem.itemGlobalPoint.y, 16, 16))
+                    pluginItem.plugin.updatePluginGeometry(Qt.rect(pluginItem.itemGlobalPoint.x, pluginItem.itemGlobalPoint.y, itemWidth, itemHeight))
                 }
             }
         }

--- a/panels/dock/tray/package/ActionToggleQuickSettingsDelegate.qml
+++ b/panels/dock/tray/package/ActionToggleQuickSettingsDelegate.qml
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import QtQuick
+import QtQuick.Controls
+
+Button {
+    property bool isHorizontal: false
+    icon.name: "dock-control-panel"
+    icon.width: 16
+    icon.height: 16
+    width: isHorizontal ? 26 : 16
+    height: isHorizontal ? 16 : 26
+    onClicked: {
+        // toggle quick settings
+    }
+}

--- a/panels/dock/tray/package/DummyDelegate.qml
+++ b/panels/dock/tray/package/DummyDelegate.qml
@@ -10,8 +10,11 @@ Button {
     icon.name: model.surfaceId
     icon.width: 16
     icon.height: 16
-    width: 16
-    height: 16
+
+    property size visualSize: Qt.size(width, height)
+
+    width: model.surfaceId === "trash::trash" ? 36 : 16
+    height: model.surfaceId === "trash::trash" ? 36 : 16
 
     Drag.active: dragHandler.active
     Drag.dragType: Drag.Automatic

--- a/panels/dock/tray/package/TrayContainer.qml
+++ b/panels/dock/tray/package/TrayContainer.qml
@@ -82,10 +82,13 @@ Item {
     readonly property int itemSize: 16
     readonly property int itemSpacing: 10
 
+    property int trayHeight: 50
+    property size containerSize: DDT.TrayItemPositionManager.visualSize
+
     implicitWidth: width
-    width: isHorizontal ? (DDT.TraySortOrderModel.visualItemCount * (itemSize + itemSpacing) - itemSpacing) : 16
+    width: containerSize.width
     implicitHeight: height
-    height: !isHorizontal ? (DDT.TraySortOrderModel.visualItemCount * (itemSize + itemSpacing) - itemSpacing) : 16
+    height: containerSize.height
 
     Behavior on width {
         NumberAnimation { duration: 200; easing.type: Easing.OutQuad }
@@ -125,11 +128,10 @@ Item {
         }
         onDropped: function (dropEvent) {
             let surfaceId = dropEvent.getDataAsString("text/x-dde-shell-tray-dnd-surfaceId")
-            let pos = root.isHorizontal ? drag.x : drag.y
-            let currentItemIndex = pos / (root.itemSize + root.itemSpacing)
-            let currentPosMapToItem = pos % (root.itemSize + root.itemSpacing)
-            let isBefore = currentPosMapToItem < root.itemSize / 2
-            console.log("dropped", currentItemIndex, currentPosMapToItem, isBefore)
+            let dropIdx = DDT.TrayItemPositionManager.itemIndexByPoint(Qt.point(drag.x, drag.y))
+            let currentItemIndex = dropIdx.index
+            let isBefore = dropIdx.isBefore
+            console.log("dropped", currentItemIndex, isBefore)
             DDT.TraySortOrderModel.dropToDockTray(surfaceId, Math.floor(currentItemIndex), isBefore);
             DDT.TraySortOrderModel.actionsAlwaysVisible = false
         }
@@ -140,5 +142,17 @@ Item {
         anchors.fill: parent
         model: root.model
         delegate: trayItemDelegateChooser
+    }
+
+    Component.onCompleted: {
+        DDT.TrayItemPositionManager.orientation = Qt.binding(function() {
+            return root.isHorizontal ? Qt.Horizontal : Qt.Vertical
+        });
+        DDT.TrayItemPositionManager.visualItemCount = Qt.binding(function() {
+            return root.model.visualItemCount
+        });
+        DDT.TrayItemPositionManager.dockHeight = Qt.binding(function() {
+            return root.trayHeight
+        });
     }
 }

--- a/panels/dock/tray/package/TrayItemDelegateChooser.qml
+++ b/panels/dock/tray/package/TrayItemDelegateChooser.qml
@@ -18,13 +18,19 @@ LQM.DelegateChooser {
     LQM.DelegateChoice {
         roleValue: "dummy"
         TrayItemPositioner {
-            contentItem: DummyDelegate {}
+            visualSize: dummyDelegate.visualSize
+            contentItem: DummyDelegate {
+                id: dummyDelegate
+            }
         }
     }
     LQM.DelegateChoice {
         roleValue: "legacy-tray-plugin"
         TrayItemPositioner {
-            contentItem: ActionLegacyTrayPluginDelegate {}
+            visualSize: traySurfaceDelegate.visualSize
+            contentItem: ActionLegacyTrayPluginDelegate {
+                id: traySurfaceDelegate
+            }
         }
     }
     LQM.DelegateChoice {
@@ -37,6 +43,16 @@ LQM.DelegateChooser {
         roleValue: "action-toggle-collapse"
         TrayItemPositioner {
             contentItem: ActionToggleCollapseDelegate {
+                isHorizontal: root.isHorizontal
+            }
+        }
+    }
+    LQM.DelegateChoice {
+        roleValue: "action-toggle-quick-settings"
+        TrayItemPositioner {
+            visualSize: Qt.size(quickSettingsDelegate.width, quickSettingsDelegate.height)
+            ActionToggleQuickSettingsDelegate {
+                id: quickSettingsDelegate
                 isHorizontal: root.isHorizontal
             }
         }

--- a/panels/dock/tray/package/TrayItemPositioner.qml
+++ b/panels/dock/tray/package/TrayItemPositioner.qml
@@ -4,6 +4,7 @@
 
 import QtQuick
 import QtQuick.Controls
+import org.deepin.ds.dock.tray 1.0 as DDT
 
 Control {
     id: root
@@ -11,12 +12,17 @@ Control {
         if (model.sectionType === "collapsable") return !collapsed
         return model.sectionType !== "stashed" && model.visibility
     }
+    property size visualSize: Qt.size(0, 0)
 
-    width: 16
-    height: 16
+    property point visualPosition: DDT.TrayItemPositionRegister.visualPosition
+    DDT.TrayItemPositionRegister.visualIndex: model.visualIndex
+    DDT.TrayItemPositionRegister.visualSize: Qt.size(width, height)
 
-    x: isHorizontal ? (model.visualIndex * (16 + 10)) : 0
-    y: !isHorizontal ? (model.visualIndex * (16 + 10)) : 0
+    width: visualSize.width !== 0 ? visualSize.width : 16
+    height: visualSize.height !== 0 ? visualSize.height : 16
+
+    x: visualPosition.x
+    y: visualPosition.y
     Behavior on x {
         NumberAnimation { duration: 200; easing.type: Easing.OutQuad }
     }

--- a/panels/dock/tray/package/tray.qml
+++ b/panels/dock/tray/package/tray.qml
@@ -68,7 +68,8 @@ AppletItem {
                     filterRowCallback: (sourceRow, sourceParent) => {
                         console.log(sourceRow, sourceParent)
                         let index = sourceModel.index(sourceRow, 0, sourceParent)
-                        return sourceModel.data(index, DDT.TraySortOrderModel.SectionTypeRole) === "stashed"
+                        return sourceModel.data(index, DDT.TraySortOrderModel.SectionTypeRole) === "stashed" &&
+                               sourceModel.data(index, DDT.TraySortOrderModel.VisibilityRole) === true
                     }
                 }
                 anchors.centerIn: parent
@@ -90,6 +91,7 @@ AppletItem {
             isHorizontal: !tray.useColumnLayout
             model: DDT.TraySortOrderModel
             collapsed: DDT.TraySortOrderModel.collapsed
+            trayHeight: isHorizontal ? tray.implicitHeight : tray.implicitWidth
             color: "transparent"
         }
 
@@ -145,7 +147,9 @@ AppletItem {
                 if (filterTrayPlugins.indexOf(item.pluginId) >= 0)
                     continue;
                 let surfaceId = `${item.pluginId}::${item.itemKey}`
-                surfacesData.push({"surfaceId": surfaceId, "delegateType": "legacy-tray-plugin"})
+                let forbiddenSections = item.pluginSizePolicy === Dock.Custom ? ["stashed", "collapsable", "pinned"] : ["fixed"]
+                let preferredSection = item.pluginSizePolicy === Dock.Custom ? "fixed" : "collapsable"
+                surfacesData.push({"surfaceId": surfaceId, "delegateType": "legacy-tray-plugin", "sectionType": preferredSection, "forbiddenSections": forbiddenSections})
                 console.log(surfaceId, item, item.pluginId, "surfaceId")
             }
             DDT.TraySortOrderModel.availableSurfaces = surfacesData

--- a/panels/dock/tray/trayitempositionmanager.cpp
+++ b/panels/dock/tray/trayitempositionmanager.cpp
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "trayitempositionmanager.h"
+
+namespace docktray {
+
+void TrayItemPositionManager::registerVisualItemSize(int index, const QSize &size)
+{
+    while (m_registeredItemsSize.count() < (index + 1)) {
+        m_registeredItemsSize.append(QSize(16, 16));
+    }
+    m_registeredItemsSize[index] = size;
+}
+
+QSize TrayItemPositionManager::visualItemSize(int index) const
+{
+    if (m_registeredItemsSize.count() <= index) return QSize(16, 16);
+    return m_registeredItemsSize.at(index);
+}
+
+QSize TrayItemPositionManager::visualSize(int index, bool includeLastSpacing) const
+{
+    if (m_orientation == Qt::Horizontal) {
+        int width = 0;
+        for (int i = 0; i <= index; i++) {
+            width += (visualItemSize(i).width() + 10);
+        }
+        return QSize((!includeLastSpacing && index > 0) ? (width - 10) : width, m_dockHeight);
+    } else {
+        int height = 0;
+        for (int i = 0; i <= index; i++) {
+            height += (visualItemSize(i).height() + 10);
+        }
+        return QSize(m_dockHeight, (!includeLastSpacing && index > 0) ? (height - 10) : height);
+    }
+}
+
+DropIndex TrayItemPositionManager::itemIndexByPoint(const QPoint point) const
+{
+    if (m_orientation == Qt::Horizontal) {
+        int pos = point.x();
+        int width = 0;
+        for (int i = 0; i < m_visualItemCount; i++) {
+            int visualWidth = visualItemSize(i).width();
+            if (pos < (width + visualWidth + 10)) {
+                pos -= width;
+                return DropIndex {
+                    .index = i,
+                    .isOnItem = pos <= visualWidth,
+                    .isBefore = pos < (visualWidth / 2)
+                };
+            }
+            width += (visualWidth + 10);
+        }
+        return DropIndex { .index = m_visualItemCount - 1 };
+    } else {
+        int pos = point.y();
+        int height = 0;
+        for (int i = 0; i <= m_visualItemCount; i++) {
+            int visualHeight = visualItemSize(i).height();
+            if (pos < (height + visualHeight + 10)) {
+                pos -= height;
+                return DropIndex {
+                    .index = i,
+                    .isOnItem = pos <= visualHeight,
+                    .isBefore = pos < (visualHeight / 2)
+                };
+            }
+            height += (visualHeight + 10);
+        }
+        return DropIndex { .index = m_visualItemCount - 1 };
+    }
+}
+
+Qt::Orientation TrayItemPositionManager::orientation() const
+{
+    return m_orientation;
+}
+
+int TrayItemPositionManager::dockHeight() const
+{
+    return m_dockHeight;
+}
+
+TrayItemPositionManager::TrayItemPositionManager(QObject *parent)
+    : QObject(parent)
+{
+    connect(this, &TrayItemPositionManager::visualItemCountChanged,
+            this, &TrayItemPositionManager::updateVisualSize);
+    connect(this, &TrayItemPositionManager::dockHeightChanged,
+            this, &TrayItemPositionManager::updateVisualSize);
+    connect(this, &TrayItemPositionManager::orientationChanged,
+            this, &TrayItemPositionManager::updateVisualSize);
+}
+
+void TrayItemPositionManager::updateVisualSize()
+{
+    if (m_dockHeight == 0) return;
+    QSize result(visualSize(m_visualItemCount - 1, false));
+    qDebug() << "updateVisualSize()" << m_dockHeight << result;
+    setProperty("visualSize", result);
+}
+
+}

--- a/panels/dock/tray/trayitempositionmanager.h
+++ b/panels/dock/tray/trayitempositionmanager.h
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <QPoint>
+#include <QQmlEngine>
+#include <QSize>
+
+namespace docktray {
+
+struct DropIndex {
+    Q_GADGET
+    Q_PROPERTY(int index MEMBER index)
+    Q_PROPERTY(bool isOnItem MEMBER isOnItem)
+    Q_PROPERTY(bool isBefore MEMBER isBefore)
+    QML_ELEMENT
+public:
+    int index;
+    bool isOnItem = true;
+    bool isBefore = false;
+};
+
+class TrayItemPositionManager : public QObject
+{
+    Q_OBJECT
+    // dock properties, to notify tray items its property has been changed
+    Q_PROPERTY(Qt::Orientation orientation MEMBER m_orientation NOTIFY orientationChanged)
+    Q_PROPERTY(int dockHeight MEMBER m_dockHeight NOTIFY dockHeightChanged)
+    // position manager properties, when tray items reports visualPositionChanged, re-calculate this
+    Q_PROPERTY(QSize visualSize MEMBER m_visualSize NOTIFY visualSizeChanged)
+    // position manager properties, use to know how to calculate the actual width of visualSize
+    Q_PROPERTY(int visualItemCount MEMBER m_visualItemCount NOTIFY visualItemCountChanged)
+    QML_ELEMENT
+    QML_SINGLETON
+public:
+    static TrayItemPositionManager &instance()
+    {
+        static TrayItemPositionManager _instance;
+        return _instance;
+    }
+
+    static TrayItemPositionManager *create(QQmlEngine *qmlEngine, QJSEngine *jsEngine)
+    {
+        Q_UNUSED(qmlEngine)
+        Q_UNUSED(jsEngine)
+        return &instance();
+    }
+
+    void registerVisualItemSize(int index, const QSize & size);
+    QSize visualItemSize(int index) const;
+    QSize visualSize(int index, bool includeLastSpacing = true) const;
+    Q_INVOKABLE DropIndex itemIndexByPoint(const QPoint point) const;
+    Qt::Orientation orientation() const;
+    int dockHeight() const;
+
+signals:
+    void orientationChanged(Qt::Orientation);
+    void dockHeightChanged(int);
+    void visualSizeChanged(QSize);
+    void visualItemCountChanged(int);
+
+private:
+    explicit TrayItemPositionManager(QObject *parent = nullptr);
+
+    void updateVisualSize();
+
+    Qt::Orientation m_orientation;
+    QSize m_visualSize;
+    int m_dockHeight;
+    int m_visualItemCount;
+    QList<QSize> m_registeredItemsSize;
+};
+
+}

--- a/panels/dock/tray/trayitempositionregister.cpp
+++ b/panels/dock/tray/trayitempositionregister.cpp
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "trayitempositionregister.h"
+
+#include "trayitempositionmanager.h"
+
+namespace docktray {
+
+TrayItemPositionRegisterAttachedType::TrayItemPositionRegisterAttachedType(QObject *parent)
+    : QObject(parent)
+{
+    // register / update visual position
+    connect(this, &TrayItemPositionRegisterAttachedType::visualIndexChanged,
+            this, [this](){
+                registerVisualSize();
+                emit visualPositionChanged();
+            });
+    connect(this, &TrayItemPositionRegisterAttachedType::visualSizeChanged,
+            this, [this](){
+                registerVisualSize();
+                emit visualPositionChanged();
+            });
+    // recalculate position
+    connect(&TrayItemPositionManager::instance(), &TrayItemPositionManager::orientationChanged,
+            this, &TrayItemPositionRegisterAttachedType::visualPositionChanged);
+    connect(&TrayItemPositionManager::instance(), &TrayItemPositionManager::dockHeightChanged,
+            this, &TrayItemPositionRegisterAttachedType::visualPositionChanged);
+    connect(&TrayItemPositionManager::instance(), &TrayItemPositionManager::visualItemCountChanged,
+            this, &TrayItemPositionRegisterAttachedType::visualPositionChanged);
+}
+
+QPoint TrayItemPositionRegisterAttachedType::visualPosition() const
+{
+    TrayItemPositionManager & pm = TrayItemPositionManager::instance();
+    if (pm.orientation() == Qt::Horizontal) {
+        int width = m_visualIndex == 0 ? 0 : pm.visualSize(m_visualIndex - 1).width();
+        return QPoint(width, (pm.dockHeight() - m_visualSize.height()) / 2);
+    } else {
+        int height = m_visualIndex == 0 ? 0 : pm.visualSize(m_visualIndex - 1).height();
+        return QPoint((pm.dockHeight() - m_visualSize.width()) / 2, height);
+    }
+}
+
+void TrayItemPositionRegisterAttachedType::registerVisualSize()
+{
+    if (m_visualIndex == -1 || m_visualSize.isEmpty()) return;
+    TrayItemPositionManager::instance().registerVisualItemSize(m_visualIndex, m_visualSize);
+}
+
+}

--- a/panels/dock/tray/trayitempositionregister.h
+++ b/panels/dock/tray/trayitempositionregister.h
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <QQmlEngine>
+#include <QSize>
+#include <QPoint>
+
+namespace docktray {
+
+class TrayItemPositionRegisterAttachedType : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(int visualIndex MEMBER m_visualIndex NOTIFY visualIndexChanged)
+    Q_PROPERTY(QSize visualSize MEMBER m_visualSize NOTIFY visualSizeChanged)
+    Q_PROPERTY(QPoint visualPosition READ visualPosition NOTIFY visualPositionChanged)
+    QML_ANONYMOUS
+public:
+    TrayItemPositionRegisterAttachedType(QObject *parent);
+
+    QPoint visualPosition() const;
+
+signals:
+    void visualIndexChanged(int);
+    void visualSizeChanged(QSize);
+    void visualPositionChanged();
+
+private:
+    void registerVisualSize();
+
+    int m_visualIndex = -1;
+    QSize m_visualSize;
+};
+
+// -------------------------------------------------------
+
+class TrayItemPositionRegister : public QObject
+{
+    Q_OBJECT
+    QML_ATTACHED(TrayItemPositionRegisterAttachedType)
+    QML_ELEMENT
+public:
+    static TrayItemPositionRegisterAttachedType *qmlAttachedProperties(QObject *object)
+    {
+        return new TrayItemPositionRegisterAttachedType(object);
+    }
+};
+
+}

--- a/panels/dock/tray/traysortordermodel.h
+++ b/panels/dock/tray/traysortordermodel.h
@@ -35,6 +35,8 @@ public:
         SectionTypeRole,
         VisualIndexRole,
         DelegateTypeRole,
+        // this tray item cannot be drop (or moved in any form) to the given sections
+        ForbiddenSectionsRole,
         ModelExtendedRole = 0x1000
     };
     Q_ENUM(Roles)
@@ -74,11 +76,12 @@ private:
 
     QStandardItem * findItemByVisualIndex(int visualIndex, VisualSections visualSection) const;
     QStringList * getSection(const QString & sectionType);
-    QString findSection(const QString & surfaceId, const QString & fallback);
+    QString findSection(const QString & surfaceId, const QString & fallback, const QStringList & forbiddenSections = {});
     void registerToSection(const QString & surfaceId, const QString & sectionType);
-    QStandardItem * createTrayItem(const QString & name, const QString & sectionType, const QString & delegateType);
+    QStandardItem * createTrayItem(const QString & name, const QString & sectionType,
+                                  const QString & delegateType, const QStringList & forbiddenSections = {});
     void updateVisualIndexes();
-    void registerSurfaceId(const QString & name, const QString & delegateType);
+    QString registerSurfaceId(const QVariantMap &surfaceData);
     void loadDataFromDConfig();
     void saveDataToDConfig();
 


### PR DESCRIPTION
此提交新增了用于支持非常规尺寸的托盘图标的相关工具类。包括一个管理布
局的类 TrayItemPositionManager 以及用于向此类注册托盘尺寸的另一个类
TrayItemPositionRegister。

------------------

QML 一侧做了初步对接，目前行为是托盘插件可以更新自己的尺寸了，而不再是之前的固定 16*16。另外，Custom 插件目前会被放到 fixed 区域且不允许跨区域拖动，这个行为和需求还有差异，会在后续的 PR 里调整。