### PR TITLE
fix: The padding and rounded corners of the tooltip are incorrect

### DIFF
--- a/frame/qml/PanelToolTip.qml
+++ b/frame/qml/PanelToolTip.qml
@@ -82,11 +82,12 @@ Item {
 
     Control {
         id: toolTip
-        padding: DStyle.Style.toolTip.horizontalPadding
         visible: readyBinding
         anchors.centerIn: parent
-        topPadding: 0
-        bottomPadding: 0
+        topPadding: DStyle.Style.toolTip.verticalPadding
+        bottomPadding: DStyle.Style.toolTip.verticalPadding
+        leftPadding: DStyle.Style.toolTip.horizontalPadding
+        rightPadding: DStyle.Style.toolTip.horizontalPadding
         parent: toolTipWindow ? toolTipWindow.contentItem : undefined
         contentItem: Text {
             horizontalAlignment: Text.AlignLeft
@@ -94,7 +95,7 @@ Item {
             font: toolTip.font
             wrapMode: Text.WordWrap
             text: control.text
-            color: toolTip.palette.windowText
+            color: toolTip.palette.brightText
         }
     }
 }

--- a/frame/qml/PanelToolTipWindow.qml
+++ b/frame/qml/PanelToolTipWindow.qml
@@ -11,6 +11,6 @@ PanelPopupWindow {
     id: root
 
     flags: (Qt.platform.pluginName === "xcb" ? Qt.Tool : Qt.ToolTip) | Qt.WindowStaysOnTopHint
-    D.DWindow.windowRadius: 4
+    D.DWindow.windowRadius: 8
     D.DWindow.shadowRadius: 8
 }


### PR DESCRIPTION
windowRadius： 4 ->8
vPadding: 0->4
textColor:  windowText->brightText

Issue:
- https://github.com/linuxdeepin/developer-center/issues/10005
- https://github.com/linuxdeepin/developer-center/issues/9997