### PR TITLE
fix: incorrect position for popup in multi screen

### DIFF
--- a/frame/qml/PanelPopupWindow.qml
+++ b/frame/qml/PanelPopupWindow.qml
@@ -14,8 +14,8 @@ Window {
     property real xOffset: 0
     property real yOffset: 0
     property Item currentItem
-    x: selectValue(transientParent ? transientParent.x + xOffset : 0, 0, Screen.width - root.width)
-    y: selectValue(transientParent ? transientParent.y + yOffset : 0, 0, Screen.height - root.height)
+    x: selectValue(transientParent ? transientParent.x + xOffset : 0, Screen.virtualX, Screen.virtualX + Screen.width - root.width)
+    y: selectValue(transientParent ? transientParent.y + yOffset : 0, Screen.virtualY, Screen.virtualY + Screen.height - root.height)
     function selectValue(value, min, max) {
         if (value < min)
             return min
@@ -23,6 +23,12 @@ Window {
             return max
 
         return value
+    }
+    // following transientParent's screen.
+    Binding {
+        when: root.transientParent
+        target: root; property: "screen"
+        value: root.transientParent ? root.transientParent.screen: undefined
     }
     // TODO: it's a qt bug which make Qt.Popup can not get input focus
     flags: Qt.Tool | Qt.BypassWindowManagerHint

--- a/panels/dock/dockpositioner.cpp
+++ b/panels/dock/dockpositioner.cpp
@@ -28,11 +28,16 @@ static DockPanel *isInDockPanel(QObject *object)
 DockPositioner::DockPositioner(DockPanel *panel, QObject *parent)
     : QObject(parent)
     , m_panel(panel)
+    , m_positionTimer(new QTimer(this))
 {
+    m_positionTimer->setSingleShot(true);
+    m_positionTimer->setInterval(0);
+    connect(m_positionTimer, &QTimer::timeout, this, &DockPositioner::updatePosition);
+
     Q_ASSERT(m_panel);
-    connect(m_panel, &DockPanel::positionChanged, this, &DockPositioner::updatePosition);
-    connect(m_panel, &DockPanel::geometryChanged, this, &DockPositioner::updatePosition);
-    connect(this, &DockPositioner::boundingChanged, this, &DockPositioner::updatePosition);
+    connect(m_panel, &DockPanel::positionChanged, this, &DockPositioner::update);
+    connect(m_panel, &DockPanel::geometryChanged, this, &DockPositioner::update);
+    connect(this, &DockPositioner::boundingChanged, this, &DockPositioner::update);
 }
 
 DockPositioner::~DockPositioner()
@@ -92,6 +97,11 @@ void DockPositioner::setY(int y)
     emit yChanged();
 }
 
+void DockPositioner::update()
+{
+    m_positionTimer->start();
+}
+
 void DockPositioner::updatePosition()
 {
     int xPosition = 0;
@@ -128,8 +138,8 @@ void DockPositioner::updatePosition()
 DockPanelPositioner::DockPanelPositioner(DockPanel *panel, QObject *parent)
     : DockPositioner(panel, parent)
 {
-    connect(this, &DockPanelPositioner::horizontalOffsetChanged, this, &DockPanelPositioner::updatePosition);
-    connect(this, &DockPanelPositioner::vertialOffsetChanged, this, &DockPanelPositioner::updatePosition);
+    connect(this, &DockPanelPositioner::horizontalOffsetChanged, this, &DockPanelPositioner::update);
+    connect(this, &DockPanelPositioner::vertialOffsetChanged, this, &DockPanelPositioner::update);
 }
 
 DockPanelPositioner::~DockPanelPositioner()

--- a/panels/dock/dockpositioner.h
+++ b/panels/dock/dockpositioner.h
@@ -34,6 +34,7 @@ public:
     void setX(int x);
     void setY(int y);
 public slots:
+    void update();
     virtual void updatePosition();
 
 signals:
@@ -46,6 +47,7 @@ protected:
     QRect m_bounding {};
     int m_x = 0;
     int m_y = 0;
+    QTimer *m_positionTimer = nullptr;
 };
 
 class DockPanelPositioner : public DockPositioner


### PR DESCRIPTION
following transientParent's screen for PanelPoupWindow.
delay to update position.
