### PR TITLE
fix: tray item position registration

### DIFF
--- a/panels/dock/tray/package/TrayItemPositioner.qml
+++ b/panels/dock/tray/package/TrayItemPositioner.qml
@@ -15,8 +15,10 @@ Control {
     property size visualSize: Qt.size(0, 0)
 
     property point visualPosition: DDT.TrayItemPositionRegister.visualPosition
-    DDT.TrayItemPositionRegister.visualIndex: model.visualIndex
-    DDT.TrayItemPositionRegister.visualSize: Qt.size(width, height)
+    DDT.TrayItemPositionRegister.visualIndex: (model.sectionType !== "stashed") ? model.visualIndex : -1
+    DDT.TrayItemPositionRegister.visualSize: (model.sectionType !== "stashed") ? Qt.size(width, height) : Qt.size(0, 0)
+    DDT.TrayItemPositionRegister.surfaceId: model.surfaceId
+    DDT.TrayItemPositionRegister.sectionType: model.sectionType
 
     width: visualSize.width !== 0 ? visualSize.width : DDT.TrayItemPositionManager.itemVisualSize.width
     height: visualSize.height !== 0 ? visualSize.height : DDT.TrayItemPositionManager.itemVisualSize.height

--- a/panels/dock/tray/trayitempositionregister.h
+++ b/panels/dock/tray/trayitempositionregister.h
@@ -13,6 +13,8 @@ namespace docktray {
 class TrayItemPositionRegisterAttachedType : public QObject
 {
     Q_OBJECT
+    Q_PROPERTY(QString surfaceId MEMBER m_surfaceId NOTIFY surfaceIdChanged)
+    Q_PROPERTY(QString sectionType MEMBER m_sectionType NOTIFY sectionTypeChanged)
     Q_PROPERTY(int visualIndex MEMBER m_visualIndex NOTIFY visualIndexChanged)
     Q_PROPERTY(QSize visualSize MEMBER m_visualSize NOTIFY visualSizeChanged)
     Q_PROPERTY(QPoint visualPosition READ visualPosition NOTIFY visualPositionChanged)
@@ -23,6 +25,8 @@ public:
     QPoint visualPosition() const;
 
 signals:
+    void surfaceIdChanged(QString);
+    void sectionTypeChanged(QString);
     void visualIndexChanged(int);
     void visualSizeChanged(QSize);
     void visualPositionChanged();
@@ -30,6 +34,8 @@ signals:
 private:
     void registerVisualSize();
 
+    QString m_surfaceId;
+    QString m_sectionType;
     int m_visualIndex = -1;
     QSize m_visualSize;
 };


### PR DESCRIPTION
If sectiontype is stashed, the position is not registered

Log: tray item position registration