### PR TITLE
fix: popup's height isn't enough

### DIFF
--- a/panels/dock/DockCompositor.qml
+++ b/panels/dock/DockCompositor.qml
@@ -61,6 +61,11 @@ Item {
         }
     }
 
+    function updatePopupMinHeight(height)
+    {
+        pluginManager.setPopupMinHeight(height)
+    }
+
     WaylandCompositor {
         id: waylandCompositor
         socketName: "dockplugin"

--- a/panels/dock/pluginmanagerextension_p.h
+++ b/panels/dock/pluginmanagerextension_p.h
@@ -29,7 +29,7 @@ public:
     void initialize() override;
 
     Q_INVOKABLE void updateDockOverflowState(int state);
-    Q_INVOKABLE void dockPanelSizeChanged(int width, int height);
+    Q_INVOKABLE void setPopupMinHeight(int height);
 
     uint32_t dockPosition() const;
     void setDockPosition(uint32_t dockPosition);
@@ -41,9 +41,6 @@ public:
 
     QSize dockSize() const;
     void setDockSize(const QSize &newDockSize);
-
-public slots:
-    void updateDockSize();
 
 Q_SIGNALS:
     void pluginPopupCreated(PluginPopup*);
@@ -61,6 +58,9 @@ private:
     static QJsonObject getRootObj(const QString &jsonStr);
     static QString toJson(const QJsonObject &jsonObj);
     void sendEventMsg(const QString &msg);
+    void sendEventMsg(Resource *target, const QString &msg);
+    QString dockSizeMsg() const;
+    QString popupMinHeightMsg() const;
 
 private:
     QList<PluginSurface*> m_pluginSurfaces;
@@ -68,6 +68,7 @@ private:
     uint32_t m_dockPosition;
     uint32_t m_dockColorTheme;
     QSize m_dockSize;
+    int m_popupMinHeight = 0;
 };
 
 class PluginSurface : public QWaylandShellSurfaceTemplate<PluginSurface>, public QtWaylandServer::plugin

--- a/panels/dock/tray/quickpanel/QuickPanel.qml
+++ b/panels/dock/tray/quickpanel/QuickPanel.qml
@@ -27,6 +27,11 @@ Item {
     property int trayItemMargins: 4
     readonly property bool isOpened: panelTrayItem.isOpened
 
+    function updatePopupMinHeight(value)
+    {
+        DockCompositor.updatePopupMinHeight(value)
+    }
+
     PanelTrayItem {
         id: panelTrayItem
         shellSurface: quickpanelModel.trayItemSurface
@@ -65,6 +70,10 @@ Item {
                     let itemKey = tmp[1]
                     return quickpanelModel.isQuickPanelPopup(pluginId, itemKey)
                 }
+            }
+
+            onPopupMinHeightChanged: function () {
+                root.updatePopupMinHeight(popupContent.popupMinHeight)
             }
         }
     }

--- a/panels/dock/tray/quickpanel/QuickPanelPage.qml
+++ b/panels/dock/tray/quickpanel/QuickPanelPage.qml
@@ -16,6 +16,7 @@ Item {
     height: panelView.height
 
     required property var model
+    property int popupMinHeight: Math.max(360, panelPage.height)
 
     Connections {
         target: model
@@ -26,7 +27,7 @@ Item {
                                pluginId: pluginId,
                                model: root.model,
                                shellSurface: surface,
-                               subPluginMinHeight: Math.max(360, panelPage.height)
+                               subPluginMinHeight: root.popupMinHeight
                            },
                            StackView.PushTransition)
         }


### PR DESCRIPTION
set minHeight for plugins when creating.
refact sendEventMsg to support sendEvent for one resource.

Issue: https://github.com/linuxdeepin/developer-center/issues/9702
