### PR TITLE
fix: plugin crash on treeland

### DIFF
--- a/panels/dock/loadtrayplugins.cpp
+++ b/panels/dock/loadtrayplugins.cpp
@@ -121,6 +121,9 @@ void LoadTrayPlugins::setProcessEnv(QProcess *process)
     env.insert("QT_SCALE_FACTOR", QString::number(qApp->devicePixelRatio()));
     env.insert("D_DXCB_DISABLE_OVERRIDE_HIDPI", "1");
 
+    // TODO: use protocols to determine the environment instead of environment variables
+    env.remove("DDE_CURRENT_COMPOSITOR");
+
     process->setProcessEnvironment(env);
 }
 


### PR DESCRIPTION
plugin run in wayland compositor, while treelane set DDE_CURRENT_COMPOSITOR env. so it will call dtk treeland protocols and crash at that.

log: as title