### PR TITLE
fix: incorrect hovered state when using ShellSurface

### DIFF
--- a/panels/dock/tray/quickpanel/PanelTrayItem.qml
+++ b/panels/dock/tray/quickpanel/PanelTrayItem.qml
@@ -15,23 +15,21 @@ Control {
     required property var trayQuickPanelItemSurface
     property bool isOpened
     signal clicked()
+    property bool contentHovered
     padding: 5
+    ColorSelector.hovered: root.contentHovered || root.hovered || root.isOpened
+
     contentItem: RowLayout {
         spacing: 5
-        TapHandler {
-            id: clickedLayer
-            gesturePolicy: TapHandler.ReleaseWithinBounds
-            acceptedButtons: Qt.LeftButton
-            onTapped: {
-                root.clicked()
-            }
-        }
 
         Loader {
             active: root.shellSurface
             visible: active
             sourceComponent: TrayItemSurface {
                 shellSurface: root.shellSurface
+                onHoveredChanged: function () {
+                    root.contentHovered = hovered
+                }
             }
         }
         Loader {
@@ -40,6 +38,9 @@ Control {
             visible: active
             sourceComponent: TrayItemSurface {
                 shellSurface: root.trayQuickPanelItemSurface
+                onHoveredChanged: function () {
+                    root.contentHovered = hovered
+                }
             }
         }
         DciIcon {
@@ -50,7 +51,7 @@ Control {
         }
     }
     background: BoxPanel {
-        radius: 0
+        radius: 4
         color2: color1
         property Palette openedPalette: Palette {
             normal {
@@ -68,12 +69,26 @@ Control {
         color1: isOpened ? openedPalette : unopenedPalette
         insideBorderColor: null
         outsideBorderColor: null
+
+        TapHandler {
+            gesturePolicy: TapHandler.ReleaseWithinBounds
+            acceptedButtons: Qt.LeftButton
+            onTapped: {
+                root.clicked()
+            }
+        }
     }
 
     component TrayItemSurface: Item {
         implicitWidth: surfaceLayer.width
         implicitHeight: surfaceLayer.height
         property alias shellSurface: surfaceLayer.shellSurface
+        property alias hovered: hoverHandler.hovered
+
+        HoverHandler {
+            id: hoverHandler
+            parent: surfaceLayer
+        }
 
         ShellSurfaceItemProxy {
             id: surfaceLayer

--- a/panels/dock/tray/quickpanel/PluginItem.qml
+++ b/panels/dock/tray/quickpanel/PluginItem.qml
@@ -18,12 +18,19 @@ Control {
         surfaceLayer.updateSurfacePosition()
     }
 
+    // Control's hovered is false when hover ShellSurfaceItem.
+    ColorSelector.hovered: hoverHandler.hovered
     DragItem {
         id: dragLayer
         anchors.fill: parent
         dragItem: root
         dragTextData: `${root.pluginId}::${root.itemKey}`
         fallbackIconSize: traySurface ? traySurface.size : Qt.size(16, 16)
+    }
+
+    HoverHandler {
+        id: hoverHandler
+        parent: surfaceLayer
     }
 
     ShellSurfaceItemProxy {
@@ -49,7 +56,6 @@ Control {
         }
     }
 
-    // TODO Control's hovered is false when hover ShellSurfaceItem.
     background: BoxPanel {
         insideBorderColor: null
         outsideBorderColor: null


### PR DESCRIPTION
using HoverHandler to transmit ShellSurfaceItem's hover state. using ColorSelector.hovered to control Palette's state.