### PR TITLE
fix: WorkspaceItem preview image might be incorrect in screen change

### DIFF
--- a/panels/dock/workspaceitem/xworkspaceworker.cpp
+++ b/panels/dock/workspaceitem/xworkspaceworker.cpp
@@ -30,7 +30,11 @@ XWorkspaceWorker::XWorkspaceWorker(WorkspaceModel *model)
     bus.connect("org.kde.KWin", "/VirtualDesktopManager", "org.kde.KWin.VirtualDesktopManager", "currentChanged", this, SLOT(updateData()));
     bus.connect("org.kde.KWin", "/VirtualDesktopManager", "org.kde.KWin.VirtualDesktopManager", "desktopsChanged", this, SLOT(updateData()));
     bus.connect("org.deepin.dde.Appearance1", "/org/deepin/dde/Appearance1", "org.deepin.dde.Appearance1", "Changed", this, SLOT(appearanceChanged(const QString,const QString)));
-    connect(qApp, &QGuiApplication::primaryScreenChanged, this, &XWorkspaceWorker::updateData);
+    connect(qApp, &QGuiApplication::primaryScreenChanged, this, [this] {
+        updateData();
+        // FIXME: Dirty fix for occationally wallpaper change delays after this signal
+        QTimer::singleShot(3000, this, &XWorkspaceWorker::updateData);
+    });
     connect(m_model, &WorkspaceModel::currentIndexChanged, this, &XWorkspaceWorker::setIndex);
 }
 


### PR DESCRIPTION
Use dirty fix to run updateData again with timer for delayed screen changing

Bug: https://pms.uniontech.com/bug-view-272001.html Log: