### PR TITLE
fix: tooltip can't show for stash container

### DIFF
--- a/panels/dock/tray/SurfacePopup.qml
+++ b/panels/dock/tray/SurfacePopup.qml
@@ -14,6 +14,7 @@ Item {
     property var surfaceAcceptor: function (surfaceId) {
         return true
     }
+    property int toolTipVOffset: 0
 
     PanelToolTipWindow {
         id: toolTipWindow
@@ -96,10 +97,10 @@ Item {
 
                 toolTip.shellSurface = popupSurface
                 toolTip.toolTipX = Qt.binding(function () {
-                    return toolTip.shellSurface.x
+                    return toolTip.shellSurface.x - toolTip.width / 2
                 })
                 toolTip.toolTipY = Qt.binding(function () {
-                    return toolTip.shellSurface.y
+                    return toolTip.shellSurface.y - toolTip.height - toolTipVOffset
                 })
                 toolTip.open()
             } else if (popupSurface.popupType === Dock.TrayPopupTypeMenu) {

--- a/panels/dock/tray/package/StashContainer.qml
+++ b/panels/dock/tray/package/StashContainer.qml
@@ -68,6 +68,7 @@ Item {
     DDT.SurfacePopup {
         objectName: "stash"
         surfaceAcceptor: isStashPopup
+        toolTipVOffset: root.itemPadding
     }
 
     // debug


### PR DESCRIPTION
ToolTip's window is show on the popup window, it causes the widget's
widow is received leave event from WM, so we move tooltip to top
of the popup window.

TODO: tooltip's position is not centered.
