### PR TITLE
fix: When app tray popup is turned off, the position flashes

### DIFF
--- a/frame/qml/PanelPopup.qml
+++ b/frame/qml/PanelPopup.qml
@@ -65,8 +65,8 @@ Item {
         if (!popupWindow)
             return
 
-        popupWindow.currentItem = null
         popupWindow.close()
+        popupWindow.currentItem = null
     }
 
     Connections {


### PR DESCRIPTION
Close first and then set null

Log: