### PR TITLE
fix: plugin not show when not found in dconfig even it can not set vi…

### DIFF
--- a/panels/dock/tray/package/tray.qml
+++ b/panels/dock/tray/package/tray.qml
@@ -141,7 +141,7 @@ AppletItem {
                     preferredSection = "pinned"
                 }
 
-                surfacesData.push({"surfaceId": surfaceId, "delegateType": "legacy-tray-plugin", "sectionType": preferredSection, "forbiddenSections": forbiddenSections, "isForceDock": item.pluginFlags & 0x1000})
+                surfacesData.push({"surfaceId": surfaceId, "delegateType": "legacy-tray-plugin", "sectionType": preferredSection, "forbiddenSections": forbiddenSections, "pluginFlags": item.pluginFlags})
             }
             // actually only for datetime plugin currently
             for (let i = 0; i < DockCompositor.fixedPluginSurfaces.count; i++) {
@@ -150,7 +150,7 @@ AppletItem {
                 let forbiddenSections = ["stashed", "collapsable", "pinned"]
                 let preferredSection = "fixed"
 
-                surfacesData.push({"surfaceId": surfaceId, "delegateType": "legacy-tray-plugin", "sectionType": preferredSection, "forbiddenSections": forbiddenSections, "isForceDock": item.pluginFlags & 0x1000})
+                surfacesData.push({"surfaceId": surfaceId, "delegateType": "legacy-tray-plugin", "sectionType": preferredSection, "forbiddenSections": forbiddenSections, "pluginFlags": item.pluginFlags})
             }
             DDT.TraySortOrderModel.availableSurfaces = surfacesData
             console.log("onPluginSurfacesUpdated", surfacesData.length)

--- a/panels/dock/tray/traysortordermodel.h
+++ b/panels/dock/tray/traysortordermodel.h
@@ -4,8 +4,9 @@
 
 #pragma once
 
-#include <QStandardItemModel>
+#include "constants.h"
 #include <QQmlEngine>
+#include <QStandardItemModel>
 
 namespace Dtk {
 namespace Core {
@@ -43,7 +44,7 @@ public:
         DelegateTypeRole,
         // this tray item cannot be drop (or moved in any form) to the given sections
         ForbiddenSectionsRole,
-        IsForceDockRole,
+        PluginFlagsRole,
         ModelExtendedRole = 0x1000
     };
     Q_ENUM(Roles)
@@ -86,10 +87,13 @@ private:
 
     QStandardItem * findItemByVisualIndex(int visualIndex, VisualSections visualSection) const;
     QStringList * getSection(const QString & sectionType);
-    QString findSection(const QString & surfaceId, const QString & fallback, const QStringList & forbiddenSections, bool isForceDock);
+    QString findSection(const QString &surfaceId, const QString &fallback, const QStringList &forbiddenSections, int pluginFlags);
     void registerToSection(const QString & surfaceId, const QString & sectionType);
-    QStandardItem * createTrayItem(const QString & name, const QString & sectionType,
-                                  const QString & delegateType, const QStringList & forbiddenSections = {}, bool isForceDock = false);
+    QStandardItem *createTrayItem(const QString &name,
+                                  const QString &sectionType,
+                                  const QString &delegateType,
+                                  const QStringList &forbiddenSections = {},
+                                  int pluginFlags = Dock::Attribute_Normal);
     void updateVisualIndexes();
     QString registerSurfaceId(const QVariantMap &surfaceData);
     void loadDataFromDConfig();


### PR DESCRIPTION
…sible

only make plugin invisible when it's can_setting plugin, plugin without can_setting will make always show.

log: as title