### PR TITLE
fix: Remove unnecessary animation for notificationcenter

### DIFF
--- a/panels/notification-center/AnimationSettingButton.qml
+++ b/panels/notification-center/AnimationSettingButton.qml
@@ -11,7 +11,14 @@ SettingActionButton {
     id: root
 
     property int duration: 200
-    property bool textVisible: root.hovered
+    property bool textVisible: root.hovered && text !== ""
+    property bool enableAnimation: false
+
+    Component.onCompleted: {
+        Qt.callLater(function () {
+            enableAnimation = true
+        })
+    }
 
     contentItem: Item {
         clip: true
@@ -19,9 +26,9 @@ SettingActionButton {
         implicitHeight: iconDelegate.width
 
         Behavior on implicitWidth {
+            enabled: root.enableAnimation
             NumberAnimation { duration: root.duration; easing.type: root.textVisible ? Easing.OutQuad : Easing.InQuad }
         }
-
         AnimationDelegate {
             id: textDelegate
             leftPadding: 4
@@ -73,13 +80,11 @@ SettingActionButton {
         transitions: [
             Transition {
                 to: "invisible"
+                enabled: root.enableAnimation
                 SequentialAnimation {
                     NumberAnimation { property: "opacity"; easing.type: Easing.InQuad; duration: root.duration }
                     PropertyAction { target: delegate; property: "visible"; value: false }
                 }
-            },
-            Transition {
-                NumberAnimation { property: "opacity"; easing.type: Easing.OutQuad; duration: root.duration }
             }
         ]
     }

--- a/panels/notification-center/NormalNotify.qml
+++ b/panels/notification-center/NormalNotify.qml
@@ -21,8 +21,8 @@ NotifyItem {
     transitions: Transition {
         to: "removing"
         ParallelAnimation {
-            NumberAnimation { properties: "x"; duration: 200; easing.type: Easing.InOutQuad }
-            NumberAnimation { properties: "opacity"; duration: 200; easing.type: Easing.InOutQuad }
+            NumberAnimation { properties: "x"; duration: 300; easing.type: Easing.Linear }
+            NumberAnimation { properties: "opacity"; duration: 300; easing.type: Easing.Linear }
         }
         onRunningChanged: {
             if (!running) {

--- a/panels/notification-center/OverlapNotify.qml
+++ b/panels/notification-center/OverlapNotify.qml
@@ -24,8 +24,8 @@ NotifyItem {
     transitions: Transition {
         to: "removing"
         ParallelAnimation {
-            NumberAnimation { properties: "x"; duration: 200; easing.type: Easing.InOutQuad }
-            NumberAnimation { properties: "opacity"; duration: 200; easing.type: Easing.InOutQuad }
+            NumberAnimation { properties: "x"; duration: 300; easing.type: Easing.Linear }
+            NumberAnimation { properties: "opacity"; duration: 300; easing.type: Easing.Linear }
         }
         onRunningChanged: {
             if (!running) {


### PR DESCRIPTION
Disable animation when opening group, only enable aniation when
switching textVisible.
