### PR TITLE
fix: plugin item cannot be clicked after the collapsible area is coll…

### DIFF
--- a/panels/dock/tray/package/ActionLegacyTrayPluginDelegate.qml
+++ b/panels/dock/tray/package/ActionLegacyTrayPluginDelegate.qml
@@ -73,7 +73,6 @@ Button {
             id: surfaceItem
             anchors.centerIn: parent
             shellSurface: pluginItem.plugin
-            inputEventsEnabled: !DDT.TraySortOrderModel.collapsed
         }
 
         Component.onCompleted: {

--- a/panels/dock/tray/package/TrayItemDelegateChooser.qml
+++ b/panels/dock/tray/package/TrayItemDelegateChooser.qml
@@ -31,6 +31,7 @@ LQM.DelegateChooser {
             visualSize: traySurfaceDelegate.visualSize
             contentItem: ActionLegacyTrayPluginDelegate {
                 id: traySurfaceDelegate
+                inputEventsEnabled: model.sectionType !== "collapsable" || !DDT.TraySortOrderModel.collapsed
             }
         }
     }


### PR DESCRIPTION
…apsed.

as title

Log: as title
issue: https://github.com/linuxdeepin/developer-center/issues/9723
Influence: plugin item can be clicked