### PR TITLE
fix: popup can't reopen

### DIFF
--- a/frame/utility_x11.cpp
+++ b/frame/utility_x11.cpp
@@ -72,10 +72,10 @@ bool X11Utility::grabMouse(QWindow *target, bool grab)
         auto filter = new MouseGrabEventFilter(target);
         qApp->installEventFilter(filter);
         QObject::connect(filter, &MouseGrabEventFilter::outsideMousePressed, target, [filter, target] () {
-            qCDebug(dsLog) << "ungrab mouse for the window:" << target->winId();
-            target->close();
             qApp->removeEventFilter(filter);
+            qCDebug(dsLog) << "ungrab mouse for the window:" << target->winId();
             target->setMouseGrabEnabled(false);
+            target->close();
             filter->deleteLater();
         });
         return target->setMouseGrabEnabled(grab);
@@ -106,8 +106,8 @@ void MouseGrabEventFilter::mousePressEvent(QMouseEvent *e)
     const auto pos = e->globalPosition();
     if ((e->position().toPoint().isNull() && !pos.isNull()) ||
         !bounding.contains(pos.toPoint())) {
-        emit outsideMousePressed();
         instance()->deliverMouseEvent(e->button(), pos.x(), pos.y());
+        emit outsideMousePressed();
         return;
     }
 }

--- a/panels/dock/tray/ShellSurfaceItemProxy.qml
+++ b/panels/dock/tray/ShellSurfaceItemProxy.qml
@@ -17,7 +17,7 @@ ShellSurfaceItem {
     }
     function closeShellSurface()
     {
-        if (surface && shellSurface && output.window && output.window.visible) {
+        if (surface && shellSurface) {
             DockCompositor.closeShellSurface(shellSurface)
         }
     }


### PR DESCRIPTION
Failed to call close because of output's check.
The Menu is reopen when right click the plugin surface, so we
deliverMouseEvent before close window.

Issue: https://github.com/linuxdeepin/developer-center/issues/9959
