### PR TITLE
fix: PopupWindow position cannot be refreshed

### DIFF
--- a/frame/qml/PanelPopupWindow.qml
+++ b/frame/qml/PanelPopupWindow.qml
@@ -70,6 +70,26 @@ Window {
         {
             requestUpdateGeometry()
         }
+        function onYChanged()
+        {
+            requestUpdateGeometry()
+        }
+        function onXChanged()
+        {
+            requestUpdateGeometry()
+        }
+    }
+
+    Connections {
+        target: root.Screen
+        function onDesktopAvailableHeightChanged()
+        {
+            requestUpdateGeometry()
+        }
+        function onDesktopAvailableWidthChanged()
+        {
+            requestUpdateGeometry()
+        }
     }
 
     onHeightChanged: requestUpdateGeometry()

--- a/panels/dock/tray/package/ActionLegacyTrayPluginDelegate.qml
+++ b/panels/dock/tray/package/ActionLegacyTrayPluginDelegate.qml
@@ -97,7 +97,7 @@ AppletItemButton {
 
         Timer {
             id: updatePluginItemGeometryTimer
-            interval: 500
+            interval: 100
             running: false
             repeat: false
             onTriggered: {
@@ -112,7 +112,7 @@ AppletItemButton {
 
         Timer {
             id: updatePluginItemPosTimer
-            interval: 500
+            interval: 100
             running: false
             repeat: false
             onTriggered: {


### PR DESCRIPTION
Automatically refresh the position of Popupwindow when the available area of the screen changes or when the taskbar position changes

Issue: https://github.com/linuxdeepin/developer-center/issues/10096