### PR TITLE
fix: drag size has a devicePixelRatio from quickpanel to tray

### DIFF
--- a/panels/dock/pluginmanagerextension.cpp
+++ b/panels/dock/pluginmanagerextension.cpp
@@ -75,7 +75,7 @@ uint32_t PluginSurface::pluginSizePolicy () const
 
 QSize PluginSurface::pluginSize() const
 {
-    return m_surface->bufferSize();
+    return m_surface->bufferSize() / qApp->devicePixelRatio();
 }
 
 QString PluginSurface::dccIcon() const


### PR DESCRIPTION
buffersize is image physical size not logical size

log: as title