### PR TITLE
refact: delay to create subwindow

### DIFF
--- a/panels/dock/tray/SurfacePopup.qml
+++ b/panels/dock/tray/SurfacePopup.qml
@@ -57,14 +57,6 @@ Item {
                 return
             menu.shellSurface.updatePluginGeometry(Qt.rect(menu.menuWindow.x, menu.menuWindow.y, 0, 0))
         }
-        SurfaceSubPopup {
-            objectName: "stashed's subPopup"
-            surfaceAcceptor: function (surfaceId) {
-                if (root.surfaceAcceptor && !root.surfaceAcceptor(surfaceId))
-                    return false
-                return true
-            }
-        }
     }
     PanelMenu {
         id: menu
@@ -79,6 +71,18 @@ Item {
             autoClose: true
             onSurfaceDestroyed: function () {
                 menu.close()
+            }
+        }
+        Loader {
+            active: menu.menuVisible
+            sourceComponent: SurfaceSubPopup {
+                objectName: "stashed's subPopup"
+                transientParent: menuWindow
+                surfaceAcceptor: function (surfaceId) {
+                    if (root.surfaceAcceptor && !root.surfaceAcceptor(surfaceId))
+                        return false
+                    return true
+                }
             }
         }
     }

--- a/panels/dock/tray/SurfaceSubPopup.qml
+++ b/panels/dock/tray/SurfaceSubPopup.qml
@@ -15,51 +15,51 @@ Item {
         return true
     }
     property alias transientParent: menuWindow.transientParent
-    PanelMenuWindow {
-        id: menuWindow
-        objectName: "subMenu"
-        mainMenuWindow: Panel.menuWindow
-        updateGeometryer : function ()
-        {
-            if (menuWindow.width <= 10 || menuWindow.height <= 10) {
-                return
-            }
 
-            // following transientParent's screen.
-            menuWindow.screen = menuWindow.transientParent.screen
-
-            let bounding = Qt.rect(menuWindow.screen.virtualX + margins, menuWindow.screen.virtualY + margins,
-                                   menuWindow.screen.width - margins * 2, menuWindow.screen.height - margins * 2)
-            let pos = Qt.point(xOffset, yOffset)
-            x = selectValue(pos.x, bounding.left, bounding.right - menuWindow.width)
-            y = selectValue(pos.y, bounding.top, bounding.bottom - menuWindow.height)
-        }
-        onUpdateGeometryFinished: function ()
-        {
-            if (!popup.shellSurface)
-                return
-            popup.shellSurface.updatePluginGeometry(Qt.rect(popup.menuWindow.x, popup.menuWindow.y, 0, 0))
-        }
-    }
     WaylandOutput {
         compositor: DockCompositor.compositor
-        window: popup.menuWindow
         sizeFollowsWindow: false
-    }
+        window: PanelMenuWindow {
+            id: menuWindow
+            objectName: "subMenu"
+            mainMenuWindow: Panel.menuWindow
+            updateGeometryer : function ()
+            {
+                if (menuWindow.width <= 10 || menuWindow.height <= 10) {
+                    return
+                }
 
-    PanelMenu {
-        id: popup
-        width: popupSurfaceLayer.width
-        height: popupSurfaceLayer.height
-        menuWindow: menuWindow
+                // following transientParent's screen.
+                menuWindow.screen = menuWindow.transientParent.screen
 
-        property alias shellSurface: popupSurfaceLayer.shellSurface
-        ShellSurfaceItemProxy {
-            id: popupSurfaceLayer
-            anchors.centerIn: parent
-            autoClose: true
-            onSurfaceDestroyed: function () {
-                popup.close()
+                let bounding = Qt.rect(menuWindow.screen.virtualX + margins, menuWindow.screen.virtualY + margins,
+                                       menuWindow.screen.width - margins * 2, menuWindow.screen.height - margins * 2)
+                let pos = Qt.point(xOffset, yOffset)
+                x = selectValue(pos.x, bounding.left, bounding.right - menuWindow.width)
+                y = selectValue(pos.y, bounding.top, bounding.bottom - menuWindow.height)
+            }
+            onUpdateGeometryFinished: function ()
+            {
+                if (!popup.shellSurface)
+                    return
+                popup.shellSurface.updatePluginGeometry(Qt.rect(popup.menuWindow.x, popup.menuWindow.y, 0, 0))
+            }
+
+            PanelMenu {
+                id: popup
+                width: popupSurfaceLayer.width
+                height: popupSurfaceLayer.height
+                menuWindow: menuWindow
+
+                property alias shellSurface: popupSurfaceLayer.shellSurface
+                ShellSurfaceItemProxy {
+                    id: popupSurfaceLayer
+                    anchors.centerIn: parent
+                    autoClose: true
+                    onSurfaceDestroyed: function () {
+                        popup.close()
+                    }
+                }
             }
         }
     }

--- a/panels/dock/tray/TrayItemSurfacePopup.qml
+++ b/panels/dock/tray/TrayItemSurfacePopup.qml
@@ -66,15 +66,19 @@ Item {
                     popupMenu.close()
                 }
             }
-            SurfaceSubPopup {
-                objectName: "tray's subPopup"
-                transientParent: popupMenu.menuWindow
-                surfaceAcceptor: function (surfaceId) {
-                    if (root.surfaceAcceptor && !root.surfaceAcceptor(surfaceId))
-                        return false
-                    return true
+            Loader {
+                active: popupMenu.menuVisible
+                sourceComponent: SurfaceSubPopup {
+                    objectName: "tray's subPopup"
+                    transientParent: popupMenu.menuWindow
+                    surfaceAcceptor: function (surfaceId) {
+                        if (root.surfaceAcceptor && !root.surfaceAcceptor(surfaceId))
+                            return false
+                        return true
+                    }
                 }
             }
+
             Connections {
                 target: popupMenu.menuWindow
                 enabled: popupMenu.readyBinding


### PR DESCRIPTION
Delay to create subwindow.
app crashed if SurfaceItem isn't in OutPut when exit, so we move
SurfaceItem to OutPut, and the item is managed by OutPut.
