### PR TITLE
fix: tray item sometimes shows empty

### DIFF
--- a/panels/dock/tray/package/ActionLegacyTrayPluginDelegate.qml
+++ b/panels/dock/tray/package/ActionLegacyTrayPluginDelegate.qml
@@ -16,9 +16,6 @@ import org.deepin.ds.dock.tray 1.0 as DDT
 Button {
     property alias inputEventsEnabled: surfaceItem.inputEventsEnabled
 
-    x: isHorizontal ? (model.visualIndex * (16 + 10)) : 0
-    y: !isHorizontal ? (model.visualIndex * (16 + 10)) : 0
-
     property size visualSize: Qt.size(pluginItem.implicitWidth, pluginItem.implicitHeight)
 
     readonly property int itemWidth: isHorizontal ? 0 : DDT.TrayItemPositionManager.dockHeight


### PR DESCRIPTION
当 tray item 被拖到托盘区域内后，有可能只显示位置而不显示图标的问题
（因为图标被放到了错误的位置）。这可能是因为 tray 分支 rebase 合入
主干时此段代码被回退了。

Log: