### PR TITLE
fix: workaround incorrect layout at startup

### DIFF
--- a/panels/dock/tray/package/tray.qml
+++ b/panels/dock/tray/package/tray.qml
@@ -130,6 +130,9 @@ AppletItem {
         collapsed: DDT.TraySortOrderModel.collapsed
         trayHeight: isHorizontal ? tray.implicitHeight : tray.implicitWidth
         color: "transparent"
+        Component.onCompleted: {
+            DDT.TrayItemPositionManager.layoutHealthCheck(1500)
+        }
     }
 
     function isQuickPanelPopup(popupSurface)

--- a/panels/dock/tray/trayitempositionmanager.cpp
+++ b/panels/dock/tray/trayitempositionmanager.cpp
@@ -4,6 +4,9 @@
 
 #include "trayitempositionmanager.h"
 
+#include <QTimer>
+#include <QDebug>
+
 namespace docktray {
 
 void TrayItemPositionManager::registerVisualItemSize(int index, const QSize &size)
@@ -82,6 +85,26 @@ Qt::Orientation TrayItemPositionManager::orientation() const
 int TrayItemPositionManager::dockHeight() const
 {
     return m_dockHeight;
+}
+
+// This should only be used to check layout issue or workaround layout issues.
+// Do NOT rely on this to correct layout issue in a long run!
+void TrayItemPositionManager::layoutHealthCheck(int delayMs)
+{
+    QTimer::singleShot(delayMs, [this](){
+        if (m_dockHeight == 0) {
+            qWarning() << "dock height is not valid, aborting layout health check...";
+            return;
+        }
+        QSize result(visualSize(m_visualItemCount - 1, false));
+        if (m_visualSize != result) {
+            qWarning() << "layout size not matched, will trigger a force re-layout...";
+            emit orientationChanged(m_orientation);
+        } else {
+            qDebug() << "no problem founded while performing layout health check!";
+        }
+    });
+    qDebug() << "layout health check scheduled!";
 }
 
 TrayItemPositionManager::TrayItemPositionManager(QObject *parent)

--- a/panels/dock/tray/trayitempositionmanager.h
+++ b/panels/dock/tray/trayitempositionmanager.h
@@ -54,6 +54,7 @@ public:
     Q_INVOKABLE DropIndex itemIndexByPoint(const QPoint point) const;
     Qt::Orientation orientation() const;
     int dockHeight() const;
+    Q_INVOKABLE void layoutHealthCheck(int delayMs = 200);
 
 signals:
     void orientationChanged(Qt::Orientation);


### PR DESCRIPTION
首次初始化布局后有概率出现托盘大小/插件位置有偏差的问题，粗略排查和
注册与更新插件位置的时序存在关系。

新增一个辅助接口用来检查布局问题，并在存在问题时触发一次矫正。此新
接口后续可以保留，但程序逻辑中后续不应当依赖此检查来进行布局位置的矫
正行为，例如不应当在设计上依赖此接口来更新布局。

Log: