### PR TITLE
feat: hide search, clipboard and workspace when leftAlignment

### DIFF
--- a/panels/dock/clipboarditem/package/clipboarditem.qml
+++ b/panels/dock/clipboarditem/package/clipboarditem.qml
@@ -17,7 +17,7 @@ AppletItem {
     property int dockOrder: 1
     implicitWidth: Panel.rootObject.useColumnLayout ? dockSize : 30
     implicitHeight: Panel.rootObject.useColumnLayout ? 30 : dockSize
-    property bool shouldVisible: Applet.visible
+    property bool shouldVisible: Applet.visible && Panel.itemAlignment === Dock.CenterAlignment
     property D.Palette toolButtonColor: DockPalette.toolButtonColor
     property D.Palette toolButtonBorderColor: DockPalette.toolButtonBorderColor
 

--- a/panels/dock/searchitem/package/searchitem.qml
+++ b/panels/dock/searchitem/package/searchitem.qml
@@ -19,7 +19,7 @@ AppletItem {
     property int dockOrder: 3
     implicitWidth: Panel.rootObject.useColumnLayout ? dockSize : 30 
     implicitHeight: Panel.rootObject.useColumnLayout ? 30 : dockSize
-    property bool shouldVisible: Applet.visible
+    property bool shouldVisible: Applet.visible && Panel.itemAlignment === Dock.CenterAlignment
 
     property D.Palette toolButtonColor: DockPalette.toolButtonColor
     property D.Palette toolButtonBorderColor: DockPalette.toolButtonBorderColor

--- a/panels/dock/workspaceitem/package/workspaceitem.qml
+++ b/panels/dock/workspaceitem/package/workspaceitem.qml
@@ -19,20 +19,7 @@ AppletItem {
     property int itemSize: 16
     property int space: 4
     // todo: visible property to be set
-    property bool shouldVisible: {
-        let clipboardApplet = DS.applet("org.deepin.ds.dock.clipboarditem")
-        let searchApplet = DS.applet("org.deepin.ds.dock.searchitem")
-        let clipboardVisible = true
-        let searchVisible = true
-        if (clipboardApplet) {
-            clipboardVisible = clipboardApplet.visible;
-        }
-        if (searchApplet) {
-            searchVisible = searchApplet.visible;
-        }
-
-        return ((clipboardVisible || searchVisible) || Panel.itemAlignment === Dock.CenterAlignment) && listView.count > 1
-    }
+    property bool shouldVisible: listView.count > 1 && Panel.itemAlignment === Dock.CenterAlignment
 
     // visible:listView.count > 1
     implicitWidth: Panel.position === Dock.Top || Panel.position === Dock.Bottom ? listView.count * frameSize + space * (listView.count - 1) : dockSize


### PR DESCRIPTION
hide search, clipboard and workspace when leftAlignment

Issue: https://github.com/linuxdeepin/developer-center/issues/10363