### PR TITLE
fix: mouse position drift

### DIFF
--- a/frame/utility_x11.cpp
+++ b/frame/utility_x11.cpp
@@ -103,9 +103,10 @@ bool MouseGrabEventFilter::eventFilter(QObject *watched, QEvent *event)
 void MouseGrabEventFilter::mousePressEvent(QMouseEvent *e)
 {
     const auto bounding = m_target->geometry();
-    const auto pos = e->globalPosition();
+    auto pos = e->globalPosition();
     if ((e->position().toPoint().isNull() && !pos.isNull()) ||
         !bounding.contains(pos.toPoint())) {
+        pos = pos * m_target->devicePixelRatio();
         instance()->deliverMouseEvent(e->button(), pos.x(), pos.y());
         emit outsideMousePressed();
         return;


### PR DESCRIPTION
Simulate clicking without converting to X coordinates

Issue: https://github.com/linuxdeepin/developer-center/issues/9964