### PR TITLE
fix: The dock translation is incorrect 

### DIFF
--- a/panels/dock/package/main.qml
+++ b/panels/dock/package/main.qml
@@ -174,7 +174,13 @@ Window {
             MutuallyExclusiveMenu {
                 title: qsTr("Alignment")
                 EnumPropertyMenuItem {
-                    name: qsTr("Align Left")
+                    name: {
+                        if (Panel.position === Dock.Top || Panel.position === Dock.Bottom) {
+                            return qsTr("Align Left")
+                        } else {
+                            return qsTr("Align Top")
+                        }
+                    }
                     prop: "itemAlignment"
                     value: Dock.LeftAlignment
                 }

--- a/panels/dock/translations/org.deepin.ds.dock.ts
+++ b/panels/dock/translations/org.deepin.ds.dock.ts
@@ -4,82 +4,87 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="148"/>
+        <location filename="../package/main.qml" line="162"/>
         <source>Indicator Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="150"/>
+        <location filename="../package/main.qml" line="164"/>
         <source>Fashion Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="155"/>
+        <location filename="../package/main.qml" line="169"/>
         <source>Efficient Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="161"/>
+        <location filename="../package/main.qml" line="175"/>
         <source>Alignment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="189"/>
+        <location filename="../package/main.qml" line="206"/>
         <source>Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="174"/>
+        <location filename="../package/main.qml" line="194"/>
         <source>Position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="163"/>
+        <location filename="../package/main.qml" line="179"/>
         <source>Align Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="168"/>
+        <location filename="../package/main.qml" line="181"/>
+        <source>Align Top</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/main.qml" line="188"/>
         <source>Align Center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="178"/>
+        <location filename="../package/main.qml" line="196"/>
         <source>Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="183"/>
+        <location filename="../package/main.qml" line="201"/>
         <source>Bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="195"/>
+        <location filename="../package/main.qml" line="211"/>
         <source>Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="201"/>
+        <location filename="../package/main.qml" line="217"/>
         <source>Status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="203"/>
+        <location filename="../package/main.qml" line="219"/>
         <source>Keep Shown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="208"/>
+        <location filename="../package/main.qml" line="224"/>
         <source>Keep Hidden</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="214"/>
+        <location filename="../package/main.qml" line="230"/>
         <source>Smart Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="221"/>
+        <location filename="../package/main.qml" line="237"/>
         <source>Dock Settings</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/translations/org.deepin.ds.dock_az.ts
+++ b/panels/dock/translations/org.deepin.ds.dock_az.ts
@@ -4,82 +4,87 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="148"/>
+        <location filename="../package/main.qml" line="162"/>
         <source>Indicator Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="150"/>
+        <location filename="../package/main.qml" line="164"/>
         <source>Fashion Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="155"/>
+        <location filename="../package/main.qml" line="169"/>
         <source>Efficient Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="161"/>
+        <location filename="../package/main.qml" line="175"/>
         <source>Alignment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="189"/>
+        <location filename="../package/main.qml" line="206"/>
         <source>Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="174"/>
+        <location filename="../package/main.qml" line="194"/>
         <source>Position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="163"/>
+        <location filename="../package/main.qml" line="179"/>
         <source>Align Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="168"/>
+        <location filename="../package/main.qml" line="181"/>
+        <source>Align Top</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/main.qml" line="188"/>
         <source>Align Center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="178"/>
+        <location filename="../package/main.qml" line="196"/>
         <source>Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="183"/>
+        <location filename="../package/main.qml" line="201"/>
         <source>Bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="195"/>
+        <location filename="../package/main.qml" line="211"/>
         <source>Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="201"/>
+        <location filename="../package/main.qml" line="217"/>
         <source>Status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="203"/>
+        <location filename="../package/main.qml" line="219"/>
         <source>Keep Shown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="208"/>
+        <location filename="../package/main.qml" line="224"/>
         <source>Keep Hidden</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="214"/>
+        <location filename="../package/main.qml" line="230"/>
         <source>Smart Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="221"/>
+        <location filename="../package/main.qml" line="237"/>
         <source>Dock Settings</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/translations/org.deepin.ds.dock_bo.ts
+++ b/panels/dock/translations/org.deepin.ds.dock_bo.ts
@@ -4,82 +4,87 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="148"/>
+        <location filename="../package/main.qml" line="162"/>
         <source>Indicator Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="150"/>
+        <location filename="../package/main.qml" line="164"/>
         <source>Fashion Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="155"/>
+        <location filename="../package/main.qml" line="169"/>
         <source>Efficient Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="161"/>
+        <location filename="../package/main.qml" line="175"/>
         <source>Alignment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="189"/>
+        <location filename="../package/main.qml" line="206"/>
         <source>Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="174"/>
+        <location filename="../package/main.qml" line="194"/>
         <source>Position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="163"/>
+        <location filename="../package/main.qml" line="179"/>
         <source>Align Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="168"/>
+        <location filename="../package/main.qml" line="181"/>
+        <source>Align Top</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/main.qml" line="188"/>
         <source>Align Center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="178"/>
+        <location filename="../package/main.qml" line="196"/>
         <source>Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="183"/>
+        <location filename="../package/main.qml" line="201"/>
         <source>Bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="195"/>
+        <location filename="../package/main.qml" line="211"/>
         <source>Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="201"/>
+        <location filename="../package/main.qml" line="217"/>
         <source>Status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="203"/>
+        <location filename="../package/main.qml" line="219"/>
         <source>Keep Shown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="208"/>
+        <location filename="../package/main.qml" line="224"/>
         <source>Keep Hidden</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="214"/>
+        <location filename="../package/main.qml" line="230"/>
         <source>Smart Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="221"/>
+        <location filename="../package/main.qml" line="237"/>
         <source>Dock Settings</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/translations/org.deepin.ds.dock_ca.ts
+++ b/panels/dock/translations/org.deepin.ds.dock_ca.ts
@@ -4,82 +4,87 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="148"/>
+        <location filename="../package/main.qml" line="162"/>
         <source>Indicator Style</source>
         <translation>Estil de l&apos;indicador</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="150"/>
+        <location filename="../package/main.qml" line="164"/>
         <source>Fashion Mode</source>
         <translation>Mode de moda</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="155"/>
+        <location filename="../package/main.qml" line="169"/>
         <source>Efficient Mode</source>
         <translation>Mode eficient</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="161"/>
+        <location filename="../package/main.qml" line="175"/>
         <source>Alignment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="189"/>
+        <location filename="../package/main.qml" line="206"/>
         <source>Left</source>
         <translation>A l&apos;esquerra</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="174"/>
+        <location filename="../package/main.qml" line="194"/>
         <source>Position</source>
         <translation>Posició</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="163"/>
+        <location filename="../package/main.qml" line="179"/>
         <source>Align Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="168"/>
+        <location filename="../package/main.qml" line="181"/>
+        <source>Align Top</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/main.qml" line="188"/>
         <source>Align Center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="178"/>
+        <location filename="../package/main.qml" line="196"/>
         <source>Top</source>
         <translation>A dalt</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="183"/>
+        <location filename="../package/main.qml" line="201"/>
         <source>Bottom</source>
         <translation>A baix</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="195"/>
+        <location filename="../package/main.qml" line="211"/>
         <source>Right</source>
         <translation>A la dreta</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="201"/>
+        <location filename="../package/main.qml" line="217"/>
         <source>Status</source>
         <translation>Estat</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="203"/>
+        <location filename="../package/main.qml" line="219"/>
         <source>Keep Shown</source>
         <translation>Mantén-ho visible</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="208"/>
+        <location filename="../package/main.qml" line="224"/>
         <source>Keep Hidden</source>
         <translation>Mantén-ho amagat</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="214"/>
+        <location filename="../package/main.qml" line="230"/>
         <source>Smart Hide</source>
         <translation>Ocultació intel·ligent</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="221"/>
+        <location filename="../package/main.qml" line="237"/>
         <source>Dock Settings</source>
         <translation>Paràmetres de l&apos;acoblador</translation>
     </message>

--- a/panels/dock/translations/org.deepin.ds.dock_es.ts
+++ b/panels/dock/translations/org.deepin.ds.dock_es.ts
@@ -1,83 +1,90 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="es">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="es">
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="148"/>
+        <location filename="../package/main.qml" line="162"/>
         <source>Indicator Style</source>
         <translation>Estilo de indicador</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="150"/>
+        <location filename="../package/main.qml" line="164"/>
         <source>Fashion Mode</source>
         <translation>Modo elegante</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="155"/>
+        <location filename="../package/main.qml" line="169"/>
         <source>Efficient Mode</source>
         <translation>Modo eficiente</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="161"/>
+        <location filename="../package/main.qml" line="175"/>
         <source>Alignment</source>
         <translation>Alineación</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="189"/>
+        <location filename="../package/main.qml" line="206"/>
         <source>Left</source>
         <translation>Izquierda</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="174"/>
+        <location filename="../package/main.qml" line="194"/>
         <source>Position</source>
         <translation>Posición</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="163"/>
+        <location filename="../package/main.qml" line="179"/>
         <source>Align Left</source>
         <translation>Alinear a la izquierda</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="168"/>
+        <location filename="../package/main.qml" line="181"/>
+        <source>Align Top</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/main.qml" line="188"/>
         <source>Align Center</source>
         <translation>Alinear al centro</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="178"/>
+        <location filename="../package/main.qml" line="196"/>
         <source>Top</source>
         <translation>parte superior</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="183"/>
+        <location filename="../package/main.qml" line="201"/>
         <source>Bottom</source>
         <translation>parte inferior</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="195"/>
+        <location filename="../package/main.qml" line="211"/>
         <source>Right</source>
         <translation>Derecha</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="201"/>
+        <location filename="../package/main.qml" line="217"/>
         <source>Status</source>
         <translation>Estado</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="203"/>
+        <location filename="../package/main.qml" line="219"/>
         <source>Keep Shown</source>
         <translation>Mantener visible</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="208"/>
+        <location filename="../package/main.qml" line="224"/>
         <source>Keep Hidden</source>
         <translation>Mantener oculto</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="214"/>
+        <location filename="../package/main.qml" line="230"/>
         <source>Smart Hide</source>
         <translation>Ocultado inteligente</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="221"/>
+        <location filename="../package/main.qml" line="237"/>
         <source>Dock Settings</source>
         <translation>Ajustes del muelle</translation>
     </message>

--- a/panels/dock/translations/org.deepin.ds.dock_fi.ts
+++ b/panels/dock/translations/org.deepin.ds.dock_fi.ts
@@ -4,82 +4,87 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="148"/>
+        <location filename="../package/main.qml" line="162"/>
         <source>Indicator Style</source>
         <translation>Ilmaisimen tyyli</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="150"/>
+        <location filename="../package/main.qml" line="164"/>
         <source>Fashion Mode</source>
         <translation>Keskitetty</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="155"/>
+        <location filename="../package/main.qml" line="169"/>
         <source>Efficient Mode</source>
         <translation>Alavalikko</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="161"/>
+        <location filename="../package/main.qml" line="175"/>
         <source>Alignment</source>
         <translation>Tasaus</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="189"/>
+        <location filename="../package/main.qml" line="206"/>
         <source>Left</source>
         <translation>Vasen</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="174"/>
+        <location filename="../package/main.qml" line="194"/>
         <source>Position</source>
         <translation>Asema</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="163"/>
+        <location filename="../package/main.qml" line="179"/>
         <source>Align Left</source>
         <translation>Vasemmalle</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="168"/>
+        <location filename="../package/main.qml" line="181"/>
+        <source>Align Top</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/main.qml" line="188"/>
         <source>Align Center</source>
         <translation>Keskelle</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="178"/>
+        <location filename="../package/main.qml" line="196"/>
         <source>Top</source>
         <translation>Ylös</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="183"/>
+        <location filename="../package/main.qml" line="201"/>
         <source>Bottom</source>
         <translation>Alas</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="195"/>
+        <location filename="../package/main.qml" line="211"/>
         <source>Right</source>
         <translation>Oikea</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="201"/>
+        <location filename="../package/main.qml" line="217"/>
         <source>Status</source>
         <translation>Tila</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="203"/>
+        <location filename="../package/main.qml" line="219"/>
         <source>Keep Shown</source>
         <translation>Näytä aina</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="208"/>
+        <location filename="../package/main.qml" line="224"/>
         <source>Keep Hidden</source>
         <translation>Piilotta paneeli</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="214"/>
+        <location filename="../package/main.qml" line="230"/>
         <source>Smart Hide</source>
         <translation>Älykäs piilotus</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="221"/>
+        <location filename="../package/main.qml" line="237"/>
         <source>Dock Settings</source>
         <translation>Paneeli asetukset</translation>
     </message>

--- a/panels/dock/translations/org.deepin.ds.dock_fr.ts
+++ b/panels/dock/translations/org.deepin.ds.dock_fr.ts
@@ -4,82 +4,87 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="148"/>
+        <location filename="../package/main.qml" line="162"/>
         <source>Indicator Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="150"/>
+        <location filename="../package/main.qml" line="164"/>
         <source>Fashion Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="155"/>
+        <location filename="../package/main.qml" line="169"/>
         <source>Efficient Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="161"/>
+        <location filename="../package/main.qml" line="175"/>
         <source>Alignment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="189"/>
+        <location filename="../package/main.qml" line="206"/>
         <source>Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="174"/>
+        <location filename="../package/main.qml" line="194"/>
         <source>Position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="163"/>
+        <location filename="../package/main.qml" line="179"/>
         <source>Align Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="168"/>
+        <location filename="../package/main.qml" line="181"/>
+        <source>Align Top</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/main.qml" line="188"/>
         <source>Align Center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="178"/>
+        <location filename="../package/main.qml" line="196"/>
         <source>Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="183"/>
+        <location filename="../package/main.qml" line="201"/>
         <source>Bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="195"/>
+        <location filename="../package/main.qml" line="211"/>
         <source>Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="201"/>
+        <location filename="../package/main.qml" line="217"/>
         <source>Status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="203"/>
+        <location filename="../package/main.qml" line="219"/>
         <source>Keep Shown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="208"/>
+        <location filename="../package/main.qml" line="224"/>
         <source>Keep Hidden</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="214"/>
+        <location filename="../package/main.qml" line="230"/>
         <source>Smart Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="221"/>
+        <location filename="../package/main.qml" line="237"/>
         <source>Dock Settings</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/translations/org.deepin.ds.dock_hu.ts
+++ b/panels/dock/translations/org.deepin.ds.dock_hu.ts
@@ -4,82 +4,87 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="148"/>
+        <location filename="../package/main.qml" line="162"/>
         <source>Indicator Style</source>
         <translation>Jelölő stíéusa</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="150"/>
+        <location filename="../package/main.qml" line="164"/>
         <source>Fashion Mode</source>
         <translation>Stílusos mód</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="155"/>
+        <location filename="../package/main.qml" line="169"/>
         <source>Efficient Mode</source>
         <translation>Hatékony mód</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="161"/>
+        <location filename="../package/main.qml" line="175"/>
         <source>Alignment</source>
         <translation>Igazítás</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="189"/>
+        <location filename="../package/main.qml" line="206"/>
         <source>Left</source>
         <translation>Bal</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="174"/>
+        <location filename="../package/main.qml" line="194"/>
         <source>Position</source>
         <translation>Pozíció</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="163"/>
+        <location filename="../package/main.qml" line="179"/>
         <source>Align Left</source>
         <translation>Igazítás Balra</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="168"/>
+        <location filename="../package/main.qml" line="181"/>
+        <source>Align Top</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/main.qml" line="188"/>
         <source>Align Center</source>
         <translation>Igazítás Középre</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="178"/>
+        <location filename="../package/main.qml" line="196"/>
         <source>Top</source>
         <translation>Fent</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="183"/>
+        <location filename="../package/main.qml" line="201"/>
         <source>Bottom</source>
         <translation>Lent</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="195"/>
+        <location filename="../package/main.qml" line="211"/>
         <source>Right</source>
         <translation>Jobb</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="201"/>
+        <location filename="../package/main.qml" line="217"/>
         <source>Status</source>
         <translation>Állapot</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="203"/>
+        <location filename="../package/main.qml" line="219"/>
         <source>Keep Shown</source>
         <translation>Folyamatosan látható</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="208"/>
+        <location filename="../package/main.qml" line="224"/>
         <source>Keep Hidden</source>
         <translation>Maradjon rejtve</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="214"/>
+        <location filename="../package/main.qml" line="230"/>
         <source>Smart Hide</source>
         <translation>Intelligens elrejtés</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="221"/>
+        <location filename="../package/main.qml" line="237"/>
         <source>Dock Settings</source>
         <translation>Dokkoló beállításai</translation>
     </message>

--- a/panels/dock/translations/org.deepin.ds.dock_it.ts
+++ b/panels/dock/translations/org.deepin.ds.dock_it.ts
@@ -4,82 +4,87 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="148"/>
+        <location filename="../package/main.qml" line="162"/>
         <source>Indicator Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="150"/>
+        <location filename="../package/main.qml" line="164"/>
         <source>Fashion Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="155"/>
+        <location filename="../package/main.qml" line="169"/>
         <source>Efficient Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="161"/>
+        <location filename="../package/main.qml" line="175"/>
         <source>Alignment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="189"/>
+        <location filename="../package/main.qml" line="206"/>
         <source>Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="174"/>
+        <location filename="../package/main.qml" line="194"/>
         <source>Position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="163"/>
+        <location filename="../package/main.qml" line="179"/>
         <source>Align Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="168"/>
+        <location filename="../package/main.qml" line="181"/>
+        <source>Align Top</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/main.qml" line="188"/>
         <source>Align Center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="178"/>
+        <location filename="../package/main.qml" line="196"/>
         <source>Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="183"/>
+        <location filename="../package/main.qml" line="201"/>
         <source>Bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="195"/>
+        <location filename="../package/main.qml" line="211"/>
         <source>Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="201"/>
+        <location filename="../package/main.qml" line="217"/>
         <source>Status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="203"/>
+        <location filename="../package/main.qml" line="219"/>
         <source>Keep Shown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="208"/>
+        <location filename="../package/main.qml" line="224"/>
         <source>Keep Hidden</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="214"/>
+        <location filename="../package/main.qml" line="230"/>
         <source>Smart Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="221"/>
+        <location filename="../package/main.qml" line="237"/>
         <source>Dock Settings</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/translations/org.deepin.ds.dock_ja.ts
+++ b/panels/dock/translations/org.deepin.ds.dock_ja.ts
@@ -4,82 +4,87 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="148"/>
+        <location filename="../package/main.qml" line="162"/>
         <source>Indicator Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="150"/>
+        <location filename="../package/main.qml" line="164"/>
         <source>Fashion Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="155"/>
+        <location filename="../package/main.qml" line="169"/>
         <source>Efficient Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="161"/>
+        <location filename="../package/main.qml" line="175"/>
         <source>Alignment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="189"/>
+        <location filename="../package/main.qml" line="206"/>
         <source>Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="174"/>
+        <location filename="../package/main.qml" line="194"/>
         <source>Position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="163"/>
+        <location filename="../package/main.qml" line="179"/>
         <source>Align Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="168"/>
+        <location filename="../package/main.qml" line="181"/>
+        <source>Align Top</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/main.qml" line="188"/>
         <source>Align Center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="178"/>
+        <location filename="../package/main.qml" line="196"/>
         <source>Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="183"/>
+        <location filename="../package/main.qml" line="201"/>
         <source>Bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="195"/>
+        <location filename="../package/main.qml" line="211"/>
         <source>Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="201"/>
+        <location filename="../package/main.qml" line="217"/>
         <source>Status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="203"/>
+        <location filename="../package/main.qml" line="219"/>
         <source>Keep Shown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="208"/>
+        <location filename="../package/main.qml" line="224"/>
         <source>Keep Hidden</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="214"/>
+        <location filename="../package/main.qml" line="230"/>
         <source>Smart Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="221"/>
+        <location filename="../package/main.qml" line="237"/>
         <source>Dock Settings</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/translations/org.deepin.ds.dock_ko.ts
+++ b/panels/dock/translations/org.deepin.ds.dock_ko.ts
@@ -4,82 +4,87 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="148"/>
+        <location filename="../package/main.qml" line="162"/>
         <source>Indicator Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="150"/>
+        <location filename="../package/main.qml" line="164"/>
         <source>Fashion Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="155"/>
+        <location filename="../package/main.qml" line="169"/>
         <source>Efficient Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="161"/>
+        <location filename="../package/main.qml" line="175"/>
         <source>Alignment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="189"/>
+        <location filename="../package/main.qml" line="206"/>
         <source>Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="174"/>
+        <location filename="../package/main.qml" line="194"/>
         <source>Position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="163"/>
+        <location filename="../package/main.qml" line="179"/>
         <source>Align Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="168"/>
+        <location filename="../package/main.qml" line="181"/>
+        <source>Align Top</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/main.qml" line="188"/>
         <source>Align Center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="178"/>
+        <location filename="../package/main.qml" line="196"/>
         <source>Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="183"/>
+        <location filename="../package/main.qml" line="201"/>
         <source>Bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="195"/>
+        <location filename="../package/main.qml" line="211"/>
         <source>Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="201"/>
+        <location filename="../package/main.qml" line="217"/>
         <source>Status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="203"/>
+        <location filename="../package/main.qml" line="219"/>
         <source>Keep Shown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="208"/>
+        <location filename="../package/main.qml" line="224"/>
         <source>Keep Hidden</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="214"/>
+        <location filename="../package/main.qml" line="230"/>
         <source>Smart Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="221"/>
+        <location filename="../package/main.qml" line="237"/>
         <source>Dock Settings</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/translations/org.deepin.ds.dock_nb_NO.ts
+++ b/panels/dock/translations/org.deepin.ds.dock_nb_NO.ts
@@ -4,82 +4,87 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="148"/>
+        <location filename="../package/main.qml" line="162"/>
         <source>Indicator Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="150"/>
+        <location filename="../package/main.qml" line="164"/>
         <source>Fashion Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="155"/>
+        <location filename="../package/main.qml" line="169"/>
         <source>Efficient Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="161"/>
+        <location filename="../package/main.qml" line="175"/>
         <source>Alignment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="189"/>
+        <location filename="../package/main.qml" line="206"/>
         <source>Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="174"/>
+        <location filename="../package/main.qml" line="194"/>
         <source>Position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="163"/>
+        <location filename="../package/main.qml" line="179"/>
         <source>Align Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="168"/>
+        <location filename="../package/main.qml" line="181"/>
+        <source>Align Top</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/main.qml" line="188"/>
         <source>Align Center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="178"/>
+        <location filename="../package/main.qml" line="196"/>
         <source>Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="183"/>
+        <location filename="../package/main.qml" line="201"/>
         <source>Bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="195"/>
+        <location filename="../package/main.qml" line="211"/>
         <source>Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="201"/>
+        <location filename="../package/main.qml" line="217"/>
         <source>Status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="203"/>
+        <location filename="../package/main.qml" line="219"/>
         <source>Keep Shown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="208"/>
+        <location filename="../package/main.qml" line="224"/>
         <source>Keep Hidden</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="214"/>
+        <location filename="../package/main.qml" line="230"/>
         <source>Smart Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="221"/>
+        <location filename="../package/main.qml" line="237"/>
         <source>Dock Settings</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/translations/org.deepin.ds.dock_pl.ts
+++ b/panels/dock/translations/org.deepin.ds.dock_pl.ts
@@ -4,82 +4,87 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="148"/>
+        <location filename="../package/main.qml" line="162"/>
         <source>Indicator Style</source>
         <translation>Styl wskaźnika</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="150"/>
+        <location filename="../package/main.qml" line="164"/>
         <source>Fashion Mode</source>
         <translation>Tryb modny</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="155"/>
+        <location filename="../package/main.qml" line="169"/>
         <source>Efficient Mode</source>
         <translation>Tryb wydajny</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="161"/>
+        <location filename="../package/main.qml" line="175"/>
         <source>Alignment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="189"/>
+        <location filename="../package/main.qml" line="206"/>
         <source>Left</source>
         <translation>Lewo</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="174"/>
+        <location filename="../package/main.qml" line="194"/>
         <source>Position</source>
         <translation>Pozycja</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="163"/>
+        <location filename="../package/main.qml" line="179"/>
         <source>Align Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="168"/>
+        <location filename="../package/main.qml" line="181"/>
+        <source>Align Top</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/main.qml" line="188"/>
         <source>Align Center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="178"/>
+        <location filename="../package/main.qml" line="196"/>
         <source>Top</source>
         <translation>Góra</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="183"/>
+        <location filename="../package/main.qml" line="201"/>
         <source>Bottom</source>
         <translation>Dół</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="195"/>
+        <location filename="../package/main.qml" line="211"/>
         <source>Right</source>
         <translation>Prawo</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="201"/>
+        <location filename="../package/main.qml" line="217"/>
         <source>Status</source>
         <translation>Status</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="203"/>
+        <location filename="../package/main.qml" line="219"/>
         <source>Keep Shown</source>
         <translation>Zawsze wyświetlaj</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="208"/>
+        <location filename="../package/main.qml" line="224"/>
         <source>Keep Hidden</source>
         <translation>Zawsze ukrywaj</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="214"/>
+        <location filename="../package/main.qml" line="230"/>
         <source>Smart Hide</source>
         <translation>Inteligentne ukrywanie</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="221"/>
+        <location filename="../package/main.qml" line="237"/>
         <source>Dock Settings</source>
         <translation>Ustawienia doku</translation>
     </message>

--- a/panels/dock/translations/org.deepin.ds.dock_pt_BR.ts
+++ b/panels/dock/translations/org.deepin.ds.dock_pt_BR.ts
@@ -1,83 +1,90 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pt_BR">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pt_BR">
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="148"/>
+        <location filename="../package/main.qml" line="162"/>
         <source>Indicator Style</source>
         <translation>Estilo do indicador</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="150"/>
+        <location filename="../package/main.qml" line="164"/>
         <source>Fashion Mode</source>
         <translation>Fashion</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="155"/>
+        <location filename="../package/main.qml" line="169"/>
         <source>Efficient Mode</source>
         <translation>Eficiente</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="161"/>
+        <location filename="../package/main.qml" line="175"/>
         <source>Alignment</source>
         <translation>Alinhamento</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="189"/>
+        <location filename="../package/main.qml" line="206"/>
         <source>Left</source>
         <translation>Esquerda</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="174"/>
+        <location filename="../package/main.qml" line="194"/>
         <source>Position</source>
         <translation>Posição</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="163"/>
+        <location filename="../package/main.qml" line="179"/>
         <source>Align Left</source>
         <translation>Esquerda</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="168"/>
+        <location filename="../package/main.qml" line="181"/>
+        <source>Align Top</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/main.qml" line="188"/>
         <source>Align Center</source>
         <translation>Centro</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="178"/>
+        <location filename="../package/main.qml" line="196"/>
         <source>Top</source>
         <translation>Superior</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="183"/>
+        <location filename="../package/main.qml" line="201"/>
         <source>Bottom</source>
         <translation>Inferior</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="195"/>
+        <location filename="../package/main.qml" line="211"/>
         <source>Right</source>
         <translation>Direita</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="201"/>
+        <location filename="../package/main.qml" line="217"/>
         <source>Status</source>
         <translation>Exibição</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="203"/>
+        <location filename="../package/main.qml" line="219"/>
         <source>Keep Shown</source>
         <translation>Sempre exibir</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="208"/>
+        <location filename="../package/main.qml" line="224"/>
         <source>Keep Hidden</source>
         <translation>Sempre ocultar</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="214"/>
+        <location filename="../package/main.qml" line="230"/>
         <source>Smart Hide</source>
         <translation>Ocultar automaticamente</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="221"/>
+        <location filename="../package/main.qml" line="237"/>
         <source>Dock Settings</source>
         <translation>Configurações do dock</translation>
     </message>

--- a/panels/dock/translations/org.deepin.ds.dock_ru.ts
+++ b/panels/dock/translations/org.deepin.ds.dock_ru.ts
@@ -4,82 +4,87 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="148"/>
+        <location filename="../package/main.qml" line="162"/>
         <source>Indicator Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="150"/>
+        <location filename="../package/main.qml" line="164"/>
         <source>Fashion Mode</source>
         <translation>Современный Режим</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="155"/>
+        <location filename="../package/main.qml" line="169"/>
         <source>Efficient Mode</source>
         <translation>Эффективный Режим</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="161"/>
+        <location filename="../package/main.qml" line="175"/>
         <source>Alignment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="189"/>
+        <location filename="../package/main.qml" line="206"/>
         <source>Left</source>
         <translation>Слева</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="174"/>
+        <location filename="../package/main.qml" line="194"/>
         <source>Position</source>
         <translation>Положение</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="163"/>
+        <location filename="../package/main.qml" line="179"/>
         <source>Align Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="168"/>
+        <location filename="../package/main.qml" line="181"/>
+        <source>Align Top</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/main.qml" line="188"/>
         <source>Align Center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="178"/>
+        <location filename="../package/main.qml" line="196"/>
         <source>Top</source>
         <translation>Сверху</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="183"/>
+        <location filename="../package/main.qml" line="201"/>
         <source>Bottom</source>
         <translation>Снизу</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="195"/>
+        <location filename="../package/main.qml" line="211"/>
         <source>Right</source>
         <translation>Справа</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="201"/>
+        <location filename="../package/main.qml" line="217"/>
         <source>Status</source>
         <translation>Состояние</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="203"/>
+        <location filename="../package/main.qml" line="219"/>
         <source>Keep Shown</source>
         <translation>Отображать Всегда</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="208"/>
+        <location filename="../package/main.qml" line="224"/>
         <source>Keep Hidden</source>
         <translation>Держать Скрытым</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="214"/>
+        <location filename="../package/main.qml" line="230"/>
         <source>Smart Hide</source>
         <translation>Умное Скрытие</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="221"/>
+        <location filename="../package/main.qml" line="237"/>
         <source>Dock Settings</source>
         <translation>Настройки Dock</translation>
     </message>

--- a/panels/dock/translations/org.deepin.ds.dock_uk.ts
+++ b/panels/dock/translations/org.deepin.ds.dock_uk.ts
@@ -4,82 +4,87 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="148"/>
+        <location filename="../package/main.qml" line="162"/>
         <source>Indicator Style</source>
         <translation>Стиль індикатора</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="150"/>
+        <location filename="../package/main.qml" line="164"/>
         <source>Fashion Mode</source>
         <translation>Модний режим</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="155"/>
+        <location filename="../package/main.qml" line="169"/>
         <source>Efficient Mode</source>
         <translation>Практичний режим</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="161"/>
+        <location filename="../package/main.qml" line="175"/>
         <source>Alignment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="189"/>
+        <location filename="../package/main.qml" line="206"/>
         <source>Left</source>
         <translation>Ліворуч</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="174"/>
+        <location filename="../package/main.qml" line="194"/>
         <source>Position</source>
         <translation>Розташування</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="163"/>
+        <location filename="../package/main.qml" line="179"/>
         <source>Align Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="168"/>
+        <location filename="../package/main.qml" line="181"/>
+        <source>Align Top</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/main.qml" line="188"/>
         <source>Align Center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="178"/>
+        <location filename="../package/main.qml" line="196"/>
         <source>Top</source>
         <translation>Вгорі</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="183"/>
+        <location filename="../package/main.qml" line="201"/>
         <source>Bottom</source>
         <translation>Внизу</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="195"/>
+        <location filename="../package/main.qml" line="211"/>
         <source>Right</source>
         <translation>Праворуч</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="201"/>
+        <location filename="../package/main.qml" line="217"/>
         <source>Status</source>
         <translation>Стан</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="203"/>
+        <location filename="../package/main.qml" line="219"/>
         <source>Keep Shown</source>
         <translation>Показувати постійно</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="208"/>
+        <location filename="../package/main.qml" line="224"/>
         <source>Keep Hidden</source>
         <translation>Приховувати</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="214"/>
+        <location filename="../package/main.qml" line="230"/>
         <source>Smart Hide</source>
         <translation>Розумне приховування</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="221"/>
+        <location filename="../package/main.qml" line="237"/>
         <source>Dock Settings</source>
         <translation>Параметри бічної панелі</translation>
     </message>

--- a/panels/dock/translations/org.deepin.ds.dock_zh_CN.ts
+++ b/panels/dock/translations/org.deepin.ds.dock_zh_CN.ts
@@ -4,82 +4,87 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="148"/>
+        <location filename="../package/main.qml" line="162"/>
         <source>Indicator Style</source>
         <translation>指示器样式</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="150"/>
+        <location filename="../package/main.qml" line="164"/>
         <source>Fashion Mode</source>
         <translation>时尚模式</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="155"/>
+        <location filename="../package/main.qml" line="169"/>
         <source>Efficient Mode</source>
         <translation>高效模式</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="161"/>
+        <location filename="../package/main.qml" line="175"/>
         <source>Alignment</source>
         <translation>应用布局</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="189"/>
+        <location filename="../package/main.qml" line="206"/>
         <source>Left</source>
         <translation>左</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="174"/>
+        <location filename="../package/main.qml" line="194"/>
         <source>Position</source>
         <translation>位置</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="163"/>
+        <location filename="../package/main.qml" line="179"/>
         <source>Align Left</source>
         <translation>靠左</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="168"/>
+        <location filename="../package/main.qml" line="181"/>
+        <source>Align Top</source>
+        <translation>靠上</translation>
+    </message>
+    <message>
+        <location filename="../package/main.qml" line="188"/>
         <source>Align Center</source>
         <translation>居中</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="178"/>
+        <location filename="../package/main.qml" line="196"/>
         <source>Top</source>
         <translation>上</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="183"/>
+        <location filename="../package/main.qml" line="201"/>
         <source>Bottom</source>
         <translation>下</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="195"/>
+        <location filename="../package/main.qml" line="211"/>
         <source>Right</source>
         <translation>右</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="201"/>
+        <location filename="../package/main.qml" line="217"/>
         <source>Status</source>
         <translation>状态</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="203"/>
+        <location filename="../package/main.qml" line="219"/>
         <source>Keep Shown</source>
         <translation>一直显示</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="208"/>
+        <location filename="../package/main.qml" line="224"/>
         <source>Keep Hidden</source>
         <translation>一直隐藏</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="214"/>
+        <location filename="../package/main.qml" line="230"/>
         <source>Smart Hide</source>
         <translation>智能隐藏</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="221"/>
+        <location filename="../package/main.qml" line="237"/>
         <source>Dock Settings</source>
         <translation>任务栏设置</translation>
     </message>

--- a/panels/dock/translations/org.deepin.ds.dock_zh_HK.ts
+++ b/panels/dock/translations/org.deepin.ds.dock_zh_HK.ts
@@ -4,82 +4,87 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="148"/>
+        <location filename="../package/main.qml" line="162"/>
         <source>Indicator Style</source>
         <translation>指示器樣式</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="150"/>
+        <location filename="../package/main.qml" line="164"/>
         <source>Fashion Mode</source>
         <translation>時尚模式</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="155"/>
+        <location filename="../package/main.qml" line="169"/>
         <source>Efficient Mode</source>
         <translation>高效模式</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="161"/>
+        <location filename="../package/main.qml" line="175"/>
         <source>Alignment</source>
         <translation>佈局樣式</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="189"/>
+        <location filename="../package/main.qml" line="206"/>
         <source>Left</source>
         <translation>左</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="174"/>
+        <location filename="../package/main.qml" line="194"/>
         <source>Position</source>
         <translation>位置</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="163"/>
+        <location filename="../package/main.qml" line="179"/>
         <source>Align Left</source>
         <translation>靠左</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="168"/>
+        <location filename="../package/main.qml" line="181"/>
+        <source>Align Top</source>
+        <translation>靠上</translation>
+    </message>
+    <message>
+        <location filename="../package/main.qml" line="188"/>
         <source>Align Center</source>
         <translation>居中</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="178"/>
+        <location filename="../package/main.qml" line="196"/>
         <source>Top</source>
         <translation>上</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="183"/>
+        <location filename="../package/main.qml" line="201"/>
         <source>Bottom</source>
         <translation>下</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="195"/>
+        <location filename="../package/main.qml" line="211"/>
         <source>Right</source>
         <translation>右</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="201"/>
+        <location filename="../package/main.qml" line="217"/>
         <source>Status</source>
         <translation>狀態</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="203"/>
+        <location filename="../package/main.qml" line="219"/>
         <source>Keep Shown</source>
         <translation>壹直顯示</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="208"/>
+        <location filename="../package/main.qml" line="224"/>
         <source>Keep Hidden</source>
         <translation>壹直隱藏</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="214"/>
+        <location filename="../package/main.qml" line="230"/>
         <source>Smart Hide</source>
         <translation>智能隱藏</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="221"/>
+        <location filename="../package/main.qml" line="237"/>
         <source>Dock Settings</source>
         <translation>任務欄設置</translation>
     </message>

--- a/panels/dock/translations/org.deepin.ds.dock_zh_TW.ts
+++ b/panels/dock/translations/org.deepin.ds.dock_zh_TW.ts
@@ -4,82 +4,87 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="148"/>
+        <location filename="../package/main.qml" line="162"/>
         <source>Indicator Style</source>
         <translation>指示器樣式</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="150"/>
+        <location filename="../package/main.qml" line="164"/>
         <source>Fashion Mode</source>
         <translation>時尚模式</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="155"/>
+        <location filename="../package/main.qml" line="169"/>
         <source>Efficient Mode</source>
         <translation>高效模式</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="161"/>
+        <location filename="../package/main.qml" line="175"/>
         <source>Alignment</source>
         <translation>佈局樣式</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="189"/>
+        <location filename="../package/main.qml" line="206"/>
         <source>Left</source>
         <translation>左</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="174"/>
+        <location filename="../package/main.qml" line="194"/>
         <source>Position</source>
         <translation>位置</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="163"/>
+        <location filename="../package/main.qml" line="179"/>
         <source>Align Left</source>
         <translation>靠左</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="168"/>
+        <location filename="../package/main.qml" line="181"/>
+        <source>Align Top</source>
+        <translation>靠上</translation>
+    </message>
+    <message>
+        <location filename="../package/main.qml" line="188"/>
         <source>Align Center</source>
         <translation>居中</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="178"/>
+        <location filename="../package/main.qml" line="196"/>
         <source>Top</source>
         <translation>上</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="183"/>
+        <location filename="../package/main.qml" line="201"/>
         <source>Bottom</source>
         <translation>下</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="195"/>
+        <location filename="../package/main.qml" line="211"/>
         <source>Right</source>
         <translation>右</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="201"/>
+        <location filename="../package/main.qml" line="217"/>
         <source>Status</source>
         <translation>狀態</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="203"/>
+        <location filename="../package/main.qml" line="219"/>
         <source>Keep Shown</source>
         <translation>壹直顯示</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="208"/>
+        <location filename="../package/main.qml" line="224"/>
         <source>Keep Hidden</source>
         <translation>壹直隱藏</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="214"/>
+        <location filename="../package/main.qml" line="230"/>
         <source>Smart Hide</source>
         <translation>智能隱藏</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="221"/>
+        <location filename="../package/main.qml" line="237"/>
         <source>Dock Settings</source>
         <translation>任務欄設置</translation>
     </message>


### PR DESCRIPTION
When the dock is on the left or right, the text is 'Align Top'

Issue: https://github.com/linuxdeepin/developer-center/issues/9947