### PR TITLE
fix: quickpanel's main page doesn't show when reopened

### DIFF
--- a/panels/dock/tray/quickpanel/QuickPanelPage.qml
+++ b/panels/dock/tray/quickpanel/QuickPanelPage.qml
@@ -56,6 +56,10 @@ Item {
             onRequestBack: function () {
                 panelView.pop()
             }
+            onVisibleChanged: function () {
+                if (!visible)
+                    panelView.pop()
+            }
             StackView.onActivating: function () {
                 panelView.contentHeight = Qt.binding(function() { return contentHeight})
             }


### PR DESCRIPTION
popup SubPluginPage.
