### PR TITLE
chore: change the default order of system tray

### DIFF
--- a/panels/dock/dconfig/org.deepin.ds.dock.tray.json
+++ b/panels/dock/dconfig/org.deepin.ds.dock.tray.json
@@ -26,8 +26,8 @@
         },
         "collapsableSurfaceIds": {
             "value": [
-                "bluetooth::bluetooth-item-key",
                 "application-tray::SNI:Fcitx-0",
+                "bluetooth::bluetooth-item-key",
                 "network::network-item-key",
                 "battery::power",
                 "shutdown::shutdown"


### PR DESCRIPTION
输入法图标移动到蓝牙图标之前

Issues: linuxdeepin/developer-center#10049