### PR TITLE
fix: Time zone overlaps with show desktop item

### DIFF
--- a/panels/dock/tray/package/tray.qml
+++ b/panels/dock/tray/package/tray.qml
@@ -16,14 +16,15 @@ import org.deepin.ds.dock.tray 1.0 as DDT
 AppletItem {
     id: tray
 
+    readonly property int nextAppletSpacing: 6
     property bool useColumnLayout: Panel.position % 2
     property int dockOrder: 25
     readonly property string quickpanelTrayItemPluginId: "sound"
     readonly property var filterTrayPlugins: [quickpanelTrayItemPluginId]
     property bool quickPanelIsOpened: false
 
-    implicitWidth: useColumnLayout ? Panel.rootObject.dockSize : trayContainter.implicitWidth
-    implicitHeight: useColumnLayout ? trayContainter.implicitHeight : Panel.rootObject.dockSize
+    implicitWidth: useColumnLayout ? Panel.rootObject.dockSize : trayContainter.implicitWidth + nextAppletSpacing
+    implicitHeight: useColumnLayout ? trayContainter.implicitHeight + nextAppletSpacing: Panel.rootObject.dockSize
     Component.onCompleted: {
         Applet.trayPluginModel = Qt.binding(function () {
             return DockCompositor.trayPluginSurfaces


### PR DESCRIPTION
Add spacing between the tray applet and the next one

log: as title
issue: https://github.com/linuxdeepin/developer-center/issues/9768