### PR TITLE
feat: Move notification server to worker thread

### DIFF
--- a/panels/notification/center/NotifyItemContent.qml
+++ b/panels/notification/center/NotifyItemContent.qml
@@ -22,6 +22,8 @@ NotifyItem {
             right: parent.right
             rightMargin: -width / 2
         }
+        width: 20
+        height: 20
         contentItem: Loader {
             active: root.closeVisible || closePlaceHolder.hovered || closePlaceHolder.activeFocus || activeFocus
             sourceComponent: SettingActionButton {

--- a/panels/notification/center/notificationcenterpanel.cpp
+++ b/panels/notification/center/notificationcenterpanel.cpp
@@ -7,14 +7,50 @@
 #include "notificationcenterproxy.h"
 #include "notifyaccessor.h"
 #include "dbaccessor.h"
-#include "pluginfactory.h"
 
+#include <pluginfactory.h>
+#include <pluginloader.h>
+#include <applet.h>
+#include <containment.h>
+
+#include <QQueue>
 #include <QDBusConnection>
 #include <QDBusInterface>
 #include <QLoggingCategory>
 
+DS_USE_NAMESPACE
+
 namespace notification {
 Q_LOGGING_CATEGORY(notificationCenterLog, "dde.shell.notificationcenter")
+
+static const QString DDENotifyDBusServer = "org.deepin.dde.Notification1";
+static const QString DDENotifyDBusInterface = "org.deepin.dde.Notification1";
+static const QString DDENotifyDBusPath = "/org/deepin/dde/Notification1";
+
+static QDBusInterface notifyCenterInterface()
+{
+    return QDBusInterface(DDENotifyDBusServer, DDENotifyDBusPath, DDENotifyDBusInterface);
+}
+static QList<DApplet *> appletList(const QString &pluginId)
+{
+    QList<DApplet *> ret;
+    auto rootApplet = DPluginLoader::instance()->rootApplet();
+    auto root = qobject_cast<DContainment *>(rootApplet);
+
+    QQueue<DContainment *> containments;
+    containments.enqueue(root);
+    while (!containments.isEmpty()) {
+        DContainment *containment = containments.dequeue();
+        for (const auto applet : containment->applets()) {
+            if (auto item = qobject_cast<DContainment *>(applet)) {
+                containments.enqueue(item);
+            }
+            if (applet->pluginId() == pluginId)
+                ret << applet;
+        }
+    }
+    return ret;
+}
 
 NotificationCenterPanel::NotificationCenterPanel(QObject *parent)
     : DPanel(parent)
@@ -46,6 +82,27 @@ bool NotificationCenterPanel::init()
 
     auto accessor = notification::DBAccessor::instance();
     notifycenter::NotifyAccessor::instance()->setDataAccessor(accessor);
+
+    auto applets = appletList("org.deepin.ds.notificationserver");
+    bool valid = false;
+    if (!applets.isEmpty()) {
+        if (auto server = applets.first()) {
+            valid = QObject::connect(server,
+                                     SIGNAL(notificationStateChanged(qint64, int)),
+                                     notifycenter::NotifyAccessor::instance(),
+                                     SLOT(onReceivedRecordStateChanged(qint64, int)),
+                                     Qt::QueuedConnection);
+            notifycenter::NotifyAccessor::instance()->setDataUpdater(server);
+        }
+    } else {
+        // old interface by dbus
+        auto connection = QDBusConnection::sessionBus();
+        valid = connection.connect(DDENotifyDBusServer, DDENotifyDBusPath, DDENotifyDBusInterface,
+                                   "RecordAdded", this, SLOT(onReceivedRecord(const QString &)));
+    }
+    if (!valid) {
+        qWarning() << "NotifyConnection is invalid, and can't receive RecordAdded signal.";
+    }
 
     return true;
 }

--- a/panels/notification/center/notifyaccessor.h
+++ b/panels/notification/center/notifyaccessor.h
@@ -33,6 +33,7 @@ public:
     static NotifyAccessor *create(QQmlEngine *, QJSEngine *);
 
     void setDataAccessor(DataAccessor *accessor);
+    void setDataUpdater(QObject *updater);
 
     void invokeAction(const NotifyEntity &entity, const QString &actionId);
     void pinApplication(const QString &appName, bool pin);
@@ -73,6 +74,7 @@ private:
 
 private:
     DataAccessor *m_accessor = nullptr;
+    QObject *m_dataUpdater = nullptr;
     QStringList m_pinnedApps;
     QStringList m_apps;
     bool m_debugging = false;

--- a/panels/notification/server/notificationmanager.h
+++ b/panels/notification/server/notificationmanager.h
@@ -34,6 +34,10 @@ public:
     void notificationClosed(qint64 id, uint bubbleId, uint reason);
     void notificationReplaced(qint64 id);
 
+    void removeNotification(qint64 id);
+    void removeNotifications(const QString &appName);
+    void removeNotifications();
+
 Q_SIGNALS:
     // Standard Notifications dbus implementation
     void ActionInvoked(uint id, const QString &actionKey);

--- a/panels/notification/server/notificationsetting.h
+++ b/panels/notification/server/notificationsetting.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <QMutex>
 #include <QObject>
 #include <QTimer>
 #include <QVariantMap>
@@ -84,7 +85,9 @@ private:
     Dtk::Core::DConfig *m_impl = nullptr;
     QAbstractListModel *m_appAccessor = nullptr;
     QList<AppItem> m_appItems;
+    QMutex m_appItemsMutex;
     QVariantMap m_appsInfo;
+    QMutex m_appsInfoMutex;
     QVariantMap m_systemInfo;
 };
 

--- a/panels/notification/server/notifyserverapplet.h
+++ b/panels/notification/server/notifyserverapplet.h
@@ -14,6 +14,7 @@ class NotifyServerApplet : public DS_NAMESPACE::DApplet
     Q_OBJECT
 public:
     explicit NotifyServerApplet(QObject *parent = nullptr);
+    ~NotifyServerApplet() override;
 
     bool load() override;
     bool init() override;
@@ -26,9 +27,13 @@ public Q_SLOTS:
     void notificationClosed(qint64 id, uint bubbleId, uint reason);
     void notificationReplaced(qint64 id);
     QVariant appValue(const QString &appId, int configItem);
+    void removeNotification(qint64 id);
+    void removeNotifications(const QString &appName);
+    void removeNotifications();
 
 private:
     NotificationManager *m_manager = nullptr;
+    QThread *m_worker = nullptr;
 };
 
 }


### PR DESCRIPTION
Move notification server to other thread to avoid blocking gui
thread.
notification server has a DB connection to update DataBase, and
it provids update's interface for other applets, notification center
and notification bubble have a default DB connection, then only
query data by DBAccessor.
Add Mutex when getting app infomations, because those interface is
exposed by notification server.

task: https://pms.uniontech.com/task-view-365219.html
