### PR TITLE
fix: popup can't close when click empty area for dock

### DIFF
--- a/panels/dock/package/main.qml
+++ b/panels/dock/package/main.qml
@@ -251,6 +251,11 @@ Window {
             if (button === Qt.RightButton && lastActive !== dockMenuLoader.item) {
                 MenuHelper.openMenu(dockMenuLoader.item)
             }
+            if (button === Qt.LeftButton) {
+                // try to close popup when clicked empty, because dock does not have focus.
+                if (Panel.popupWindow.visible)
+                    Panel.popupWindow.close()
+            }
         }
     }
 


### PR DESCRIPTION
as title.

Issue: https://github.com/linuxdeepin/developer-center/issues/10075
