### PR TITLE
feat: animation when drop item from launchpad

### DIFF
--- a/panels/dock/OverflowContainer.qml
+++ b/panels/dock/OverflowContainer.qml
@@ -14,6 +14,7 @@ Item {
     property alias count: listView.count
     property alias add: listView.add
     property alias remove: listView.remove
+    property alias move: listView.move
     property alias displaced: listView.displaced
     ListView {
         id: listView

--- a/panels/dock/OverflowContainer.qml
+++ b/panels/dock/OverflowContainer.qml
@@ -12,6 +12,8 @@ Item {
     property alias delegate: listView.delegate
     property alias spacing: listView.spacing
     property alias count: listView.count
+    property alias add: listView.add
+    property alias remove: listView.remove
     property alias displaced: listView.displaced
     ListView {
         id: listView

--- a/panels/dock/taskmanager/appitem.cpp
+++ b/panels/dock/taskmanager/appitem.cpp
@@ -52,8 +52,8 @@ QString AppItem::type() const
 
 QString AppItem::icon() const
 {
-    if (m_currentActiveWindow.isNull() || m_desktopfileParser->isValied().first)
-        return m_desktopfileParser->desktopIcon();
+    if (m_currentActiveWindow.isNull() || (m_desktopfileParser && m_desktopfileParser->isValied().first))
+        return m_desktopfileParser ? m_desktopfileParser->desktopIcon() : "application-default-icon";
     else {
         return m_currentActiveWindow->icon();
     }

--- a/panels/dock/taskmanager/itemmodel.cpp
+++ b/panels/dock/taskmanager/itemmodel.cpp
@@ -138,7 +138,6 @@ void ItemModel::addItem(QPointer<AbstractItem> item)
     beginInsertRows(QModelIndex(), rowCount(), rowCount());
     m_items.append(item);
     endInsertRows();
-    Q_EMIT itemAdded();
 }
 
 void ItemModel::onItemDestroyed()
@@ -152,7 +151,6 @@ void ItemModel::onItemDestroyed()
     beginRemoveRows(QModelIndex(), beginIndex, lastIndex);
     m_items.removeAll(item);
     endRemoveRows();
-    Q_EMIT itemRemoved();
 }
 
 void ItemModel::onItemChanged()

--- a/panels/dock/taskmanager/itemmodel.cpp
+++ b/panels/dock/taskmanager/itemmodel.cpp
@@ -82,12 +82,7 @@ void ItemModel::moveTo(const QString &id, int dIndex)
     if (sIndex == dIndex) {
         return;
     }
-    if (sIndex + 1 == dIndex) {
-        // Do not move from sIndex to sIndex + 1, as endMoveRows is not trivial, this operation equals do nothing.
-        // FIXME: maybe this is a bug of Qt? but swap these two is a compatible fix
-        std::swap(sIndex, dIndex);
-    }
-    beginMoveRows(QModelIndex(), sIndex, sIndex, QModelIndex(), dIndex);
+    beginMoveRows(QModelIndex(), sIndex, sIndex, QModelIndex(), dIndex > sIndex ? (dIndex + 1) : dIndex);
     m_items.move(sIndex, dIndex);
     endMoveRows();
 

--- a/panels/dock/taskmanager/itemmodel.h
+++ b/panels/dock/taskmanager/itemmodel.h
@@ -41,10 +41,6 @@ public:
     void addItem(QPointer<AbstractItem> item);
     QJsonArray dumpDockedItems() const;
 
-Q_SIGNALS:
-    void itemAdded();
-    void itemRemoved();
-
 private Q_SLOTS:
     void onItemDestroyed();
     void onItemChanged();

--- a/panels/dock/taskmanager/package/TaskManager.qml
+++ b/panels/dock/taskmanager/package/TaskManager.qml
@@ -22,6 +22,24 @@ ContainmentItem {
         anchors.centerIn: parent
         useColumnLayout: taskmanager.useColumnLayout
         spacing: Panel.rootObject.itemSpacing
+        add: Transition {
+            NumberAnimation {
+                properties: "scale"
+                from: 0
+                to: 1
+                duration: 200
+                easing.type: Easing.OutQuad
+            }
+        }
+        remove: Transition {
+            NumberAnimation {
+                properties: "scale"
+                from: 1
+                to: 0
+                duration: 200
+                easing.type: Easing.InQuad
+            }
+        }
         displaced: Transition {
             NumberAnimation {
                 properties: "x,y"
@@ -86,9 +104,6 @@ ContainmentItem {
                     onDragFinished: function() {
                         // 就算在非法区域松开也更新 Model
                         taskmanager.Applet.dataModel.moveTo(itemId, visualIndex)
-
-                        // 更新 visualModel 的 model 数据
-                        visualModel.model = taskmanager.Applet.dataModel
                     }
                     anchors.fill: parent // This is mandatory for draggable item center in drop area
                 }

--- a/panels/dock/taskmanager/taskmanager.cpp
+++ b/panels/dock/taskmanager/taskmanager.cpp
@@ -47,9 +47,6 @@ TaskManager::TaskManager(QObject* parent)
     qDBusRegisterMetaType<PropMap>();
     qDBusRegisterMetaType<QDBusObjectPath>();
 
-    connect(ItemModel::instance(), &ItemModel::itemAdded, this, &TaskManager::itemsChanged);
-    connect(ItemModel::instance(), &ItemModel::itemRemoved, this, &TaskManager::itemsChanged);
-
     connect(Settings, &TaskManagerSettings::allowedForceQuitChanged, this, &TaskManager::allowedForceQuitChanged);
     connect(Settings, &TaskManagerSettings::windowSplitChanged, this, &TaskManager::windowSplitChanged);
 }

--- a/panels/dock/taskmanager/taskmanager.cpp
+++ b/panels/dock/taskmanager/taskmanager.cpp
@@ -179,11 +179,15 @@ bool TaskManager::allowForceQuit()
     return Settings->isAllowedForceQuit();
 }
 
+QString TaskManager::desktopIdToAppId(const QString& desktopId)
+{
+    return Q_LIKELY(desktopId.endsWith(".desktop")) ? desktopId.chopped(8) : desktopId;
+}
+
 bool TaskManager::requestDockByDesktopId(const QString& appID)
 {
     if (appID.startsWith("internal/")) return false;
-    QString dockAppId(Q_LIKELY(appID.endsWith(".desktop")) ? appID.chopped(8) : appID);
-    return RequestDock(dockAppId);
+    return RequestDock(desktopIdToAppId(appID));
 }
 
 bool TaskManager::RequestDock(QString appID)

--- a/panels/dock/taskmanager/taskmanager.h
+++ b/panels/dock/taskmanager/taskmanager.h
@@ -33,6 +33,7 @@ public:
     bool windowSplit();
     bool allowForceQuit();
 
+    Q_INVOKABLE QString desktopIdToAppId(const QString& desktopId);
     Q_INVOKABLE bool requestDockByDesktopId(const QString& appID);
     Q_INVOKABLE bool RequestDock(QString appID);
     Q_INVOKABLE bool IsDocked(QString appID);

--- a/panels/dock/taskmanager/taskmanager.h
+++ b/panels/dock/taskmanager/taskmanager.h
@@ -17,7 +17,7 @@ class AppItem;
 class TaskManager : public DS_NAMESPACE::DContainment
 {
     Q_OBJECT
-    Q_PROPERTY(ItemModel* dataModel READ dataModel NOTIFY itemsChanged)
+    Q_PROPERTY(ItemModel* dataModel READ dataModel NOTIFY dataModelChanged)
 
     Q_PROPERTY(bool windowSplit READ windowSplit NOTIFY windowSplitChanged)
     Q_PROPERTY(bool allowForceQuit READ allowForceQuit NOTIFY allowedForceQuitChanged)
@@ -45,7 +45,7 @@ public:
     Q_INVOKABLE void setAppItemWindowIconGeometry(const QString& appid, QObject* relativePositionItem, const int& x1, const int& y1, const int& x2, const int& y2);
 
 Q_SIGNALS:
-    void itemsChanged();
+    void dataModelChanged();
     void windowSplitChanged();
     void allowedForceQuitChanged();
 


### PR DESCRIPTION
拖拽图标至启动器时，拖拽释放前即跟随鼠标位置进行固定，并在释放后提供
图标淡入+放大的动画。

Log: