### PR TITLE
fix: tooltip is hide

### DIFF
--- a/frame/qml/PanelPopupWindow.qml
+++ b/frame/qml/PanelPopupWindow.qml
@@ -31,7 +31,7 @@ Window {
         value: root.transientParent ? root.transientParent.screen: undefined
     }
     // TODO: it's a qt bug which make Qt.Popup can not get input focus
-    flags: Qt.Tool | Qt.BypassWindowManagerHint
+    flags: Qt.Tool
     D.DWindow.enabled: true
     D.DWindow.windowRadius: (D.DTK.platformTheme.windowRadius < 0 ? 4 : D.DTK.platformTheme.windowRadius)
                             * Screen.devicePixelRatio


### PR DESCRIPTION
Remove BypassWindowManagerHint for tooltip's transientParent.
