### PR TITLE
feat: add AppletBridge to connect applets

### DIFF
--- a/example/applet-example-data/exampleapplet.cpp
+++ b/example/applet-example-data/exampleapplet.cpp
@@ -25,7 +25,7 @@ bool ExampleApplet::load()
 {
     DCORE_USE_NAMESPACE;
     std::unique_ptr<DConfig> config(DConfig::create("org.deepin.dde.shell", "org.deepin.ds.example"));
-    return config->value("loadAppletExampleData").toBool();
+    return config->value("loadAppletExampleData", true).toBool();
 }
 
 bool ExampleApplet::init()
@@ -54,6 +54,11 @@ void ExampleApplet::setUserData(bool newUserData)
         return;
     m_userData = newUserData;
     emit userDataChanged();
+}
+
+QString ExampleApplet::call(const QString &id)
+{
+    return id + QString("-done");
 }
 
 D_APPLET_CLASS(ExampleApplet)

--- a/example/applet-example-data/exampleapplet.h
+++ b/example/applet-example-data/exampleapplet.h
@@ -25,9 +25,12 @@ public:
     bool userData() const;
     void setUserData(bool newUserData);
 
+    Q_INVOKABLE QString call(const QString &id);
+
 Q_SIGNALS:
     void mainTextChanged();
     void userDataChanged();
+    void sendSignal(const QString &id);
 private:
     QString m_mainText;
     bool m_userData;

--- a/example/containment-example/examplecontainment.cpp
+++ b/example/containment-example/examplecontainment.cpp
@@ -6,6 +6,7 @@
 
 #include "pluginfactory.h"
 #include "pluginloader.h"
+#include "appletproxy.h"
 #include <DConfig>
 #include <QJsonDocument>
 #include <QJsonArray>
@@ -65,6 +66,11 @@ bool ExampleContainment::load()
     setAppletData(data);
 
     return DApplet::load();
+}
+
+QObject *ExampleContainment::createProxyMeta()
+{
+    return new ExampleAppletProxy(this);
 }
 
 DPluginMetaData ExampleContainment::targetPlugin() const

--- a/example/containment-example/examplecontainment.h
+++ b/example/containment-example/examplecontainment.h
@@ -8,6 +8,21 @@
 
 DS_USE_NAMESPACE
 
+class ExampleAppletProxy : public QObject
+{
+    Q_OBJECT
+public:
+    ExampleAppletProxy(QObject *parent = nullptr)
+        : QObject(parent)
+    {
+
+    }
+    Q_INVOKABLE QString call(const QString &id)
+    {
+        return id + QString("-done");
+    }
+};
+
 class ExampleContainment : public DContainment
 {
     Q_OBJECT
@@ -16,6 +31,8 @@ public:
     ~ExampleContainment();
 
     virtual bool load() override;
+protected:
+    virtual QObject *createProxyMeta() override;
 private:
     DPluginMetaData targetPlugin() const;
 };

--- a/example/panel-example/examplepanel.cpp
+++ b/example/panel-example/examplepanel.cpp
@@ -5,6 +5,7 @@
 #include "examplepanel.h"
 
 #include "pluginfactory.h"
+#include "appletbridge.h"
 
 ExamplePanel::ExamplePanel(QObject *parent)
     : DPanel(parent)
@@ -19,12 +20,46 @@ bool ExamplePanel::load()
 bool ExamplePanel::init()
 {
     DPanel::init();
+
+    DAppletBridge bridge("org.deepin.ds.example.applet-data");
+
+    qDebug() << "It's state of the bridge:" << bridge.isValid();
+    if (auto applet = bridge.applet()) {
+        qDebug() << "Get property:" << applet->property("mainText");
+        QString id("call");
+        qDebug() << "Invoke argument:" << id;
+        qDebug() << "Invoke method staus:" << QMetaObject::invokeMethod(applet, "call", Qt::DirectConnection,
+                                  Q_RETURN_ARG(QString, id), Q_ARG(const QString&, id));
+        qDebug() << "Invoked returd value:" << id;
+
+        QObject::connect(applet, SIGNAL(sendSignal(const QString &)), SLOT(onReceivedSignal(const QString &)));
+
+        QMetaObject::invokeMethod(applet, "sendSignal", Qt::DirectConnection, Q_ARG(const QString&, id));
+    }
+
+    {
+        DAppletBridge bridge("org.deepin.ds.example.containment");
+        qDebug() << "Customize MetaObject of the applet:" << bridge.isValid();
+        if (auto applet = bridge.applet()) {
+            QString id("call");
+            qDebug() << "Invoke argument:" << id;
+            qDebug() << "Invoke method staus:" << QMetaObject::invokeMethod(applet, "call", Qt::DirectConnection,
+                                      Q_RETURN_ARG(QString, id), Q_ARG(const QString&, id));
+            qDebug() << "Invoked returd value:" << id;
+        }
+    }
+
     QObject::connect(this, &DApplet::rootObjectChanged, this, [this]() {
         Q_ASSERT(rootObject());
         Q_ASSERT(window());
     });
 
     return true;
+}
+
+void ExamplePanel::onReceivedSignal(const QString &id)
+{
+    qDebug() << "Received signal:" << id;
 }
 
 D_APPLET_CLASS(ExamplePanel)

--- a/example/panel-example/examplepanel.h
+++ b/example/panel-example/examplepanel.h
@@ -17,4 +17,8 @@ public:
     virtual bool load() override;
 
     virtual bool init() override;
+
+private slots:
+    void onReceivedSignal(const QString &id);
+
 };

--- a/frame/CMakeLists.txt
+++ b/frame/CMakeLists.txt
@@ -11,6 +11,8 @@ set(PUBLIC_HEADERS
     appletdata.h
     containment.h
     panel.h
+    appletproxy.h
+    appletbridge.h
     qmlengine.h
     layershell/dlayershellwindow.h
     dsutility.h
@@ -21,6 +23,8 @@ set(PRIVATE_HEADERS
     private/containment_p.h
     private/panel_p.h
     private/appletitem_p.h
+    private/appletproxy_p.h
+    private/appletbridge_p.h
     private/dsqmlglobal_p.h
     layershell/qwaylandlayershellsurface_p.h
     layershell/qwaylandlayershellintegration_p.h
@@ -50,6 +54,8 @@ add_library(dde-shell-frame SHARED
     applet.cpp
     containment.cpp
     panel.cpp
+    appletproxy.cpp
+    appletbridge.cpp
     appletitem.cpp
     containmentitem.cpp
     qmlengine.cpp

--- a/frame/applet.cpp
+++ b/frame/applet.cpp
@@ -4,6 +4,7 @@
 
 #include "applet.h"
 #include "private/applet_p.h"
+#include "private/appletproxy_p.h"
 
 #include <QLoggingCategory>
 #include <QUuid>
@@ -24,6 +25,16 @@ DAppletPrivate::~DAppletPrivate()
     if (m_rootObject) {
         m_rootObject->deleteLater();
     }
+}
+
+DAppletProxy *DAppletPrivate::appletProxy() const
+{
+    if (!m_proxy) {
+        auto meta = const_cast<DAppletPrivate *>(this)->q_func()->createProxyMeta();
+        const_cast<DAppletPrivate *>(this)->m_proxy =
+                new DAppletMetaProxy(meta, const_cast<DAppletPrivate *>(this)->q_func());
+    }
+    return m_proxy;
 }
 
 DApplet::DApplet(QObject *parent)
@@ -107,6 +118,12 @@ bool DApplet::load()
 bool DApplet::init()
 {
     return true;
+}
+
+QObject *DApplet::createProxyMeta()
+{
+    D_DC(DApplet);
+    return this;
 }
 
 DS_END_NAMESPACE

--- a/frame/applet.h
+++ b/frame/applet.h
@@ -17,6 +17,7 @@ DS_BEGIN_NAMESPACE
  */
 class DAppletPrivate;
 class DPluginLoader;
+class DAppletBridge;
 class DS_SHARE DApplet : public QObject, public DTK_CORE_NAMESPACE::DObject
 {
     Q_OBJECT
@@ -26,6 +27,7 @@ class DS_SHARE DApplet : public QObject, public DTK_CORE_NAMESPACE::DObject
     Q_PROPERTY(QObject *rootObject READ rootObject NOTIFY rootObjectChanged)
     D_DECLARE_PRIVATE(DApplet)
     friend class DPluginLoader;
+    friend class DAppletBridge;
 public:
     explicit DApplet(QObject *parent = nullptr);
     virtual ~DApplet() override;
@@ -48,6 +50,7 @@ Q_SIGNALS:
 
 protected:
     explicit DApplet(DAppletPrivate &dd, QObject *parent = nullptr);
+    virtual QObject *createProxyMeta();
 
 private:
     void setMetaData(const DPluginMetaData &metaData);

--- a/frame/appletbridge.cpp
+++ b/frame/appletbridge.cpp
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "appletbridge.h"
+#include "containment.h"
+#include "private/appletbridge_p.h"
+#include "private/applet_p.h"
+
+#include "pluginloader.h"
+#include <QQueue>
+
+DS_BEGIN_NAMESPACE
+
+DAppletBridgePrivate::DAppletBridgePrivate(DAppletBridge *qq)
+    : DTK_CORE_NAMESPACE::DObjectPrivate(qq)
+{
+}
+
+DAppletBridgePrivate::~DAppletBridgePrivate()
+{
+}
+
+QList<DApplet *> DAppletBridgePrivate::applets() const
+{
+    QList<DApplet *> applets;
+    auto rootApplet = DPluginLoader::instance()->rootApplet();
+    auto root = qobject_cast<DContainment *>(rootApplet);
+
+    QQueue<DContainment *> containments;
+    containments.enqueue(root);
+    while (!containments.isEmpty()) {
+        DContainment *containment = containments.dequeue();
+        for (const auto applet : containment->applets()) {
+            if (auto item = qobject_cast<DContainment *>(applet)) {
+                containments.enqueue(item);
+            }
+            if (applet->pluginId() == m_pluginId)
+                applets << applet;
+        }
+    }
+    return applets;
+}
+
+DAppletBridge::DAppletBridge(const QString &pluginId, QObject *parent)
+    : DAppletBridge(*new DAppletBridgePrivate(this), parent)
+{
+    d_func()->m_pluginId = pluginId;
+}
+
+DAppletBridge::DAppletBridge(DAppletBridgePrivate &dd, QObject *parent)
+    : QObject(parent)
+    , DObject(dd)
+{
+}
+
+DAppletBridge::~DAppletBridge()
+{
+}
+
+bool DAppletBridge::isValid() const
+{
+    D_DC(DAppletBridge);
+    const auto plugin = DPluginLoader::instance()->plugin(d->m_pluginId);
+    return plugin.isValid();
+}
+
+QList<DAppletProxy *> DAppletBridge::applets() const
+{
+    D_DC(DAppletBridge);
+    if (!isValid())
+        return {};
+    QList<DAppletProxy *> ret;
+    for (const auto item : d->applets()) {
+        if (auto proxy = item->d_func()->appletProxy()) {
+            ret << proxy;
+        }
+    }
+    return ret;
+}
+
+DAppletProxy *DAppletBridge::applet() const
+{
+    D_DC(DAppletBridge);
+    if (!isValid())
+        return {};
+    for (const auto item : d->applets()) {
+        if (auto proxy = item->d_func()->appletProxy()) {
+            return proxy;
+        }
+    }
+    return nullptr;
+}
+
+DS_END_NAMESPACE

--- a/frame/appletbridge.h
+++ b/frame/appletbridge.h
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include "dsglobal.h"
+#include "appletproxy.h"
+
+#include <QObject>
+#include <DObject>
+
+DS_BEGIN_NAMESPACE
+/**
+ * @brief Interacting with other applets
+ */
+class DAppletBridgePrivate;
+class DS_SHARE DAppletBridge : public QObject, public DTK_CORE_NAMESPACE::DObject
+{
+    Q_OBJECT
+    D_DECLARE_PRIVATE(DAppletBridge)
+public:
+    explicit DAppletBridge(const QString &pluginId, QObject *parent = nullptr);
+    virtual ~DAppletBridge() override;
+
+    bool isValid() const;
+
+    QList<DAppletProxy *> applets() const;
+    DAppletProxy *applet() const;
+
+protected:
+    explicit DAppletBridge(DAppletBridgePrivate &dd, QObject *parent = nullptr);
+};
+
+DS_END_NAMESPACE

--- a/frame/appletproxy.cpp
+++ b/frame/appletproxy.cpp
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "appletproxy.h"
+#include "private/appletproxy_p.h"
+#include "applet.h"
+
+#include <QMetaMethod>
+
+DS_BEGIN_NAMESPACE
+
+DAppletProxyPrivate::DAppletProxyPrivate(DAppletProxy *qq)
+    : DTK_CORE_NAMESPACE::DObjectPrivate(qq)
+{
+}
+
+DAppletProxyPrivate::~DAppletProxyPrivate()
+{
+}
+
+DAppletProxy::DAppletProxy(QObject *parent)
+    : DAppletProxy(*new DAppletProxyPrivate(this), parent)
+{
+}
+
+DAppletProxy::DAppletProxy(DAppletProxyPrivate &dd, QObject *parent)
+    : QObject(parent)
+    , DObject(dd)
+{
+
+}
+
+DAppletProxy::~DAppletProxy()
+{
+}
+
+class DAppletMetaProxyPrivate : public DAppletProxyPrivate
+{
+public:
+    DAppletMetaProxyPrivate(DAppletMetaProxy *qq)
+        : DAppletProxyPrivate(qq)
+    {
+    }
+    QPointer<QObject> meta;
+};
+
+DAppletMetaProxy::DAppletMetaProxy(QObject *meta, QObject *parent)
+    : DAppletProxy(*new DAppletMetaProxyPrivate(this), parent)
+{
+    d_func()->meta = meta;
+}
+
+const QMetaObject *DAppletMetaProxy::metaObject() const
+{
+    D_DC(DAppletMetaProxy);
+    if (d->meta)
+        return d->meta->metaObject();
+    return &DAppletProxy::staticMetaObject;
+}
+
+void *DAppletMetaProxy::qt_metacast(const char *clname)
+{
+    D_D(DAppletMetaProxy);
+    if (d->meta)
+        return static_cast<void*>(const_cast<QObject*>(d->meta.data()));
+    if (!clname) return nullptr;
+    return DAppletProxy::qt_metacast(clname);
+}
+
+int DAppletMetaProxy::qt_metacall(QMetaObject::Call c, int id, void **argv)
+{
+    D_D(DAppletMetaProxy);
+    if (d->meta) {
+        auto _id = d->meta->qt_metacall(c, id, argv);
+        if (_id >= 0)
+            return _id;
+    }
+    return DAppletProxy::qt_metacall(c, id, argv);
+}
+
+DS_END_NAMESPACE

--- a/frame/appletproxy.h
+++ b/frame/appletproxy.h
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include "dsglobal.h"
+
+#include <QObject>
+#include <DObject>
+
+DS_BEGIN_NAMESPACE
+/**
+ * @brief Expose own interfaces for other applets.
+ */
+class DAppletProxyPrivate;
+class DS_SHARE DAppletProxy : public QObject, public DTK_CORE_NAMESPACE::DObject
+{
+    D_DECLARE_PRIVATE(DAppletProxy)
+public:
+    ~DAppletProxy() override;
+
+protected:
+    explicit DAppletProxy(QObject *parent = nullptr);
+    explicit DAppletProxy(DAppletProxyPrivate &dd, QObject *parent = nullptr);
+};
+
+DS_END_NAMESPACE

--- a/frame/private/applet_p.h
+++ b/frame/private/applet_p.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "applet.h"
+#include "appletproxy.h"
 
 #include <dobject_p.h>
 #include <QVariant>
@@ -20,9 +21,12 @@ public:
     explicit DAppletPrivate(DApplet *qq);
     ~DAppletPrivate() override;
 
+    DAppletProxy *appletProxy() const;
+
     DPluginMetaData m_metaData;
     DAppletData m_data;
     QPointer<QObject> m_rootObject;
+    DAppletProxy *m_proxy = nullptr;
 
     D_DECLARE_PUBLIC(DApplet);
 };

--- a/frame/private/appletbridge_p.h
+++ b/frame/private/appletbridge_p.h
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include "appletbridge.h"
+#include "applet.h"
+
+#include <dobject_p.h>
+#include <QObject>
+
+DS_BEGIN_NAMESPACE
+/**
+ * @brief
+ */
+class DAppletBridgePrivate : public DTK_CORE_NAMESPACE::DObjectPrivate
+{
+public:
+    explicit DAppletBridgePrivate(DAppletBridge *qq);
+    ~DAppletBridgePrivate() override;
+
+    QList<DApplet *> applets() const;
+
+    QString m_pluginId;
+
+    D_DECLARE_PUBLIC(DAppletBridge);
+};
+
+DS_END_NAMESPACE

--- a/frame/private/appletproxy_p.h
+++ b/frame/private/appletproxy_p.h
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include "appletproxy.h"
+
+#include <dobject_p.h>
+#include <QVariant>
+#include <QPointer>
+
+DS_BEGIN_NAMESPACE
+/**
+ * @brief
+ */
+class DAppletProxyPrivate : public DTK_CORE_NAMESPACE::DObjectPrivate
+{
+public:
+    DAppletProxyPrivate(DAppletProxy *qq);
+    ~DAppletProxyPrivate() override;
+
+    D_DECLARE_PUBLIC(DAppletProxy);
+};
+
+class DAppletMetaProxyPrivate;
+class DAppletMetaProxy : public DAppletProxy
+{
+    D_DECLARE_PRIVATE(DAppletMetaProxy)
+public:
+    explicit DAppletMetaProxy(QObject *meta, QObject *parent);
+
+    virtual const QMetaObject *metaObject() const override;
+    virtual void *qt_metacast(const char *clname) override;
+    virtual int qt_metacall(QMetaObject::Call c, int id, void **argv) override;
+};
+
+DS_END_NAMESPACE


### PR DESCRIPTION
We add AppletProxy to export Applet's signals and slots.
AppletMetaProxy as QObject's router for signals and slots.

task: https://pms.uniontech.com/task-view-365219.html
