### PR TITLE
fix: crash on get wmclass

### DIFF
--- a/panels/dock/taskmanager/CMakeLists.txt
+++ b/panels/dock/taskmanager/CMakeLists.txt
@@ -86,7 +86,7 @@ target_link_libraries(dock-taskmanager PRIVATE
 
 if (BUILD_WITH_X11)
     target_compile_definitions(dock-taskmanager PRIVATE BUILD_WITH_X11=)
-    pkg_check_modules(XCB REQUIRED IMPORTED_TARGET xcb xcb-res xcb-ewmh)
+    pkg_check_modules(TaskmanagerXcb REQUIRED IMPORTED_TARGET xcb xcb-res xcb-ewmh xcb-icccm)
     find_package(Dtk${DTK_VERSION_MAJOR} REQUIRED COMPONENTS Widget)
     target_sources(dock-taskmanager PRIVATE
         x11preview.h
@@ -101,7 +101,7 @@ if (BUILD_WITH_X11)
     )
 
     target_link_libraries(dock-taskmanager PUBLIC
-        PkgConfig::XCB
+        PkgConfig::TaskmanagerXcb
         Qt${QT_VERSION_MAJOR}::Widgets
         Dtk${DTK_VERSION_MAJOR}::Widget
     )

--- a/panels/dock/taskmanager/x11window.cpp
+++ b/panels/dock/taskmanager/x11window.cpp
@@ -47,7 +47,7 @@ pid_t X11Window::pid()
 QString X11Window::identity()
 {
     if (m_identity == "") {
-
+        m_identity = X11->getWindowWMClass(m_windowID)[0];
     }
 
     return m_identity;


### PR DESCRIPTION
use xcb-icccm instead get property directly

log: as title