### PR TITLE
fix: libdock-plugin.so contains a forbidden reference to /build/

### DIFF
--- a/panels/dock/CMakeLists.txt
+++ b/panels/dock/CMakeLists.txt
@@ -152,6 +152,7 @@ target_include_directories(dock-plugin
     $<TARGET_PROPERTY:dde-shell-frame,INTERFACE_INCLUDE_DIRECTORIES>
 )
 
+install(TARGETS dock-plugin DESTINATION "${QML_INSTALL_DIR}/org/deepin/ds/dock/")
 install(DIRECTORY "${PROJECT_BINARY_DIR}/plugins/org/deepin/ds/dock/" DESTINATION "${QML_INSTALL_DIR}/org/deepin/ds/dock/")
 dtk_add_config_meta_files(APPID org.deepin.ds.dock FILES dconfig/org.deepin.ds.dock.json) # compat
 dtk_add_config_meta_files(APPID org.deepin.ds.dock FILES dconfig/org.deepin.ds.dock.tray.json) # compat


### PR DESCRIPTION
log: cmake install TARGETS will auto remove reference to /build/