### PR TITLE
fix: Sometimes unable to trigger automatic hiding

### DIFF
--- a/panels/dock/x11dockhelper.cpp
+++ b/panels/dock/x11dockhelper.cpp
@@ -147,7 +147,7 @@ DockTriggerArea::DockTriggerArea(DockPanel *panel, X11DockHelper *helper, QScree
     , m_holdingTimer(new QTimer(this))
 {
     m_triggerTimer->setSingleShot(true);
-    m_triggerTimer->setInterval(1000);
+    m_triggerTimer->setInterval(1500);
     m_holdingTimer->setSingleShot(true);
     m_holdingTimer->setInterval(200);
 


### PR DESCRIPTION
The wake-up time is too short, causing the animation to not be fully played and resulting in a status error

log: As title