### PR TITLE
fix: Tooltips appear when modifying desktop switching

### DIFF
--- a/panels/dock/workspaceitem/package/workspaceitem.qml
+++ b/panels/dock/workspaceitem/package/workspaceitem.qml
@@ -109,6 +109,13 @@ AppletItem {
         toolTipY: DockPanelPositioner.y
     }
 
+    Connections {
+        target: Applet.dataModel
+        function onCurrentIndexChanged() {
+            toolTip.close()
+        }
+    }
+
     Rectangle {
         anchors.fill: parent
         color: "transparent"


### PR DESCRIPTION
Close tooltips when switching desktops

Issue: https://github.com/linuxdeepin/developer-center/issues/10030