### PR TITLE
chore: watch DConfig valueChanged signal, check surface flag

### DIFF
--- a/panels/dock/tray/package/tray.qml
+++ b/panels/dock/tray/package/tray.qml
@@ -151,8 +151,28 @@ AppletItem {
                 if (filterTrayPlugins.indexOf(item.pluginId) >= 0)
                     continue;
                 let surfaceId = `${item.pluginId}::${item.itemKey}`
-                let forbiddenSections = item.pluginSizePolicy === Dock.Custom ? ["stashed", "collapsable", "pinned"] : ["fixed"]
-                let preferredSection = item.pluginSizePolicy === Dock.Custom ? "fixed" : "collapsable"
+                let forbiddenSections = ["fixed"]
+                let preferredSection = "collapsable"
+
+                if (item.pluginSizePolicy === Dock.Custom) {
+                    forbiddenSections = ["stashed", "fixed"]
+                    preferredSection = "pinned"
+                }
+
+                if (item.pluginFlags & 0x1000) { // force dock.
+                    forbiddenSections = ["stashed", "collapsable", "fixed"]
+                    preferredSection = "pinned"
+                }
+
+                surfacesData.push({"surfaceId": surfaceId, "delegateType": "legacy-tray-plugin", "sectionType": preferredSection, "forbiddenSections": forbiddenSections})
+            }
+            // actually only for datetime plugin currently
+            for (let i = 0; i < DockCompositor.fixedPluginSurfaces.count; i++) {
+                let item = DockCompositor.fixedPluginSurfaces.get(i).shellSurface
+                let surfaceId = `${item.pluginId}::${item.itemKey}`
+                let forbiddenSections = ["stashed", "collapsable", "pinned"]
+                let preferredSection = "fixed"
+
                 surfacesData.push({"surfaceId": surfaceId, "delegateType": "legacy-tray-plugin", "sectionType": preferredSection, "forbiddenSections": forbiddenSections})
             }
             DDT.TraySortOrderModel.availableSurfaces = surfacesData

--- a/panels/dock/tray/traysortordermodel.h
+++ b/panels/dock/tray/traysortordermodel.h
@@ -7,6 +7,11 @@
 #include <QStandardItemModel>
 #include <QQmlEngine>
 
+namespace Dtk {
+namespace Core {
+class DConfig;
+}}
+
 namespace docktray {
 
 class TraySortOrderModel : public QStandardItemModel
@@ -64,6 +69,7 @@ private:
     int m_visualItemCount = 0;
     bool m_collapsed = false;
     bool m_actionsAlwaysVisible = false;
+    std::unique_ptr<Dtk::Core::DConfig> m_dconfig;
     // this is for the plugins that currently available.
     QList<QVariantMap> m_availableSurfaces;
     // these are the sort order data source, it might contain items that are no longer existed.


### PR DESCRIPTION
现在 DConfig 的变动信号会被监听，hidden 组变化时会更新对应状态并刷新
界面显示顺序。

另外，也调整了拖拽区域的限制，并开始检查 ForceDock 属性。调整后为：

- Custom: 折叠和常显区域随意拖拽
- ForceDock：只能在常显区域拖拽

另外，目前时间插件被特定单独加载到了 fixed 区域。