### PR TITLE
fix: can't hide menu when click outside dock

### DIFF
--- a/frame/ddeshell_qml.qrc
+++ b/frame/ddeshell_qml.qrc
@@ -4,6 +4,8 @@
         <file>qml/PanelToolTip.qml</file>
         <file>qml/PanelPopupWindow.qml</file>
         <file>qml/PanelToolTipWindow.qml</file>
+        <file>qml/PanelMenu.qml</file>
+        <file>qml/PanelMenuWindow.qml</file>
         <file>qml/QuickDragWindow.qml</file>
     </qresource>
 </RCC>

--- a/frame/panel.h
+++ b/frame/panel.h
@@ -21,6 +21,7 @@ class DS_SHARE DPanel : public DContainment
     D_DECLARE_PRIVATE(DPanel)
     Q_PROPERTY(QQuickWindow *popupWindow READ popupWindow NOTIFY popupWindowChanged)
     Q_PROPERTY(QQuickWindow *toolTipWindow READ toolTipWindow NOTIFY toolTipWindowChanged)
+    Q_PROPERTY(QQuickWindow *menuWindow READ menuWindow NOTIFY menuWindowChanged)
 public:
     explicit DPanel(QObject *parent = nullptr);
     virtual ~DPanel() override;
@@ -29,6 +30,7 @@ public:
 
     QQuickWindow *popupWindow() const;
     QQuickWindow *toolTipWindow() const;
+    QQuickWindow *menuWindow() const;
 
     // 加载插件
     virtual bool load() override;
@@ -40,6 +42,7 @@ public:
 Q_SIGNALS:
     void popupWindowChanged();
     void toolTipWindowChanged();
+    void menuWindowChanged();
 };
 
 DS_END_NAMESPACE

--- a/frame/plugin/qmlplugin.cpp
+++ b/frame/plugin/qmlplugin.cpp
@@ -46,8 +46,10 @@ void QmlpluginPlugin::registerTypes(const char *uri)
 
     dsRegisterType(uri, 1, 0, "PanelPopup");
     dsRegisterType(uri, 1, 0, "PanelToolTip");
+    dsRegisterType(uri, 1, 0, "PanelMenu");
     dsRegisterType(uri, 1, 0, "PanelPopupWindow");
     dsRegisterType(uri, 1, 0, "PanelToolTipWindow");
+    dsRegisterType(uri, 1, 0, "PanelMenuWindow");
     dsRegisterType(uri, 1, 0, "QuickDragWindow");
 }
 

--- a/frame/private/panel_p.h
+++ b/frame/private/panel_p.h
@@ -27,10 +27,12 @@ public:
     void initDciSearchPaths();
     void ensurePopupWindow() const;
     void ensureToolTipWindow() const;
+    void ensureMenuWindow() const;
 
     DQmlEngine *m_engine = nullptr;
     QQuickWindow *m_popupWindow = nullptr;
     QQuickWindow *m_toolTipWindow = nullptr;
+    QQuickWindow *m_menuWindow = nullptr;
 
     D_DECLARE_PUBLIC(DPanel)
 };

--- a/frame/qml/PanelMenu.qml
+++ b/frame/qml/PanelMenu.qml
@@ -1,0 +1,107 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import org.deepin.ds 1.0
+
+Item {
+    id: control
+    visible: false
+    default property alias menuContent: menu.contentChildren
+    property alias menuVisible: menu.visible
+    property var menuWindow: Panel.menuWindow
+    property int menuX: 0
+    property int menuY: 0
+    property bool readyBinding: false
+
+    Binding {
+        when: readyBinding
+        target: menuWindow; property: "width"
+        value: menu.width
+    }
+    Binding {
+        when: readyBinding
+        target: menuWindow; property: "height"
+        value: menu.height
+    }
+    Binding {
+        when: readyBinding
+        delayed: true
+        target: menuWindow; property: "xOffset"
+        value: control.menuX
+    }
+    Binding {
+        when: readyBinding
+        delayed: true
+        target: menuWindow; property: "yOffset"
+        value: control.menuY
+    }
+
+    function open()
+    {
+        if (menu.visible) {
+            close()
+            return
+        }
+
+        if (!menuWindow)
+            return
+
+        readyBinding = Qt.binding(function () {
+            return menuWindow && menuWindow.currentItem === control
+        })
+
+        menuWindow.currentItem = control
+        Qt.callLater(function () {
+            DS.grabMouse(menuWindow)
+            menuWindow.show()
+        })
+    }
+
+    function close()
+    {
+        if (!menuWindow)
+            return
+
+        menuWindow.currentItem = null
+        menuWindow.close()
+    }
+
+    Connections {
+        target: menuWindow
+        function onActiveChanged()
+        {
+            if (!menuWindow)
+                return
+            // TODO why activeChanged is not emit.
+            if (menuWindow && !menuWindow.active) {
+                control.close()
+            }
+        }
+    }
+
+    Popup {
+        id: menu
+        padding: 0
+        visible: readyBinding
+        width: control.width
+        height: control.height
+        parent: menuWindow ? menuWindow.contentItem : undefined
+        onParentChanged: function() {
+            if (!menuWindow)
+                return
+            menuWindow.visibleChanged.connect(function() {
+                if (menuWindow && !menuWindow.visible)
+                    control.close()
+            })
+        }
+        // TODO dtk's blur causes blurred screen.
+        background: null
+    }
+    Component.onDestruction: {
+        if (menu.visible)
+            control.close()
+    }
+}

--- a/frame/qml/PanelMenuWindow.qml
+++ b/frame/qml/PanelMenuWindow.qml
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+import QtQuick 2.15
+import QtQuick.Window 2.15
+
+PanelPopupWindow {
+    id: root
+
+    flags: Qt.Tool | Qt.X11BypassWindowManagerHint | Qt.WindowStaysOnTopHint
+}

--- a/panels/dock/tray/SurfacePopup.qml
+++ b/panels/dock/tray/SurfacePopup.qml
@@ -19,8 +19,8 @@ Item {
     PanelToolTipWindow {
         id: toolTipWindow
         onVisibleChanged: function (arg) {
-            if (arg && popupWindow.visible)
-                popupWindow.close()
+            if (arg && menuWindow.visible)
+                menuWindow.close()
         }
     }
     PanelToolTip {
@@ -44,43 +44,43 @@ Item {
         sizeFollowsWindow: false
     }
 
-    PanelPopupWindow {
-        id: popupWindow
+    PanelMenuWindow {
+        id: menuWindow
         onVisibleChanged: function (arg) {
             if (arg && toolTipWindow.visible)
                 toolTipWindow.close()
         }
         onXChanged: {
-            if (!popup.shellSurface)
+            if (!menu.shellSurface)
                 return
-            popup.shellSurface.updatePluginGeometry(Qt.rect(x, y, 0, 0))
+            menu.shellSurface.updatePluginGeometry(Qt.rect(x, y, 0, 0))
         }
         onYChanged: {
-            if (!popup.shellSurface)
+            if (!menu.shellSurface)
                 return
-            popup.shellSurface.updatePluginGeometry(Qt.rect(x, y, 0, 0))
+            menu.shellSurface.updatePluginGeometry(Qt.rect(x, y, 0, 0))
         }
     }
-    PanelPopup {
-        id: popup
-        width: popupSurfaceLayer.width
-        height: popupSurfaceLayer.height
-        popupWindow: popupWindow
+    PanelMenu {
+        id: menu
+        width: menuSurfaceLayer.width
+        height: menuSurfaceLayer.height
+        menuWindow: menuWindow
 
-        property alias shellSurface: popupSurfaceLayer.shellSurface
+        property alias shellSurface: menuSurfaceLayer.shellSurface
         ShellSurfaceItemProxy {
-            id: popupSurfaceLayer
+            id: menuSurfaceLayer
             anchors.centerIn: parent
             autoClose: true
             onSurfaceDestroyed: function () {
-                popup.close()
+                menu.close()
             }
         }
     }
 
     WaylandOutput {
         compositor: DockCompositor.compositor
-        window: popup.popupWindow
+        window: menu.menuWindow
         sizeFollowsWindow: false
     }
 
@@ -106,14 +106,14 @@ Item {
             } else if (popupSurface.popupType === Dock.TrayPopupTypeMenu) {
                 console.log(root.objectName, ": menu created", popupSurface.popupType, popupSurface.pluginId)
 
-                popup.shellSurface = popupSurface
-                popup.popupX = Qt.binding(function () {
-                    return popup.shellSurface.x
+                menu.shellSurface = popupSurface
+                menu.menuX = Qt.binding(function () {
+                    return menu.shellSurface.x
                 })
-                popup.popupY = Qt.binding(function () {
-                    return popup.shellSurface.y
+                menu.menuY = Qt.binding(function () {
+                    return menu.shellSurface.y
                 })
-                popup.open()
+                menu.open()
             }
         }
     }

--- a/panels/dock/tray/package/tray.qml
+++ b/panels/dock/tray/package/tray.qml
@@ -52,13 +52,13 @@ AppletItem {
         }
     }
 
-    PanelPopup {
+    PanelMenu {
         id: popupMenu
         property alias shellSurface: popupMenuContent.shellSurface
         width: popupMenuContent.width
         height: popupMenuContent.height
-        popupX: DockPositioner.x
-        popupY: DockPositioner.y
+        menuX: DockPositioner.x
+        menuY: DockPositioner.y
 
         Item {
             anchors.fill: parent
@@ -255,6 +255,12 @@ AppletItem {
     WaylandOutput {
         compositor: DockCompositor.compositor
         window: Panel.toolTipWindow
+        sizeFollowsWindow: false
+    }
+
+    WaylandOutput {
+        compositor: DockCompositor.compositor
+        window: Panel.menuWindow
         sizeFollowsWindow: false
     }
 }


### PR DESCRIPTION
add PanelMenu to display menu instead of using PanelPopup,
and PanelMenu could grabMouse, and it's visible is effected by
click outside instead of lossing focus.

Issue: https://github.com/linuxdeepin/developer-center/issues/9760
