### PR TITLE
fix: Popup can't switch to other by one click

### DIFF
--- a/frame/qml/PanelPopup.qml
+++ b/frame/qml/PanelPopup.qml
@@ -67,6 +67,10 @@ Item {
         if (!popupWindow)
             return
 
+        // avoid to closing window by other PanelPopup.
+        if (!readyBinding)
+            return
+
         popupWindow.close()
         popupWindow.currentItem = null
     }

--- a/panels/dock/tray/CMakeLists.txt
+++ b/panels/dock/tray/CMakeLists.txt
@@ -25,6 +25,7 @@ qt_add_qml_module(dock-tray
         ksortfilterproxymodel.h
     QML_FILES
         SurfacePopup.qml
+        TrayItemSurfacePopup.qml
         ShellSurfaceItemProxy.qml
 
     OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/plugins/org/deepin/ds/dock/tray/

--- a/panels/dock/tray/TrayItemSurfacePopup.qml
+++ b/panels/dock/tray/TrayItemSurfacePopup.qml
@@ -1,0 +1,125 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import QtQuick
+import QtQuick.Controls
+import QtWayland.Compositor
+
+import org.deepin.ds 1.0
+import org.deepin.ds.dock 1.0
+import org.deepin.ds.dock.tray 1.0
+
+Item {
+    id: root
+
+    property var surfaceAcceptor: function (surfaceId) {
+        return true
+    }
+    property var surfaceFilter: function (surfaceId) {
+        return false
+    }
+    function closeTooltip()
+    {
+        if (toolTip.toolTipVisible) {
+            toolTip.close()
+        }
+    }
+
+    PanelPopup {
+        id: popup
+        property alias shellSurface: popupContent.shellSurface
+        width: popupContent.width
+        height: popupContent.height
+        popupX: DockPanelPositioner.x
+        popupY: DockPanelPositioner.y
+
+        Item {
+            anchors.fill: parent
+            ShellSurfaceItemProxy {
+                id: popupContent
+                anchors.centerIn: parent
+                autoClose: true
+                onSurfaceDestroyed: function () {
+                    popup.close()
+                }
+            }
+        }
+    }
+
+    PanelMenu {
+        id: popupMenu
+        property alias shellSurface: popupMenuContent.shellSurface
+        width: popupMenuContent.width
+        height: popupMenuContent.height
+        menuX: DockPositioner.x
+        menuY: DockPositioner.y
+
+        Item {
+            anchors.fill: parent
+            ShellSurfaceItemProxy {
+                id: popupMenuContent
+                anchors.centerIn: parent
+                autoClose: true
+                onSurfaceDestroyed: function () {
+                    popupMenu.close()
+                }
+            }
+        }
+    }
+
+    PanelToolTip {
+        id: toolTip
+        property alias shellSurface: toolTipContent.shellSurface
+        toolTipX: DockPanelPositioner.x
+        toolTipY: DockPanelPositioner.y
+
+        ShellSurfaceItemProxy {
+            id: toolTipContent
+            anchors.centerIn: parent
+            autoClose: true
+            onSurfaceDestroyed: function () {
+                toolTip.close()
+            }
+        }
+    }
+
+    Connections {
+        target: DockCompositor
+        function onPopupCreated(popupSurface)
+        {
+            let surfaceId = `${popupSurface.pluginId}::${popupSurface.itemKey}`
+            if (surfaceAcceptor && !surfaceAcceptor(surfaceId))
+                return
+
+            if (surfaceFilter && surfaceFilter(surfaceId))
+                return
+
+            if (popupSurface.popupType === Dock.TrayPopupTypeTooltip) {
+                console.log("tray's tooltip created", popupSurface.pluginId, popupSurface.itemKey)
+                toolTip.shellSurface = popupSurface
+                toolTip.DockPanelPositioner.bounding = Qt.binding(function () {
+                    var point = Qt.point(toolTip.shellSurface.x, toolTip.shellSurface.y)
+                    return Qt.rect(point.x, point.y, toolTip.width, toolTip.height)
+                })
+                toolTip.open()
+            } else if (popupSurface.popupType === Dock.TrayPopupTypePanel) {
+                console.log("tray's popup created", popupSurface.pluginId, popupSurface.itemKey)
+                popup.shellSurface = popupSurface
+                popup.DockPanelPositioner.bounding = Qt.binding(function () {
+                    var point = Qt.point(popup.shellSurface.x, popup.shellSurface.y)
+                    return Qt.rect(point.x, point.y, popup.width, popup.height)
+                })
+                popup.open()
+            } else if (popupSurface.popupType === Dock.TrayPopupTypeMenu) {
+                console.log("tray's menu created", popupSurface.pluginId, popupSurface.itemKey)
+                popupMenu.shellSurface = popupSurface
+                popupMenu.DockPositioner.bounding = Qt.binding(function () {
+                    var point = Qt.point(popupMenu.shellSurface.x, popupMenu.shellSurface.y)
+                    return Qt.rect(point.x, point.y, popupMenu.width, popupMenu.height)
+                })
+                popupMenu.open()
+            }
+        }
+    }
+}

--- a/panels/dock/tray/package/ActionToggleQuickSettingsDelegate.qml
+++ b/panels/dock/tray/package/ActionToggleQuickSettingsDelegate.qml
@@ -13,10 +13,4 @@ QuickPanel {
     useColumnLayout: !isHorizontal
     trayItemPluginId: Applet.rootObject.quickpanelTrayItemPluginId
     trayItemMargins: itemPadding
-    Component.onCompleted: function () {
-        Applet.rootObject.quickPanelIsOpened = Qt.binding(function () {
-            return root.isOpened
-        })
-    }
-
 }

--- a/panels/dock/tray/package/TrayContainer.qml
+++ b/panels/dock/tray/package/TrayContainer.qml
@@ -87,6 +87,7 @@ Item {
     property size containerSize: DDT.TrayItemPositionManager.visualSize
     // visiualIndex default value is -1
     property int dropHoverIndex: -1
+    required property var surfaceAcceptor
 
     implicitWidth: width
     width: containerSize.width
@@ -107,6 +108,7 @@ Item {
         isHorizontal: root.isHorizontal
         collapsed: root.collapsed
         itemPadding: root.itemPadding
+        surfaceAcceptor: root.surfaceAcceptor
     }
 
     // debug

--- a/panels/dock/tray/package/TrayItemDelegateChooser.qml
+++ b/panels/dock/tray/package/TrayItemDelegateChooser.qml
@@ -14,6 +14,7 @@ LQM.DelegateChooser {
     property bool isHorizontal: false
     property bool collapsed: false
     required property int itemPadding
+    required property var surfaceAcceptor
 
     role: "delegateType"
     LQM.DelegateChoice {
@@ -36,6 +37,16 @@ LQM.DelegateChooser {
                 inputEventsEnabled: model.sectionType !== "collapsable" || !DDT.TraySortOrderModel.collapsed
                 itemVisible: traySurfacePositioner.itemVisible
                 dragable: model.sectionType !== "fixed"
+
+                // trayItem's popup
+                DDT.TrayItemSurfacePopup {
+                    surfaceAcceptor: function (surfaceId) {
+                        if (root.surfaceAcceptor && !root.surfaceAcceptor(surfaceId))
+                            return false
+
+                        return surfaceId === model.surfaceId
+                    }
+                }
             }
         }
     }

--- a/panels/dock/tray/package/tray.qml
+++ b/panels/dock/tray/package/tray.qml
@@ -21,7 +21,6 @@ AppletItem {
     property int dockOrder: 25
     readonly property string quickpanelTrayItemPluginId: "sound"
     readonly property var filterTrayPlugins: [quickpanelTrayItemPluginId]
-    property bool quickPanelIsOpened: false
 
     implicitWidth: useColumnLayout ? Panel.rootObject.dockSize : trayContainter.implicitWidth + nextAppletSpacing
     implicitHeight: useColumnLayout ? trayContainter.implicitHeight + nextAppletSpacing: Panel.rootObject.dockSize
@@ -35,64 +34,6 @@ AppletItem {
         Applet.fixedPluginModel = Qt.binding(function () {
             return DockCompositor.fixedPluginSurfaces
         })
-    }
-
-    PanelPopup {
-        id: popup
-        property alias shellSurface: popupContent.shellSurface
-        width: popupContent.width
-        height: popupContent.height
-        popupX: DockPanelPositioner.x
-        popupY: DockPanelPositioner.y
-
-        Item {
-            anchors.fill: parent
-            ShellSurfaceItemProxy {
-                id: popupContent
-                anchors.centerIn: parent
-                autoClose: true
-                onSurfaceDestroyed: function () {
-                    popup.close()
-                }
-            }
-        }
-    }
-
-    PanelMenu {
-        id: popupMenu
-        property alias shellSurface: popupMenuContent.shellSurface
-        width: popupMenuContent.width
-        height: popupMenuContent.height
-        menuX: DockPositioner.x
-        menuY: DockPositioner.y
-
-        Item {
-            anchors.fill: parent
-            ShellSurfaceItemProxy {
-                id: popupMenuContent
-                anchors.centerIn: parent
-                autoClose: true
-                onSurfaceDestroyed: function () {
-                    popupMenu.close()
-                }
-            }
-        }
-    }
-
-    PanelToolTip {
-        id: toolTip
-        property alias shellSurface: toolTipContent.shellSurface
-        toolTipX: DockPanelPositioner.x
-        toolTipY: DockPanelPositioner.y
-
-        ShellSurfaceItemProxy {
-            id: toolTipContent
-            anchors.centerIn: parent
-            autoClose: true
-            onSurfaceDestroyed: function () {
-                toolTip.close()
-            }
-        }
     }
 
     PanelPopup {
@@ -161,76 +102,22 @@ AppletItem {
         model: DDT.TraySortOrderModel
         collapsed: DDT.TraySortOrderModel.collapsed
         trayHeight: isHorizontal ? tray.implicitHeight : tray.implicitWidth
+        surfaceAcceptor: isTrayPluginPopup
         color: "transparent"
         Component.onCompleted: {
             DDT.TrayItemPositionManager.layoutHealthCheck(1500)
         }
     }
 
-    function isQuickPanelPopup(popupSurface)
+    function isTrayPluginPopup(surfaceId)
     {
-        return popupSurface &&
-                popupSurface.pluginId === tray.quickpanelTrayItemPluginId
-    }
-    onQuickPanelIsOpenedChanged: function ()
-    {
-        if (tray.quickPanelIsOpened &&
-                toolTip.toolTipVisible &&
-                isQuickPanelPopup(toolTip.shellSurface)) {
-            toolTip.close()
-        }
-    }
-
-    Connections {
-        target: DockCompositor
-        function onPopupCreated(popupSurface)
-        {
-            if (!isTrayPluginPopup(popupSurface))
-                return
-
-            if (popupSurface.popupType === Dock.TrayPopupTypeTooltip) {
-                if (tray.quickPanelIsOpened && isQuickPanelPopup(popupSurface)) {
-                    // don't show the surface, and release it.
-                    DockCompositor.closeShellSurface(popupSurface)
-                    return
-                }
-
-                console.log("tray's tooltip created", popupSurface.pluginId, popupSurface.itemKey)
-                toolTip.shellSurface = popupSurface
-                toolTip.DockPanelPositioner.bounding = Qt.binding(function () {
-                    var point = Qt.point(toolTip.shellSurface.x, toolTip.shellSurface.y)
-                    return Qt.rect(point.x, point.y, toolTip.width, toolTip.height)
-                })
-                toolTip.open()
-            } else if (popupSurface.popupType === Dock.TrayPopupTypePanel) {
-                console.log("tray's popup created", popupSurface.pluginId, popupSurface.itemKey)
-                popup.shellSurface = popupSurface
-                popup.DockPanelPositioner.bounding = Qt.binding(function () {
-                    var point = Qt.point(popup.shellSurface.x, popup.shellSurface.y)
-                    return Qt.rect(point.x, point.y, popup.width, popup.height)
-                })
-                popup.open()
-            } else if (popupSurface.popupType === Dock.TrayPopupTypeMenu) {
-                console.log("tray's menu created", popupSurface.pluginId, popupSurface.itemKey)
-                popupMenu.shellSurface = popupSurface
-                popupMenu.DockPositioner.bounding = Qt.binding(function () {
-                    var point = Qt.point(popupMenu.shellSurface.x, popupMenu.shellSurface.y)
-                    return Qt.rect(point.x, point.y, popupMenu.width, popupMenu.height)
-                })
-                popupMenu.open()
-            }
-        }
-        function isTrayPluginPopup(popupSurface)
-        {
-            let surfaceId = `${popupSurface.pluginId}::${popupSurface.itemKey}`
-            if (stashContainer.isStashPopup(surfaceId))
-                return false
-            if (DockCompositor.findSurfaceFromModel(DockCompositor.trayPluginSurfaces, surfaceId))
-                return true
-            if (DockCompositor.findSurfaceFromModel(DockCompositor.fixedPluginSurfaces, surfaceId))
-                return true
+        if (stashContainer.isStashPopup(surfaceId))
             return false
-        }
+        if (DockCompositor.findSurfaceFromModel(DockCompositor.trayPluginSurfaces, surfaceId))
+            return true
+        if (DockCompositor.findSurfaceFromModel(DockCompositor.fixedPluginSurfaces, surfaceId))
+            return true
+        return false
     }
 
     Connections {

--- a/panels/dock/tray/quickpanel/QuickPanel.qml
+++ b/panels/dock/tray/quickpanel/QuickPanel.qml
@@ -27,6 +27,27 @@ Item {
     property int trayItemMargins: 4
     readonly property bool isOpened: panelTrayItem.isOpened
 
+    function isTrayItemPopup(surfaceId)
+    {
+        return pluginIdBySurfaceId(surfaceId) === trayItemPluginId
+    }
+    function pluginIdBySurfaceId(surfaceId)
+    {
+        let tmp = surfaceId.split("::")
+        if (tmp.length !== 2) {
+            return ""
+        }
+        return tmp[0]
+    }
+    function itemKeyBySurfaceId(surfaceId)
+    {
+        let tmp = surfaceId.split("::")
+        if (tmp.length !== 2) {
+            return ""
+        }
+        return tmp[1]
+    }
+
     function updatePopupMinHeight(value)
     {
         DockCompositor.updatePopupMinHeight(value)
@@ -61,13 +82,8 @@ Item {
             DDT.SurfacePopup {
                 objectName: "quickpanel"
                 surfaceAcceptor: function (surfaceId) {
-                    let tmp = surfaceId.split("::")
-                    if (tmp.length !== 2) {
-                        console.warn("Incorrect surfaceId format, it should be PluginId::ItemKey.")
-                        return false
-                    }
-                    let pluginId = tmp[0]
-                    let itemKey = tmp[1]
+                    let pluginId = pluginIdBySurfaceId(surfaceId)
+                    let itemKey = itemKeyBySurfaceId(surfaceId)
                     return quickpanelModel.isQuickPanelPopup(pluginId, itemKey)
                 }
             }
@@ -75,6 +91,20 @@ Item {
             onPopupMinHeightChanged: function () {
                 root.updatePopupMinHeight(popupContent.popupMinHeight)
             }
+        }
+    }
+
+    // trayItem's popup
+    DDT.TrayItemSurfacePopup {
+        id: trayItemSurfacePopup
+        surfaceAcceptor: isTrayItemPopup
+        surfaceFilter: function (surfaceId) {
+            return isOpened
+        }
+    }
+    onIsOpenedChanged: function () {
+        if (isOpened) {
+            trayItemSurfacePopup.closeTooltip()
         }
     }
 


### PR DESCRIPTION
Add TrayItemSurfacePopup to deal with SurfacePopup for tray.
each TrayItem has itself PanelPopup, and then we can switch
to other item by `PopupWindow.currentItem`.

Issue: https://github.com/linuxdeepin/developer-center/issues/10095
