### PR TITLE
feat: tray item drop on stash action to move to stash area

### DIFF
--- a/panels/dock/tray/traysortordermodel.cpp
+++ b/panels/dock/tray/traysortordermodel.cpp
@@ -117,8 +117,15 @@ bool TraySortOrderModel::dropToDockTray(const QString &draggedSurfaceId, int dro
 
     if (dropOnSurfaceId == QLatin1String("internal/action-show-stash")) {
         if (isBefore) {
-            // show stash action is always the first action, cannot drop before it
-            return false;
+            // show stash action is always the first action, drop before it consider as drop into stashed area
+            if (sourceSection != &m_stashedIds) {
+                sourceSection->removeOne(draggedSurfaceId);
+                m_stashedIds.append(draggedSurfaceId);
+                return true;
+            } else {
+                // already in the stashed tray
+                return false;
+            }
         }
         if (sourceSection == &m_collapsableIds) {
             // same-section move


### PR DESCRIPTION
拖放到 stash 向上箭头图标（的左半部分）上时，原本视为试图移动到此图
标前而拒绝移动行为，现将其视为希望将图标移到托盘 stash 区域内。

这可以在使 stash tray 未被显示出来的情况下也可以将图标移动到托盘区
域内。

Log: