### PR TITLE
fix: the item of datetime and showdesktop display overlap

### DIFF
--- a/panels/dock/tray/trayitempositionmanager.cpp
+++ b/panels/dock/tray/trayitempositionmanager.cpp
@@ -20,7 +20,13 @@ void TrayItemPositionManager::registerVisualItemSize(int index, const QSize &siz
     while (m_registeredItemsSize.count() < (index + 1)) {
         m_registeredItemsSize.append(itemVisualSize);
     }
+    QSize oldSize = m_registeredItemsSize[index];
     m_registeredItemsSize[index] = size;
+
+    // The registered itemsize may change, and the layout needs to be updated when it does.
+    if (oldSize != size) {
+        emit visualItemSizeChanged();
+    }
 }
 
 QSize TrayItemPositionManager::visualItemSize(int index) const
@@ -125,6 +131,8 @@ TrayItemPositionManager::TrayItemPositionManager(QObject *parent)
     connect(this, &TrayItemPositionManager::dockHeightChanged,
             this, &TrayItemPositionManager::updateVisualSize);
     connect(this, &TrayItemPositionManager::orientationChanged,
+            this, &TrayItemPositionManager::updateVisualSize);
+    connect(this, &TrayItemPositionManager::visualItemSizeChanged,
             this, &TrayItemPositionManager::updateVisualSize);
 }
 

--- a/panels/dock/tray/trayitempositionmanager.h
+++ b/panels/dock/tray/trayitempositionmanager.h
@@ -64,6 +64,7 @@ signals:
     void dockHeightChanged(int);
     void visualSizeChanged(QSize);
     void visualItemCountChanged(int);
+    void visualItemSizeChanged();
 
 private:
     explicit TrayItemPositionManager(QObject *parent = nullptr);

--- a/panels/dock/tray/trayitempositionregister.cpp
+++ b/panels/dock/tray/trayitempositionregister.cpp
@@ -29,6 +29,8 @@ TrayItemPositionRegisterAttachedType::TrayItemPositionRegisterAttachedType(QObje
             this, &TrayItemPositionRegisterAttachedType::visualPositionChanged);
     connect(&TrayItemPositionManager::instance(), &TrayItemPositionManager::visualItemCountChanged,
             this, &TrayItemPositionRegisterAttachedType::visualPositionChanged);
+    connect(&TrayItemPositionManager::instance(), &TrayItemPositionManager::visualItemSizeChanged,
+            this, &TrayItemPositionRegisterAttachedType::visualPositionChanged);
 }
 
 QPoint TrayItemPositionRegisterAttachedType::visualPosition() const


### PR DESCRIPTION
The registered itemsize may change, and the layout needs to be updated when it does.

Issue: https://github.com/linuxdeepin/developer-center/issues/9696