### PR TITLE
chore: move network plugin to pinned area

### DIFF
--- a/panels/dock/dconfig/org.deepin.ds.dock.tray.json
+++ b/panels/dock/dconfig/org.deepin.ds.dock.tray.json
@@ -28,7 +28,6 @@
             "value": [
                 "application-tray::SNI:Fcitx-0",
                 "bluetooth::bluetooth-item-key",
-                "network::network-item-key",
                 "battery::power",
                 "shutdown::shutdown"
             ],
@@ -43,7 +42,8 @@
         },
         "pinnedSurfaceIds": {
             "value": [
-                "uosai::uosai"
+                "uosai::uosai",
+                "network::network-item-key"
             ],
             "serial": 0,
             "flags": [],


### PR DESCRIPTION
移动网络插件到固定插件区域

Issues: linuxdeepin/developer-center#10355