### PR TITLE
fix: add margins to extend mouse area for tray item

### DIFF
--- a/panels/dock/pluginmanagerextension.cpp
+++ b/panels/dock/pluginmanagerextension.cpp
@@ -24,6 +24,7 @@ PluginSurface::PluginSurface(PluginManager* manager, const QString& pluginId, co
     , m_flags(pluginFlags)
     , m_pluginType(pluginType)
     , m_sizePolicy(sizePolicy)
+    , m_margins(0)
 {
     init(resource.resource());
     setExtensionContainer(surface);
@@ -382,4 +383,19 @@ void PluginManager::sendEventMsg(const QString &msg)
             send_event_message(target->handle, msg);
         }
     }
+}
+
+int PluginSurface::margins() const
+{
+    return m_margins;
+}
+
+void PluginSurface::setMargins(int newMargins)
+{
+    if (m_margins == newMargins)
+        return;
+    m_margins = newMargins;
+    send_margin(m_margins);
+
+    emit marginsChanged();
 }

--- a/panels/dock/pluginmanagerextension_p.h
+++ b/panels/dock/pluginmanagerextension_p.h
@@ -73,10 +73,19 @@ class PluginSurface : public QWaylandShellSurfaceTemplate<PluginSurface>, public
     Q_PROPERTY(QSize size READ pluginSize NOTIFY sizeChanged)
     Q_PROPERTY(bool isItemActive WRITE setItemActive READ isItemActive NOTIFY itemActiveChanged)
     Q_PROPERTY(QString dccIcon READ dccIcon CONSTANT)
+    Q_PROPERTY(int margins READ margins WRITE setMargins NOTIFY marginsChanged FINAL)
 
 public:
-    PluginSurface(PluginManager* shell, const QString& pluginId, const QString& itemKey, const QString &displayName, int pluginFlags, int pluginType, int sizePolicy, QWaylandSurface *surface, const QWaylandResource &resource);
-    QWaylandQuickShellIntegration *createIntegration(QWaylandQuickShellSurfaceItem *item) override;
+    PluginSurface(const PluginSurface &) = delete;
+    PluginSurface(PluginSurface &&) = delete;
+    PluginSurface &operator=(const PluginSurface &) = delete;
+    PluginSurface &operator=(PluginSurface &&) = delete;
+    PluginSurface(PluginManager *shell, const QString &pluginId,
+                  const QString &itemKey, const QString &displayName,
+                  int pluginFlags, int pluginType, int sizePolicy,
+                  QWaylandSurface *surface, const QWaylandResource &resource);
+    QWaylandQuickShellIntegration *
+    createIntegration(QWaylandQuickShellSurfaceItem *item) override;
 
     QWaylandSurface *surface() const;
 
@@ -96,10 +105,15 @@ public:
     Q_INVOKABLE void updatePluginGeometry(const QRect &geometry);
     Q_INVOKABLE void setGlobalPos(const QPoint &pos);
 
+    int margins() const;
+    void setMargins(int newMargins);
+
 signals:
     void itemActiveChanged();
     void sizeChanged();
     void recvMouseEvent(QEvent::Type type);
+
+    void marginsChanged();
 
 protected:
     virtual void plugin_mouse_event(Resource *resource, int32_t type) override;
@@ -119,6 +133,7 @@ private:
     uint32_t m_sizePolicy;
 
     bool m_isItemActive = false;
+    int m_margins = 0;
 };
 
 class PluginPopup : public QWaylandShellSurfaceTemplate<PluginSurface>, public QtWaylandServer::plugin_popup

--- a/panels/dock/tray/package/ActionLegacyTrayPluginDelegate.qml
+++ b/panels/dock/tray/package/ActionLegacyTrayPluginDelegate.qml
@@ -15,18 +15,27 @@ import org.deepin.ds.dock 1.0
 import org.deepin.ds.dock.tray 1.0 as DDT
 
 Button {
+    id: root
     property alias inputEventsEnabled: surfaceItem.inputEventsEnabled
 
-    property size visualSize: isHorizontal ? Qt.size(pluginItem.implicitWidth + itemPadding * 2, itemHeight < pluginItem.implicitHeight + itemPadding * 2 ? itemHeight - itemPadding * 2 : pluginItem.implicitHeight + itemPadding * 2)
-                                           : Qt.size(itemWidth < pluginItem.implicitWidth + itemPadding * 2 ? itemWidth - itemPadding * 2 : pluginItem.implicitWidth + itemPadding * 2, pluginItem.implicitHeight + itemPadding * 2)
+    property size visualSize: isHorizontal ? Qt.size(pluginItem.implicitWidth, Math.min(itemHeight, pluginItem.implicitHeight))
+                                           : Qt.size(Math.min(itemWidth, pluginItem.implicitWidth), pluginItem.implicitHeight)
 
     readonly property int itemWidth: isHorizontal ? 0 : DDT.TrayItemPositionManager.dockHeight
     readonly property int itemHeight: isHorizontal ? DDT.TrayItemPositionManager.dockHeight : 0
 
-    topPadding: itemPadding
-    bottomPadding: itemPadding
-    leftPadding: itemPadding
-    rightPadding: itemPadding
+    required property bool itemVisible
+    topPadding: 0
+    bottomPadding: 0
+    leftPadding: 0
+    rightPadding: 0
+
+    function updatePluginMargins()
+    {
+        if (!itemVisible)
+            return
+        pluginItem.plugin.margins = itemPadding
+    }
 
     contentItem: Item {
         id: pluginItem
@@ -79,6 +88,7 @@ Button {
         Component.onCompleted: {
             if (!pluginItem.plugin)
                 return
+            updatePluginMargins()
             pluginItem.plugin.updatePluginGeometry(Qt.rect(pluginItem.itemGlobalPoint.x, pluginItem.itemGlobalPoint.y, 0, 0))
             pluginItem.plugin.setGlobalPos(pluginItem.itemGlobalPos)
         }
@@ -91,6 +101,7 @@ Button {
             onTriggered: {
                 if (!pluginItem.plugin)
                     return
+                updatePluginMargins()
                 if (pluginItem.itemGlobalPoint.x > 0 && pluginItem.itemGlobalPoint.y > 0) {
                     pluginItem.plugin.updatePluginGeometry(Qt.rect(pluginItem.itemGlobalPoint.x, pluginItem.itemGlobalPoint.y, 0, 0))
                 }
@@ -120,6 +131,7 @@ Button {
         onVisibleChanged: {
             if (!pluginItem.plugin)
                 return
+            updatePluginMargins()
             pluginItem.plugin.setGlobalPos(pluginItem.itemGlobalPos)
         }
     }
@@ -136,8 +148,8 @@ Button {
     }
 
     property Component overlayWindow: QuickDragWindow {
-        height: parent.visualSize.height
-        width: parent.visualSize.width
+        height: root.visualSize.height
+        width: root.visualSize.width
         Item {
             height: parent.height
             width: parent.width

--- a/panels/dock/tray/package/ActionToggleQuickSettingsDelegate.qml
+++ b/panels/dock/tray/package/ActionToggleQuickSettingsDelegate.qml
@@ -12,6 +12,7 @@ QuickPanel {
     property bool isHorizontal: false
     useColumnLayout: !isHorizontal
     trayItemPluginId: Applet.rootObject.quickpanelTrayItemPluginId
+    trayItemMargins: itemPadding
     Component.onCompleted: function () {
         Applet.rootObject.quickPanelIsOpened = Qt.binding(function () {
             return root.isOpened

--- a/panels/dock/tray/package/StashedItemDelegateChooser.qml
+++ b/panels/dock/tray/package/StashedItemDelegateChooser.qml
@@ -26,7 +26,11 @@ LQM.DelegateChooser {
     LQM.DelegateChoice {
         roleValue: "legacy-tray-plugin"
         StashedItemPositioner {
-            contentItem: ActionLegacyTrayPluginDelegate {}
+            id: stashItemPositioner
+            contentItem: ActionLegacyTrayPluginDelegate {
+                objectName: "stash"
+                itemVisible: stashItemPositioner.itemVisible
+            }
         }
     }
     LQM.DelegateChoice {

--- a/panels/dock/tray/package/TrayItemDelegateChooser.qml
+++ b/panels/dock/tray/package/TrayItemDelegateChooser.qml
@@ -28,10 +28,13 @@ LQM.DelegateChooser {
     LQM.DelegateChoice {
         roleValue: "legacy-tray-plugin"
         TrayItemPositioner {
+            id: traySurfacePositioner
             visualSize: traySurfaceDelegate.visualSize
             contentItem: ActionLegacyTrayPluginDelegate {
                 id: traySurfaceDelegate
+                objectName: "tray"
                 inputEventsEnabled: model.sectionType !== "collapsable" || !DDT.TraySortOrderModel.collapsed
+                itemVisible: traySurfacePositioner.itemVisible
             }
         }
     }

--- a/panels/dock/tray/quickpanel/PanelTrayItem.qml
+++ b/panels/dock/tray/quickpanel/PanelTrayItem.qml
@@ -16,10 +16,11 @@ Control {
     id: root
     property bool useColumnLayout: false
     required property var shellSurface
+    property int itemMargins
     property bool isOpened
     signal clicked()
     property bool contentHovered
-    padding: 5
+    padding: 0
     ColorSelector.hovered: root.contentHovered || root.hovered || root.isOpened
     property Palette textColor: DockPalette.iconTextPalette
     palette.windowText: ColorSelector.textColor
@@ -32,10 +33,12 @@ Control {
     }
 
     contentItem: Grid {
-        spacing: 5
         rows: root.useColumnLayout ? 2 : 1
+        spacing: 0
+        padding: 0
 
         Loader {
+            id: placeholder
             active: root.shellSurface
             visible: active
             sourceComponent: TrayItemSurface {
@@ -45,14 +48,17 @@ Control {
                 }
             }
         }
-        DciIcon {
+        Control {
             id: quickpanelPlaceholder
-            Layout.preferredWidth: 16
-            Layout.preferredHeight: 16
-            name: "dock-control-panel"
-            palette: DTK.makeIconPalette(root.palette)
-            theme: root.ColorSelector.controlTheme
-            sourceSize: Qt.size(quickpanelPlaceholder.width, quickpanelPlaceholder.width)
+            width: placeholder.width
+            height: placeholder.height
+            contentItem: DciIcon {
+                width: 16
+                height: 16
+                name: "dock-control-panel"
+                palette: DTK.makeIconPalette(root.palette)
+                theme: root.ColorSelector.controlTheme
+            }
             HoverHandler {
                 enabled: !root.isOpened
                 onHoveredChanged: function () {
@@ -87,14 +93,6 @@ Control {
         color1: isOpened ? openedPalette : unopenedPalette
         insideBorderColor: null
         outsideBorderColor: null
-
-        TapHandler {
-            gesturePolicy: TapHandler.ReleaseWithinBounds
-            acceptedButtons: Qt.LeftButton
-            onTapped: {
-                root.clicked()
-            }
-        }
     }
 
     component TrayItemSurface: Item {
@@ -125,13 +123,14 @@ Control {
             onItemGlobalPointChanged: {
                 if (!shellSurface || !(shellSurface.updatePluginGeometry))
                     return
+                shellSurface.margins = root.itemMargins
                 shellSurface.updatePluginGeometry(Qt.rect(itemGlobalPoint.x, itemGlobalPoint.y, 0, 0))
             }
         }
+    }
 
-        MouseArea {
-            anchors.fill: parent
-            onClicked: root.clicked()
-        }
+    MouseArea {
+        anchors.fill: parent
+        onClicked: root.clicked()
     }
 }

--- a/panels/dock/tray/quickpanel/QuickPanel.qml
+++ b/panels/dock/tray/quickpanel/QuickPanel.qml
@@ -24,12 +24,14 @@ Item {
     }
     property alias useColumnLayout: panelTrayItem.useColumnLayout
     property string trayItemPluginId: "sound"
+    property int trayItemMargins: 4
     readonly property bool isOpened: panelTrayItem.isOpened
 
     PanelTrayItem {
         id: panelTrayItem
         shellSurface: quickpanelModel.trayItemSurface
         isOpened: popup.popupVisible
+        itemMargins: root.trayItemMargins
         onClicked: function () {
             console.log("show quickpanel")
             popup.DockPanelPositioner.bounding = Qt.binding(function () {


### PR DESCRIPTION
Tray item has margins for content, and it's set to loader.
Tray's model has stash data, and it's filter by itemVisible.
it depends on dde-tray-loader.

Issue: https://github.com/linuxdeepin/developer-center/issues/9720
