### PR TITLE
fix: crash caused by nullptr or uninitialized ptr

### DIFF
--- a/panels/dock/taskmanager/taskmanager.cpp
+++ b/panels/dock/taskmanager/taskmanager.cpp
@@ -146,7 +146,7 @@ void TaskManager::handleWindowAdded(QPointer<AbstractWindow> window)
         desktopfile = DESKTOPFILEFACTORY::createById(res.first().data(m_activeAppModel->roleNames().key("desktopId")).toString(), "amAPP");
     }
 
-    if (!desktopfile->isValied().first) {
+    if (desktopfile.isNull() || !desktopfile->isValied().first) {
         desktopfile = DESKTOPFILEFACTORY::createByWindow(window);
     }
 

--- a/panels/dock/taskmanager/taskmanager.h
+++ b/panels/dock/taskmanager/taskmanager.h
@@ -59,7 +59,7 @@ private:
 
 private:
     QScopedPointer<AbstractWindowMonitor> m_windowMonitor;
-    RoleCombineModel *m_activeAppModel;
+    RoleCombineModel *m_activeAppModel = nullptr;
 };
 
 }


### PR DESCRIPTION
修复由缺失指针初始化或缺失空指针检查导致的崩溃

Log: