### PR TITLE
fix: the opacity of preview window isn't changed

### DIFF
--- a/panels/dock/taskmanager/x11preview.h
+++ b/panels/dock/taskmanager/x11preview.h
@@ -17,6 +17,7 @@
 #include <DBlurEffectWidget>
 #include <DGuiApplicationHelper>
 #include <DIconButton>
+#include <QDBusMessage>
 
 DWIDGET_USE_NAMESPACE
 
@@ -89,6 +90,7 @@ public Q_SLOTS:
 private Q_SLOTS:
     void updateOrientation();
     void callHide();
+    void onPropertiesChanged(const QDBusMessage &message);
 
 private:
     bool m_isPreviewEntered;


### PR DESCRIPTION
the opacity isn't changed by changing the settings in dcc.
Add the slot to the signal that opacity changes in dcc.

Log:
Bug: https://pms.uniontech.com/bug-view-273041.html