### PR TITLE
fix: pupup surface doesn't release

### DIFF
--- a/panels/dock/pluginmanagerextension_p.h
+++ b/panels/dock/pluginmanagerextension_p.h
@@ -42,6 +42,8 @@ public:
     QSize dockSize() const;
     void setDockSize(const QSize &newDockSize);
 
+    void removePluginSurface(PluginSurface *plugin);
+
 Q_SIGNALS:
     void pluginPopupCreated(PluginPopup*);
     void pluginSurfaceCreated(PluginSurface*);
@@ -124,10 +126,13 @@ signals:
     void recvMouseEvent(QEvent::Type type);
 
     void marginsChanged();
+    void aboutToDestroy();
 
 protected:
     virtual void plugin_mouse_event(Resource *resource, int32_t type) override;
     virtual void plugin_dcc_icon(Resource *resource, const QString &icon) override;
+    virtual void plugin_destroy_resource(Resource *resource) override;
+    virtual void plugin_destroy(Resource *resource) override;
 
 private:
     PluginManager* m_manager;
@@ -146,7 +151,7 @@ private:
     int m_margins = 0;
 };
 
-class PluginPopup : public QWaylandShellSurfaceTemplate<PluginSurface>, public QtWaylandServer::plugin_popup
+class PluginPopup : public QWaylandShellSurfaceTemplate<PluginPopup>, public QtWaylandServer::plugin_popup
 {
     Q_OBJECT
     Q_PROPERTY(int32_t x READ x WRITE setX NOTIFY xChanged)
@@ -177,8 +182,13 @@ public:
 
     int32_t popupType() const;
 
+signals:
+    void aboutToDestroy();
+
 protected:
     virtual void plugin_popup_set_position(Resource *resource, int32_t x, int32_t y) override;
+    virtual void plugin_popup_destroy_resource(Resource *resource) override;
+    virtual void plugin_popup_destroy(Resource *resource) override;
 
 Q_SIGNALS:
     void xChanged();

--- a/panels/dock/tray/ShellSurfaceItemProxy.qml
+++ b/panels/dock/tray/ShellSurfaceItemProxy.qml
@@ -7,18 +7,50 @@ import QtQuick.Controls
 import QtWayland.Compositor
 import org.deepin.ds.dock 1.0
 
-ShellSurfaceItem {
+Item {
+    id: root
+    property var shellSurface: null
+    signal surfaceDestroyed()
     property bool autoClose: false
-    onVisibleChanged: function () {
-        if (autoClose && !visible) {
-            // surface is valid but client's shellSurface maybe invalid.
-            Qt.callLater(closeShellSurface)
+    property bool inputEventsEnabled: true
+
+    width: impl.width
+    height: impl.height
+    implicitWidth: width
+    implicitHeight: height
+
+    ShellSurfaceItem {
+        id: impl
+        shellSurface: root.shellSurface
+        inputEventsEnabled: root.inputEventsEnabled
+        onVisibleChanged: function () {
+            if (autoClose && !visible) {
+                // surface is valid but client's shellSurface maybe invalid.
+                Qt.callLater(closeShellSurface)
+            }
+        }
+        function closeShellSurface()
+        {
+            if (surface && shellSurface) {
+                DockCompositor.closeShellSurface(shellSurface)
+            }
         }
     }
-    function closeShellSurface()
-    {
-        if (surface && shellSurface) {
-            DockCompositor.closeShellSurface(shellSurface)
+    Component.onCompleted: function () {
+        impl.surfaceDestroyed.connect(root.surfaceDestroyed)
+    }
+
+    Connections {
+        target: shellSurface
+        // TODO it's maybe a bug for qt, we force shellSurface's value to update
+        function onAboutToDestroy()
+        {
+            Qt.callLater(function() {
+                impl.shellSurface = null
+                impl.shellSurface = Qt.binding(function () {
+                    return root.shellSurface
+                })
+            })
         }
     }
 }


### PR DESCRIPTION
add protocol of destroy to release PluginPopup when client has
close the window surface.
add a signal of aboutToDestroy to update shellSurface.

Issue: https://github.com/linuxdeepin/developer-center/issues/10121
