### PR TITLE
chore: show bluetooth tray icon by default

### DIFF
--- a/panels/dock/dconfig/org.deepin.ds.dock.tray.json
+++ b/panels/dock/dconfig/org.deepin.ds.dock.tray.json
@@ -26,6 +26,7 @@
         },
         "collapsableSurfaceIds": {
             "value": [
+                "bluetooth::bluetooth-item-key",
                 "application-tray::SNI:Fcitx-0",
                 "network::network-item-key",
                 "battery::power",


### PR DESCRIPTION
Issues: linuxdeepin/developer-center#10049