### PR TITLE
fix: subMenu can't show

### DIFF
--- a/frame/qml/PanelPopupWindow.qml
+++ b/frame/qml/PanelPopupWindow.qml
@@ -16,10 +16,17 @@ Window {
     property int margins: 10
     property Item currentItem
     signal requestUpdateGeometry()
+    signal updateGeometryFinished()
 
     // order to update screen and (x,y)
-    function updateGeometry()
+    property var updateGeometryer : function updateGeometry()
     {
+        if (root.width <= 10 || root.height <= 10) {
+            return
+        }
+        if (!root.transientParent)
+            return
+
         // following transientParent's screen.
         root.screen = root.transientParent.screen
 
@@ -97,7 +104,14 @@ Window {
     onXOffsetChanged: requestUpdateGeometry()
     onYOffsetChanged: requestUpdateGeometry()
 
-    onRequestUpdateGeometry: Qt.callLater(updateGeometry)
+    onRequestUpdateGeometry: {
+        if (updateGeometryer) {
+            Qt.callLater(function () {
+                updateGeometryer()
+                updateGeometryFinished()
+            })
+        }
+    }
 
     D.StyledBehindWindowBlur {
         control: parent

--- a/panels/dock/constants.h
+++ b/panels/dock/constants.h
@@ -71,7 +71,8 @@ enum TrayPopupType {
     TrayPopupTypePanel = 1,
     TrayPopupTypeTooltip = 2,
     TrayPopupTypeMenu = 3,
-    TrayPopupTypeEmbed = 4
+    TrayPopupTypeEmbed = 4,
+    TrayPopupTypeSubPopup = 5
 };
 
 enum TrayPluginType {

--- a/panels/dock/pluginmanagerextension.cpp
+++ b/panels/dock/pluginmanagerextension.cpp
@@ -156,10 +156,6 @@ QWaylandQuickShellIntegration* PluginPopup::createIntegration(QWaylandQuickShell
 
 void PluginPopup::updatePluginGeometry(const QRect &geometry)
 {
-    if (geometry.width() <= 0 || geometry.height() <= 0) {
-        return;
-    }
-
     send_geometry(geometry.x(), geometry.y(), geometry.width(), geometry.height());
 }
 

--- a/panels/dock/tray/CMakeLists.txt
+++ b/panels/dock/tray/CMakeLists.txt
@@ -25,6 +25,7 @@ qt_add_qml_module(dock-tray
         ksortfilterproxymodel.h
     QML_FILES
         SurfacePopup.qml
+        SurfaceSubPopup.qml
         TrayItemSurfacePopup.qml
         ShellSurfaceItemProxy.qml
 

--- a/panels/dock/tray/SurfacePopup.qml
+++ b/panels/dock/tray/SurfacePopup.qml
@@ -51,15 +51,19 @@ Item {
             if (arg && toolTipWindow.visible)
                 toolTipWindow.close()
         }
-        onXChanged: {
+        onUpdateGeometryFinished: function ()
+        {
             if (!menu.shellSurface)
                 return
-            menu.shellSurface.updatePluginGeometry(Qt.rect(x, y, 0, 0))
+            menu.shellSurface.updatePluginGeometry(Qt.rect(menu.menuWindow.x, menu.menuWindow.y, 0, 0))
         }
-        onYChanged: {
-            if (!menu.shellSurface)
-                return
-            menu.shellSurface.updatePluginGeometry(Qt.rect(x, y, 0, 0))
+        SurfaceSubPopup {
+            objectName: "stashed's subPopup"
+            surfaceAcceptor: function (surfaceId) {
+                if (root.surfaceAcceptor && !root.surfaceAcceptor(surfaceId))
+                    return false
+                return true
+            }
         }
     }
     PanelMenu {

--- a/panels/dock/tray/SurfaceSubPopup.qml
+++ b/panels/dock/tray/SurfaceSubPopup.qml
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import QtQuick
+import QtQuick.Controls
+import QtWayland.Compositor
+import org.deepin.ds 1.0
+import org.deepin.ds.dock 1.0
+
+Item {
+    id: root
+
+    property var surfaceAcceptor: function (surfaceId) {
+        return true
+    }
+    PanelMenuWindow {
+        id: menuWindow
+        updateGeometryer : function ()
+        {
+            if (menuWindow.width <= 10 || menuWindow.height <= 10) {
+                return
+            }
+
+            // following transientParent's screen.
+            menuWindow.screen = menuWindow.transientParent.screen
+
+            let bounding = Qt.rect(menuWindow.screen.virtualX + margins, menuWindow.screen.virtualY + margins,
+                                   menuWindow.screen.width - margins * 2, menuWindow.screen.height - margins * 2)
+            let pos = Qt.point(xOffset, yOffset)
+            x = selectValue(pos.x, bounding.left, bounding.right - menuWindow.width)
+            y = selectValue(pos.y, bounding.top, bounding.bottom - menuWindow.height)
+        }
+        onUpdateGeometryFinished: function ()
+        {
+            if (!popup.shellSurface)
+                return
+            popup.shellSurface.updatePluginGeometry(Qt.rect(popup.menuWindow.x, popup.menuWindow.y, 0, 0))
+        }
+    }
+    WaylandOutput {
+        compositor: DockCompositor.compositor
+        window: popup.menuWindow
+        sizeFollowsWindow: false
+    }
+
+    PanelMenu {
+        id: popup
+        width: popupSurfaceLayer.width
+        height: popupSurfaceLayer.height
+        menuWindow: menuWindow
+
+        property alias shellSurface: popupSurfaceLayer.shellSurface
+        ShellSurfaceItemProxy {
+            id: popupSurfaceLayer
+            anchors.centerIn: parent
+            autoClose: true
+            onSurfaceDestroyed: function () {
+                popup.close()
+            }
+        }
+    }
+
+    Connections {
+        target: DockCompositor
+        function onPopupCreated(popupSurface)
+        {
+            let surfaceId = `${popupSurface.pluginId}::${popupSurface.itemKey}`
+            if (surfaceAcceptor && !surfaceAcceptor(surfaceId))
+                return
+
+            if (popupSurface.popupType === Dock.TrayPopupTypeSubPopup) {
+
+                popup.shellSurface = popupSurface
+                popup.menuX = Qt.binding(function () {
+                    return popup.shellSurface.x
+                })
+                popup.menuY = Qt.binding(function () {
+                    return popup.shellSurface.y
+                })
+                popup.open()
+            }
+        }
+    }
+}

--- a/panels/dock/tray/TrayItemSurfacePopup.qml
+++ b/panels/dock/tray/TrayItemSurfacePopup.qml
@@ -65,6 +65,25 @@ Item {
                     popupMenu.close()
                 }
             }
+            SurfaceSubPopup {
+                objectName: "tray's subPopup"
+                surfaceAcceptor: function (surfaceId) {
+                    if (root.surfaceAcceptor && !root.surfaceAcceptor(surfaceId))
+                        return false
+                    return true
+                }
+            }
+            Connections {
+                target: popupMenu.menuWindow
+                enabled: popupMenu.readyBinding
+                function onUpdateGeometryFinished()
+                {
+                    if (!popupMenu.shellSurface)
+                        return
+
+                    popupMenu.shellSurface.updatePluginGeometry(Qt.rect(popupMenu.menuWindow.x, popupMenu.menuWindow.y, 0, 0))
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Remove geometry's limits for PluginPopup.
Sync window's geometry to client.
Add SurfaceSubPopup to display subPoup, and SubPopup's geometry
is depends on itself instead of it's transparent geometry.
It depends on dde-tray-loader.
