### PR TITLE
fix: workaround dxcb/DWindow might cause DragEvent get rejected

### DIFF
--- a/panels/dock/tray/quickpanel/DragItem.qml
+++ b/panels/dock/tray/quickpanel/DragItem.qml
@@ -71,10 +71,11 @@ Item {
             return h
         }
 
-        DWindow.enabled: true
-        DWindow.enableBlurWindow: !isFallbackIcon
-        DWindow.shadowRadius: 0
-        DWindow.borderWidth: 0
+        // TODO: turn on this can cause DnD drag event get rejected, it's likely a dxcb bug.
+        // DWindow.enabled: true
+        // DWindow.enableBlurWindow: !isFallbackIcon
+        // DWindow.shadowRadius: 0
+        // DWindow.borderWidth: 0
         ColorSelector.family: Palette.CrystalColor
 
         height: getHeight()


### PR DESCRIPTION
当给 QuickDragWindow 设置任何 DWindow 属性时，都可能导致 DragEvent 在拖拽过程中被 reject。此处暂时绕过此问题。

Log: