### PR TITLE
chore: compatible with old notification center

### DIFF
--- a/panels/notification/center/CMakeLists.txt
+++ b/panels/notification/center/CMakeLists.txt
@@ -29,6 +29,8 @@ qt_add_qml_module(notificationcenterpanel
         notificationcenterpanel.cpp
         notificationcenterproxy.h
         notificationcenterproxy.cpp
+        notificationcenterdbusadaptor.h
+        notificationcenterdbusadaptor.cpp
         notifyaccessor.h
         notifyaccessor.cpp
         notifymodel.h

--- a/panels/notification/center/notificationcenterdbusadaptor.cpp
+++ b/panels/notification/center/notificationcenterdbusadaptor.cpp
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "notificationcenterdbusadaptor.h"
+#include "notificationcenterproxy.h"
+
+namespace notification {
+
+NotificationCenterDBusAdaptor::NotificationCenterDBusAdaptor(QObject *parent)
+    : QDBusAbstractAdaptor(parent)
+{
+    setAutoRelaySignals(true);
+}
+
+void NotificationCenterDBusAdaptor::Toggle()
+{
+    return impl()->Toggle();
+}
+
+void NotificationCenterDBusAdaptor::Show()
+{
+    return impl()->Show();
+}
+
+void NotificationCenterDBusAdaptor::Hide()
+{
+    return impl()->Hide();
+}
+
+NotificationCenterProxy *NotificationCenterDBusAdaptor::impl() const
+{
+    return qobject_cast<NotificationCenterProxy *>(parent());
+}
+
+} // notification

--- a/panels/notification/center/notificationcenterdbusadaptor.h
+++ b/panels/notification/center/notificationcenterdbusadaptor.h
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <QDBusVariant>
+#include <QDBusAbstractAdaptor>
+
+namespace notification {
+
+class NotificationCenterProxy;
+class NotificationCenterDBusAdaptor : public QDBusAbstractAdaptor
+{
+    Q_OBJECT
+    Q_CLASSINFO("D-Bus Interface", "org.deepin.dde.Widgets1")
+
+public:
+    explicit NotificationCenterDBusAdaptor(QObject *parent = nullptr);
+
+public Q_SLOTS: // methods
+    void Toggle();
+    void Show();
+    void Hide();
+
+private:
+    NotificationCenterProxy *impl() const;
+};
+
+} // notification

--- a/panels/notification/center/notificationcenterpanel.cpp
+++ b/panels/notification/center/notificationcenterpanel.cpp
@@ -5,6 +5,7 @@
 #include "notificationcenterpanel.h"
 
 #include "notificationcenterproxy.h"
+#include "notificationcenterdbusadaptor.h"
 #include "notifyaccessor.h"
 #include "dbaccessor.h"
 
@@ -17,6 +18,7 @@
 #include <QDBusConnection>
 #include <QDBusInterface>
 #include <QLoggingCategory>
+#include <QDBusConnectionInterface>
 
 DS_USE_NAMESPACE
 
@@ -77,6 +79,16 @@ bool NotificationCenterPanel::init()
         qWarning(notificationCenterLog) << QString("Can't register to the D-Bus object.");
         return false;
     }
+
+    // TODO compatible with old notification center
+    QDBusConnection connection = QDBusConnection::sessionBus();
+    connection.interface()->registerService("org.deepin.dde.Widgets1",
+                                            QDBusConnectionInterface::ReplaceExistingService,
+                                            QDBusConnectionInterface::AllowReplacement);
+    if (!connection.registerObject("/org/deepin/dde/Widgets1", m_proxy)) {
+        return false;
+    }
+    new NotificationCenterDBusAdaptor(m_proxy);
 
     DPanel::init();
 

--- a/panels/notification/osd/CMakeLists.txt
+++ b/panels/notification/osd/CMakeLists.txt
@@ -5,6 +5,8 @@
 add_library(osdpanel SHARED
     osdpanel.cpp
     osdpanel.h
+    osddbusadaptor.h
+    osddbusadaptor.cpp
     test.sh
 )
 

--- a/panels/notification/osd/osddbusadaptor.cpp
+++ b/panels/notification/osd/osddbusadaptor.cpp
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "osddbusadaptor.h"
+#include "osdpanel.h"
+
+namespace osd {
+
+OsdDBusAdaptor::OsdDBusAdaptor(QObject *parent)
+    : QDBusAbstractAdaptor(parent)
+{
+    setAutoRelaySignals(true);
+}
+
+void OsdDBusAdaptor::ShowOSD(const QString &text)
+{
+    return impl()->ShowOSD(text);
+}
+
+OsdPanel *OsdDBusAdaptor::impl() const
+{
+    return qobject_cast<OsdPanel *>(parent());
+}
+
+} // osd

--- a/panels/notification/osd/osddbusadaptor.h
+++ b/panels/notification/osd/osddbusadaptor.h
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <QDBusVariant>
+#include <QDBusAbstractAdaptor>
+
+namespace osd {
+
+class OsdPanel;
+class OsdDBusAdaptor : public QDBusAbstractAdaptor
+{
+    Q_OBJECT
+    Q_CLASSINFO("D-Bus Interface", "org.deepin.dde.Osd1")
+
+public:
+    explicit OsdDBusAdaptor(QObject *parent = nullptr);
+
+public Q_SLOTS: // methods
+    void ShowOSD(const QString &text);
+
+private:
+    OsdPanel *impl() const;
+};
+
+} // osd

--- a/panels/notification/osd/osdpanel.cpp
+++ b/panels/notification/osd/osdpanel.cpp
@@ -4,7 +4,9 @@
 
 #include "osdpanel.h"
 
+#include "osddbusadaptor.h"
 #include "pluginfactory.h"
+#include <QDBusConnectionInterface>
 
 #include <QDBusConnection>
 #include <QTimer>
@@ -34,6 +36,14 @@ bool OsdPanel::init()
         return false;
     }
 
+    bus.interface()->registerService("org.deepin.dde.Osd1",
+                                            QDBusConnectionInterface::ReplaceExistingService,
+                                            QDBusConnectionInterface::AllowReplacement);
+    if (!bus.registerObject("/", "org.deepin.dde.Osd1", this, QDBusConnection::ExportAllSlots)) {
+        return false;
+    }
+    new OsdDBusAdaptor(this);
+
     m_osdTimer = new QTimer(this);
     m_osdTimer->setInterval(m_interval);
     m_osdTimer->setSingleShot(true);
@@ -53,7 +63,7 @@ bool OsdPanel::visible() const
     return m_visible;
 }
 
-void OsdPanel::showText(const QString &text)
+void OsdPanel::ShowOSD(const QString &text)
 {
     qCInfo(osdLog()) << "show text" << text;
     m_osdTimer->setInterval(text == "SwitchWM3D" ? 2000 : 1000);

--- a/panels/notification/osd/osdpanel.h
+++ b/panels/notification/osd/osdpanel.h
@@ -14,7 +14,7 @@ class OsdPanel : public DS_NAMESPACE::DPanel
     Q_OBJECT
     Q_PROPERTY(bool visible READ visible NOTIFY visibleChanged FINAL)
     Q_PROPERTY(QString osdType READ osdType NOTIFY osdTypeChanged FINAL)
-    Q_CLASSINFO("D-Bus Interface", "org.deepin.osdService")
+    Q_CLASSINFO("D-Bus Interface", "org.deepin.dde.shell.osd")
 public:
     explicit OsdPanel(QObject *parent = nullptr);
 
@@ -25,7 +25,7 @@ public:
     QString osdType() const;
 
 public Q_SLOTS:
-    void showText(const QString &text);
+    void ShowOSD(const QString &text);
 
 Q_SIGNALS:
     void visibleChanged();


### PR DESCRIPTION
Register old dbus service to response Shortcut keys.
also we can replace the action in dde-daemon,
https://github.com/linuxdeepin/dde-daemon/blob/master/misc/dde-daemon/keybinding/system_actions.json#L88

task: https://pms.uniontech.com/task-view-365219.html
