### PR TITLE
fix(tray): The input method icon is displayed in the stashed area

### DIFF
--- a/panels/dock/dconfig/org.deepin.ds.dock.tray.json
+++ b/panels/dock/dconfig/org.deepin.ds.dock.tray.json
@@ -25,7 +25,7 @@
             "visibility": "private"
         },
         "collapsableSurfaceIds": {
-            "value": [],
+            "value": [ "application-tray:SNI:fcitx5" ],
             "serial": 0,
             "flags": [],
             "name": "Collapsable Area Surface IDs",


### PR DESCRIPTION
Issues: linuxdeepin/developer-center#9697