### PR TITLE
fix: use proper launchpad DnD MIME data

### DIFF
--- a/panels/dock/taskmanager/package/TaskManager.qml
+++ b/panels/dock/taskmanager/package/TaskManager.qml
@@ -115,10 +115,10 @@ ContainmentItem {
         DropArea {
             id: launcherDndDropArea
             anchors.fill: parent
-            keys: ["text/x-dde-launcher-dnd-desktopId"]
+            keys: ["text/x-dde-dock-dnd-appid"]
             property string launcherDndDesktopId: ""
             onEntered: function(drag) {
-                let desktopId = drag.getDataAsString("text/x-dde-launcher-dnd-desktopId")
+                let desktopId = drag.getDataAsString("text/x-dde-dock-dnd-appid")
                 launcherDndDesktopId = taskmanager.Applet.desktopIdToAppId(desktopId)
                 if (taskmanager.Applet.requestDockByDesktopId(desktopId) === false) {
                     launcherDndDesktopId = ""


### PR DESCRIPTION
处理Launchpad拖拽固定到Dock时，使用正确的MIME数据
此提交修复占位包需求的遗留问题

此PR目标为维护分支，与 linuxdeepin/dde-launchpad#449 互相依赖。

Log:
Bug: https://pms.uniontech.com/bug-view-279155.html