### PR TITLE
fix: tray-loader crashed when reopen menu

### DIFF
--- a/frame/qml/PanelPopupWindow.qml
+++ b/frame/qml/PanelPopupWindow.qml
@@ -59,6 +59,8 @@ Window {
     color: "transparent"
     onVisibleChanged: function (arg) {
         if (!arg)
+            currentItem = null
+        if (!arg)
             DS.closeChildrenWindows(root)
     }
 

--- a/panels/dock/tray/ShellSurfaceItemProxy.qml
+++ b/panels/dock/tray/ShellSurfaceItemProxy.qml
@@ -17,7 +17,7 @@ ShellSurfaceItem {
     }
     function closeShellSurface()
     {
-        if (surface && shellSurface) {
+        if (surface && shellSurface && output.window && output.window.visible) {
             DockCompositor.closeShellSurface(shellSurface)
         }
     }


### PR DESCRIPTION
add a check when close surface.
Menu can grab mouse, and close window when ungrab mouse, it causes
tray-loader's surface is invalid.
