### PR TITLE
fix: icons cannot be dragged to the stash

### DIFF
--- a/panels/dock/tray/package/StashContainer.qml
+++ b/panels/dock/tray/package/StashContainer.qml
@@ -44,9 +44,9 @@ Item {
     }
 
     implicitWidth: width
-    width: columnCount * (itemSize + itemPadding * 2 + itemSpacing) - itemSpacing
+    width: columnCount * (itemSize + itemPadding * 2 + itemSpacing) - itemSpacing + itemSpacing * 2
     implicitHeight: height
-    height: rowCount * (itemSize + itemPadding * 2 + itemSpacing) - itemSpacing
+    height: rowCount * (itemSize + itemPadding * 2 + itemSpacing) - itemSpacing + itemSpacing * 2
 
     Behavior on width {
         NumberAnimation { duration: 200; easing.type: Easing.OutQuad }
@@ -93,10 +93,15 @@ Item {
         }
     }
 
-    // Tray items
-    Repeater {
+    Item {
         anchors.fill: parent
-        model: root.model
-        delegate: stashedItemDelegateChooser
+        anchors.margins: itemSpacing
+
+        // Tray items
+        Repeater {
+            anchors.fill: parent
+            model: root.model
+            delegate: stashedItemDelegateChooser
+        }
     }
 }

--- a/panels/dock/tray/package/tray.qml
+++ b/panels/dock/tray/package/tray.qml
@@ -102,7 +102,6 @@ AppletItem {
 
         Control {
             id: stashedContainer
-            padding: 10
             contentItem: StashContainer {
                 id: stashContainer
                 color: "transparent"
@@ -122,7 +121,7 @@ AppletItem {
         target: DDT.TraySortOrderModel
         function onActionsAlwaysVisibleChanged(val) {
             if (val) {
-                if (!stashedPopup.visible) {
+                if (!stashedPopup.popupVisible) {
                     // TODO: position?
                     stashedPopup.open()
                 }


### PR DESCRIPTION
1. Expanding the acceptance of drop
2. Fix drag and drop after opening the tray, the tray will close automatically

Issue: https://github.com/linuxdeepin/developer-center/issues/9675