### PR TITLE
fix: the stash container turns into a small ball

### DIFF
--- a/panels/dock/tray/package/tray.qml
+++ b/panels/dock/tray/package/tray.qml
@@ -119,6 +119,11 @@ AppletItem {
                     }
                 }
                 anchors.centerIn: parent
+                onRowCountChanged: {
+                    if (stashContainer.rowCount === 0 || stashContainer.columnCount === 0) {
+                        stashedPopup.close()
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
When the last stashed item exits, the stash container should be closed

Issue: https://github.com/linuxdeepin/developer-center/issues/9830