### PR TITLE
fix(tray): The input method icon is displayed in the stashed area

### DIFF
--- a/panels/dock/dconfig/org.deepin.ds.dock.tray.json
+++ b/panels/dock/dconfig/org.deepin.ds.dock.tray.json
@@ -26,7 +26,7 @@
         },
         "collapsableSurfaceIds": {
             "value": [
-                "application-tray::SNI::Fcitx",
+                "application-tray::SNI:Fcitx-0",
                 "network::network-item-key",
                 "battery::power",
                 "shutdown::shutdown"


### PR DESCRIPTION
Rel: linuxdeepin/dde-tray-loader#103
Issues: linuxdeepin/developer-center#9697