### PR TITLE
fix: mouse dance when click ToggleCollapse

### DIFF
--- a/panels/dock/tray/package/ActionLegacyTrayPluginDelegate.qml
+++ b/panels/dock/tray/package/ActionLegacyTrayPluginDelegate.qml
@@ -75,6 +75,7 @@ Button {
             id: surfaceItem
             anchors.centerIn: parent
             shellSurface: pluginItem.plugin
+            inputEventsEnabled: !DDT.TraySortOrderModel.collapsed
         }
 
         Component.onCompleted: {


### PR DESCRIPTION
not send event to plugin when it's invisible

log: as title
issue: https://github.com/linuxdeepin/developer-center/issues/9608