### PR TITLE
fix: Temporarily disable all windows action

### DIFF
--- a/panels/dock/taskmanager/appitem.cpp
+++ b/panels/dock/taskmanager/appitem.cpp
@@ -97,12 +97,13 @@ QString AppItem::menus() const
         }
     }
 
-    if (hasWindow()) {
-        QJsonObject allWindowMenu;
-        allWindowMenu["id"] = DOCK_ACTION_ALLWINDOW;
-        allWindowMenu["name"] = tr("All Windows");
-        array.append(allWindowMenu);        
-    }
+    // Temporarily disable all windows action for the related functionality missing in deepin-kwin
+    // if (hasWindow()) {
+    //     QJsonObject allWindowMenu;
+    //     allWindowMenu["id"] = DOCK_ACTION_ALLWINDOW;
+    //     allWindowMenu["name"] = tr("All Windows");
+    //     array.append(allWindowMenu);
+    // }
 
     QJsonObject dockMenu;
     dockMenu["id"] = DOCK_ACTION_DOCK;


### PR DESCRIPTION
Because the corresponding action in deepin-kwin was disabled.

Issue: https://github.com/linuxdeepin/developer-center/issues/10172
Log: Temporarily disable all windows action