### PR TITLE
fix: some bugs for notification

### DIFF
--- a/panels/notification/bubble/bubbleitem.cpp
+++ b/panels/notification/bubble/bubbleitem.cpp
@@ -204,7 +204,7 @@ QString BubbleItem::summary() const
 
 QString BubbleItem::body() const
 {
-    return m_entity.body();
+    return enablePreview() ? m_entity.body() : tr("1 new message");
 }
 
 uint BubbleItem::replacesId() const

--- a/panels/notification/bubble/bubblepanel.cpp
+++ b/panels/notification/bubble/bubblepanel.cpp
@@ -144,7 +144,8 @@ void BubblePanel::addBubble(qint64 id)
 {
     const auto entity = m_accessor->fetchEntity(id);
     auto bubble = new BubbleItem(entity);
-
+    const auto enabled = enablePreview(entity.appId());
+    bubble->setEnablePreview(enabled);
     if (m_bubbles->isReplaceBubble(bubble)) {
         auto oldBubble = m_bubbles->replaceBubble(bubble);
         if (oldBubble) {
@@ -180,6 +181,15 @@ void BubblePanel::setVisible(const bool visible)
         return;
     m_visible = visible;
     Q_EMIT visibleChanged();
+}
+
+bool BubblePanel::enablePreview(const QString &appId) const
+{
+    static const int EnablePreview = 3;
+    QVariant value;
+    QMetaObject::invokeMethod(m_notificationServer, "appValue", Qt::DirectConnection,
+                              Q_RETURN_ARG(QVariant, value), Q_ARG(const QString &, appId), Q_ARG(int, EnablePreview));
+    return value.toBool();
 }
 
 BubbleItem *BubblePanel::bubbleItem(int index)

--- a/panels/notification/bubble/bubblepanel.h
+++ b/panels/notification/bubble/bubblepanel.h
@@ -52,6 +52,7 @@ private:
     void onActionInvoked(qint64 id, uint bubbleId, const QString &actionId);
     void onBubbleClosed(qint64 id, uint bubbleId, uint reason);
     void setVisible(const bool visible);
+    bool enablePreview(const QString &appId) const;
 
     BubbleItem *bubbleItem(int index);
 

--- a/panels/notification/bubble/package/BubbleContent.qml
+++ b/panels/notification/bubble/package/BubbleContent.qml
@@ -173,7 +173,10 @@ D.Control {
                 icon.name: "window-close"
                 icon.width: 16
                 icon.height: 16
-                onClicked: Applet.delayProcess(bubble.index)
+                onClicked: {
+                    console.log("close process", bubble.index)
+                    Applet.close(bubble.index)
+                }
                 background: D.BoxPanel {
                     radius: closeBtn.height / 2
                 }

--- a/panels/notification/bubble/package/main.qml
+++ b/panels/notification/bubble/package/main.qml
@@ -71,7 +71,8 @@ Window {
         interactive: false
         verticalLayoutDirection: ListView.BottomToTop
         add: Transition {
-            NumberAnimation { properties: "x"; from: 100; duration: 500 }
+            id: addTrans
+            NumberAnimation { properties: "x"; from: addTrans.ViewTransition.item.width; duration: 600; easing.type: Easing.OutExpo }
         }
         delegate: Bubble {
             width: 360

--- a/panels/notification/center/NotifyView.qml
+++ b/panels/notification/center/NotifyView.qml
@@ -24,7 +24,7 @@ Control {
         id: view
         spacing: 10
         // activeFocusOnTab: true
-        // ScrollBar.vertical: ScrollBar { }
+        ScrollBar.vertical: ScrollBar { }
 
         model: root.notifyModel
         delegate: NotifyViewDelegate {

--- a/panels/notification/center/package/main.qml
+++ b/panels/notification/center/package/main.qml
@@ -40,12 +40,12 @@ Window {
     visible: Panel.visible
     flags: Qt.Tool
 
-    width: 380
+    width: 360 + notifyCenter.anchors.leftMargin + notifyCenter.anchors.rightMargin
     // height: 800
     DLayerShellWindow.layer: DLayerShellWindow.LayerOverlay
     DLayerShellWindow.anchors: DLayerShellWindow.AnchorRight | DLayerShellWindow.AnchorTop | DLayerShellWindow.AnchorBottom
     DLayerShellWindow.topMargin: windowMargin(0) + 10
-    DLayerShellWindow.rightMargin: windowMargin(1)
+    DLayerShellWindow.rightMargin: windowMargin(1) + 10
     DLayerShellWindow.bottomMargin: windowMargin(2) + 10
     ColorSelector.family: Palette.CrystalColor
     DWindow.enabled: true
@@ -73,11 +73,28 @@ Window {
         }
     }
 
+    // close Panel when click dock.
+    Connections {
+        target: DS.applet("org.deepin.ds.dock")
+        function onRequestClosePopup() {
+            Panel.close()
+        }
+    }
+
     NotifyCenter {
         id: notifyCenter
         anchors {
-            centerIn: parent
+            top: parent.top
+            left: parent.left
             margins: 10
+        }
+        Connections {
+            target: Panel
+            function onVisibleChanged() {
+                if (!Panel.visible) {
+                    notifyCenter.model.collapseAllApp()
+                }
+            }
         }
 
         width: 360

--- a/panels/notification/server/configs/org.deepin.dde.shell.notification.json
+++ b/panels/notification/server/configs/org.deepin.dde.shell.notification.json
@@ -102,7 +102,7 @@
       "visibility": "private"
     },
     "systemApps": {
-      "value": ["dde-control-center"],
+      "value": ["org.deepin.dde.control-center"],
       "serial": 0,
       "flags": [],
       "name": "system applications",

--- a/panels/notification/server/dbusadaptor.cpp
+++ b/panels/notification/server/dbusadaptor.cpp
@@ -15,6 +15,7 @@ DbusAdaptor::DbusAdaptor(QObject *parent)
 
 QStringList DbusAdaptor::GetCapabilities()
 {
+    qDebug() << "GetCapabilities";
     return manager()->GetCapabilities();
 }
 
@@ -27,11 +28,13 @@ uint DbusAdaptor::Notify(const QString &appName, uint replacesId, const QString 
 
 void DbusAdaptor::CloseNotification(uint id)
 {
+    qDebug() << "Close notification" << id;
     manager()->CloseNotification(id);
 }
 
 void DbusAdaptor::GetServerInformation(QString &name, QString &vendor, QString &version, QString &specVersion)
 {
+    qDebug() << "GetServerInformation";
     manager()->GetServerInformation(name, vendor, version, specVersion);
 }
 
@@ -41,7 +44,7 @@ NotificationManager *DbusAdaptor::manager() const
 }
 
 DDENotificationDbusAdaptor::DDENotificationDbusAdaptor(QObject *parent)
-    : DbusAdaptor(parent)
+    : QDBusAbstractAdaptor(parent)
 {
     setAutoRelaySignals(true);
 
@@ -49,6 +52,11 @@ DDENotificationDbusAdaptor::DDENotificationDbusAdaptor(QObject *parent)
     connect(manager(), &NotificationManager::AppAdded, this, &DDENotificationDbusAdaptor::AppRemoved);
     connect(manager(), &NotificationManager::AppInfoChanged, this, &DDENotificationDbusAdaptor::AppInfoChanged);
     connect(manager(), &NotificationManager::SystemInfoChanged, this, &DDENotificationDbusAdaptor::SystemInfoChanged);
+}
+
+NotificationManager *DDENotificationDbusAdaptor::manager() const
+{
+    return qobject_cast<NotificationManager *>(parent());
 }
 
 uint DDENotificationDbusAdaptor::recordCount() const

--- a/panels/notification/server/dbusadaptor.h
+++ b/panels/notification/server/dbusadaptor.h
@@ -28,7 +28,7 @@ public Q_SLOTS: // methods
     void GetServerInformation(QString &name, QString &vendor, QString &version, QString &specVersion);
 
 
-protected:
+private:
     NotificationManager *manager() const;
 
 Q_SIGNALS:
@@ -37,7 +37,7 @@ Q_SIGNALS:
     // todo void ActivationToken(uint id, const QString &activationToken)
 };
 
-class DDENotificationDbusAdaptor : public DbusAdaptor
+class DDENotificationDbusAdaptor : public QDBusAbstractAdaptor
 {
     Q_OBJECT
     Q_PROPERTY(uint recordCount READ recordCount NOTIFY RecordCountChanged)
@@ -58,6 +58,9 @@ public Q_SLOTS: // methods
 
     void SetSystemInfo(uint configItem, const QDBusVariant &value);
     QDBusVariant GetSystemInfo(uint configItem);
+
+private:
+    NotificationManager *manager() const;
 
 Q_SIGNALS:
     void AppAdded(const QString &appId);

--- a/panels/notification/server/notificationmanager.h
+++ b/panels/notification/server/notificationmanager.h
@@ -70,8 +70,10 @@ private:
     void emitRecordCountChanged();
 
     void pushPendingEntity(const NotifyEntity &entity, int expireTimeout);
-    void updateEntityProcessed(qint64 id);
+    void updateEntityProcessed(qint64 id, uint reason);
     void updateEntityProcessed(const NotifyEntity &entity);
+
+    QString appIdByAppName(const QString &appName) const;
 
 private slots:
     void onHandingPendingEntities();


### PR DESCRIPTION
Missing enablePreview's settings.
Get AppId by notification's AppName.
Close NotificationCenter when click dock.
Remove notification directly when close notification.
Change the margins of NotificationCenter.

task: https://pms.uniontech.com/task-view-365219.html
