### PR TITLE
fix: popup's window display abnormal

### DIFF
--- a/frame/qml/PanelPopupWindow.qml
+++ b/frame/qml/PanelPopupWindow.qml
@@ -36,7 +36,6 @@ Window {
     D.DWindow.windowRadius: (D.DTK.platformTheme.windowRadius < 0 ? 4 : D.DTK.platformTheme.windowRadius)
                             * Screen.devicePixelRatio
     D.DWindow.enableBlurWindow: true
-    D.DWindow.shadowRadius: 8
     // TODO set shadowOffset maunally.
     D.DWindow.shadowOffset: Qt.point(0, 10)
     D.ColorSelector.family: D.Palette.CrystalColor

--- a/frame/qml/PanelToolTipWindow.qml
+++ b/frame/qml/PanelToolTipWindow.qml
@@ -11,4 +11,5 @@ PanelPopupWindow {
     id: root
 
     D.DWindow.windowRadius: 4 * Screen.devicePixelRatio
+    D.DWindow.shadowRadius: 8
 }


### PR DESCRIPTION
it maybe a bug for deepin-kwin, and shadowRadius is set to tooltip.

Issue: https://github.com/linuxdeepin/developer-center/issues/9616
