### PR TITLE
fix: Unable to pop up when modifying network pop ups

### DIFF
--- a/panels/dock/tray/quickpanel/QuickPanel.qml
+++ b/panels/dock/tray/quickpanel/QuickPanel.qml
@@ -121,6 +121,9 @@ Item {
         {
             if (popupSurface.popupType === Dock.TrayPopupTypeEmbed) {
                 console.log("popup created", popupSurface.popupType, popupSurface.pluginId)
+                if (!popup.popupVisible) {
+                    panelTrayItem.clicked()
+                }
                 quickpanelModel.requestShowSubPlugin(popupSurface.pluginId, popupSurface)
             }
         }


### PR DESCRIPTION
Before displaying sub windows on the shortcut panel, you need to show yourself first

Issue: https://github.com/linuxdeepin/developer-center/issues/10153