### PR TITLE
任务栏识别纠正

### DIFF
--- a/applets/CMakeLists.txt
+++ b/applets/CMakeLists.txt
@@ -4,3 +4,4 @@
 
 add_subdirectory(dde-am)
 add_subdirectory(dde-appearance)
+add_subdirectory(dde-apps)

--- a/applets/dde-apps/CMakeLists.txt
+++ b/applets/dde-apps/CMakeLists.txt
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+find_package(Qt${QT_VERSION_MAJOR} ${REQUIRED_QT_VERSION} REQUIRED COMPONENTS DBus)
+find_package(DDEApplicationManager REQUIRED)
+find_package(yaml-cpp REQUIRED)
+
+set_source_files_properties(
+    ${DDE_APPLICATION_MANAGER_DBUS_API_DIR}/org.desktopspec.ApplicationManager1.Application.xml
+    PROPERTIES  INCLUDE api/types/am.h
+                CLASSNAME Application
+)
+
+set_source_files_properties(
+    ${DDE_APPLICATION_MANAGER_DBUS_API_DIR}/org.desktopspec.ApplicationManager1.xml
+    PROPERTIES  INCLUDE api/types/am.h
+                CLASSNAME ApplicationManager
+)
+
+set_source_files_properties(
+    ${DDE_APPLICATION_MANAGER_DBUS_API_DIR}/org.desktopspec.ObjectManager1.xml
+    PROPERTIES  INCLUDE api/types/am.h
+                CLASSNAME ObjectManager
+)
+
+qt_add_dbus_interfaces(
+    DBUS_INTERFACES
+    ${DDE_APPLICATION_MANAGER_DBUS_API_DIR}/org.desktopspec.ApplicationManager1.Application.xml
+    ${DDE_APPLICATION_MANAGER_DBUS_API_DIR}/org.desktopspec.ApplicationManager1.xml
+    ${DDE_APPLICATION_MANAGER_DBUS_API_DIR}/org.desktopspec.ObjectManager1.xml
+)
+
+
+add_library(dde-apps SHARED ${DBUS_INTERFACES}
+    amappitem.cpp
+    amappitem.h
+    amappitemmodel.cpp
+    amappitemmodel.h
+    appgroup.cpp
+    appgroup.h
+    appgroupmanager.cpp
+    appgroupmanager.h
+    appitem.cpp
+    appitem.h
+    appitemmodel.cpp
+    appitemmodel.h
+    appsapplet.cpp
+    appsapplet.h
+    appsdockedhelper.cpp
+    appsdockedhelper.h
+    appslaunchtimes.cpp
+    appslaunchtimes.h
+    categoryutils.cpp
+    categoryutils.h
+)
+
+target_link_libraries(dde-apps PRIVATE
+    dde-shell-frame
+    Qt${QT_VERSION_MAJOR}::Concurrent
+    yaml-cpp
+)
+
+ds_install_package(PACKAGE org.deepin.ds.dde-apps TARGET dde-apps)
+dtk_add_config_meta_files(APPID org.deepin.dde.shell FILES configs/org.deepin.ds.dde-apps.json)

--- a/applets/dde-apps/amappitem.cpp
+++ b/applets/dde-apps/amappitem.cpp
@@ -1,0 +1,129 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "amappitem.h"
+#include "appitem.h"
+#include "appitemmodel.h"
+#include "applicationinterface.h"
+#include "categoryutils.h"
+
+#include <DUtil>
+
+namespace apps
+{
+// AM static string
+static const QString AM_DBUS_SERVICE = "org.desktopspec.ApplicationManager1";
+static const QString DESKTOP_ENTRY_ICON_KEY = "Desktop Entry";
+static const QString DEFAULT_KEY = "default";
+static QString locale = QLocale::system().name();
+
+AMAppItem::AMAppItem(const QDBusObjectPath &path, QObject *parent)
+    : AppItem(DUtil::unescapeFromObjectPath(path.path().split('/').last()))
+    , Application(AM_DBUS_SERVICE, path.path(), QDBusConnection::sessionBus(), parent)
+{
+}
+
+AMAppItem::AMAppItem(const QDBusObjectPath &path, const ObjectInterfaceMap &source, QObject *parent)
+    : AMAppItem(path, parent)
+{
+    const QVariantMap appInfo = source.value("org.desktopspec.ApplicationManager1.Application");
+    if (appInfo.isEmpty())
+        return;
+
+    auto name = getLocaleOrDefaultValue(qdbus_cast<QStringMap>(appInfo.value(u8"Name")), locale, DEFAULT_KEY);
+    auto genericName = getLocaleOrDefaultValue(qdbus_cast<QStringMap>(appInfo.value(u8"GenericName")), locale, DEFAULT_KEY);
+    auto xDeepinVendor = appInfo.value(u8"X_Deepin_Vendor").toString();
+
+    if (QStringLiteral("deepin") == xDeepinVendor && !genericName.isEmpty()) {
+        AppItem::setAppName(genericName);
+    } else {
+        AppItem::setAppName(name);
+    }
+
+    auto iconName = getLocaleOrDefaultValue(qdbus_cast<QStringMap>(appInfo.value(u8"Icons")), DESKTOP_ENTRY_ICON_KEY, "");
+    AppItem::setAppIconName(iconName);
+
+    auto noDisplay = appInfo.value(u8"NoDisplay").toBool();
+    AppItem::setNoDisPlay(noDisplay);
+
+    auto categories = appInfo.value(u8"Categories").toStringList();
+    AppItem::setDDECategories(AppItemModel::DDECategories(CategoryUtils::parseBestMatchedCategory(categories)));
+
+    auto lastLaunchedTime = appInfo.value(u8"LastLaunchedTime").toULongLong();
+    AppItem::setLastLaunchedTime(lastLaunchedTime);
+
+    auto installedTime = appInfo.value(u8"InstalledTime").toULongLong();
+    AppItem::setInstalledTime(installedTime);
+
+    auto startUpWMClass = appInfo.value(u8"StartupWMClass").toString();
+    AppItem::setStartupWMclass(startUpWMClass);
+
+    auto autoStart = appInfo.value(u8"AutoStart").toBool();
+    AppItem::setAutoStart(autoStart);
+
+    auto isOnDesktop = appInfo.value(u8"OnDesktop").toBool();
+    AppItem::setOnDesktop(isOnDesktop);
+}
+
+void AMAppItem::launch(const QString &action, const QStringList &fields, const QVariantMap &options)
+{
+    Application::Launch(action, fields, options);
+    AppItem::launch();
+}
+
+void AMAppItem::setAutoStart(bool autoStart)
+{
+    Application::setAutoStart(autoStart);
+    AppItem::setAutoStart(autoStart);
+}
+
+void AMAppItem::setOnDesktop(bool on)
+{
+    if (on) {
+        Application::SendToDesktop();
+    } else {
+        Application::RemoveFromDesktop();
+    }
+    AppItem::setOnDesktop(on);
+}
+
+QString AMAppItem::getLocaleOrDefaultValue(const QStringMap &value, const QString &targetKey, const QString &fallbackKey)
+{
+    auto targetValue = value.value(targetKey);
+    auto fallbackValue = value.value(fallbackKey);
+    return !targetValue.isEmpty() ? targetValue : fallbackValue;
+}
+
+void AMAppItem::onPropertyChanged(const QDBusMessage &msg)
+{
+    QList<QVariant> arguments = msg.arguments();
+    if (3 != arguments.count())
+        return;
+
+    QString interfaceName = msg.arguments().at(0).toString();
+    if (interfaceName != QStringLiteral("org.desktopspec.ApplicationManager1.Application"))
+        return;
+
+    // AM send changed signal together
+    auto name = getLocaleOrDefaultValue(Application::name(), locale, DEFAULT_KEY);
+    auto genericName = getLocaleOrDefaultValue(Application::genericName(), locale, DEFAULT_KEY);
+    auto xDeepinVendor = Application::x_Deepin_Vendor();
+    if (QStringLiteral("deepin") == xDeepinVendor && !genericName.isEmpty()) {
+        AppItem::setAppName(genericName);
+    } else {
+        AppItem::setAppName(name);
+    }
+
+    auto iconName = getLocaleOrDefaultValue(Application::icons(), DESKTOP_ENTRY_ICON_KEY, "");
+    AppItem::setAppIconName(iconName);
+
+    AppItem::setNoDisPlay(Application::noDisplay());
+    AppItem::setDDECategories(AppItemModel::DDECategories(CategoryUtils::parseBestMatchedCategory(Application::categories())));
+    AppItem::setLastLaunchedTime(Application::lastLaunchedTime());
+    AppItem::setInstalledTime(Application::installedTime());
+    AppItem::setStartupWMclass(Application::startupWMClass());
+    AppItem::setAutoStart(Application::autoStart());
+    AppItem::setOnDesktop(Application::isOnDesktop());
+}
+}

--- a/applets/dde-apps/amappitem.h
+++ b/applets/dde-apps/amappitem.h
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include "appitem.h"
+#include "applicationinterface.h"
+
+namespace apps
+{
+class AMAppItem : public Application, public AppItem
+{
+    Q_OBJECT
+
+public:
+    explicit AMAppItem(const QDBusObjectPath &path, QObject *parent = nullptr);
+    explicit AMAppItem(const QDBusObjectPath &path, const ObjectInterfaceMap &source, QObject *parent = nullptr);
+
+    void launch(const QString &action = {}, const QStringList &fields = {}, const QVariantMap &options = {}) override;
+    void setAutoStart(bool autoStart) override;
+    void setOnDesktop(bool on) override;
+
+private:
+    QString getLocaleOrDefaultValue(const QStringMap &value, const QString &targetKey, const QString &fallbackKey);
+
+private Q_SLOTS:
+    void onPropertyChanged(const QDBusMessage &msg);
+};
+}

--- a/applets/dde-apps/amappitemmodel.cpp
+++ b/applets/dde-apps/amappitemmodel.cpp
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "amappitemmodel.h"
+#include "amappitem.h"
+#include "appgroupmanager.h"
+#include "appitemmodel.h"
+#include "objectmanager1interface.h"
+
+#include <DUtil>
+#include <QtConcurrent>
+#include <tuple>
+
+Q_LOGGING_CATEGORY(appsLog, "dde.shell.dde-apps.amappitemmodel")
+
+namespace apps
+{
+AMAppItemModel::AMAppItemModel(QObject *parent)
+    : AppItemModel(parent)
+    , m_manager(new ObjectManager("org.desktopspec.ApplicationManager1", "/org/desktopspec/ApplicationManager1", QDBusConnection::sessionBus()))
+{
+    qRegisterMetaType<ObjectInterfaceMap>();
+    qDBusRegisterMetaType<ObjectInterfaceMap>();
+    qRegisterMetaType<ObjectMap>();
+    qDBusRegisterMetaType<ObjectMap>();
+    qDBusRegisterMetaType<QStringMap>();
+    qRegisterMetaType<QStringMap>();
+    qRegisterMetaType<PropMap>();
+    qDBusRegisterMetaType<PropMap>();
+    qDBusRegisterMetaType<QDBusObjectPath>();
+
+    connect(m_manager, &ObjectManager::InterfacesAdded, this, [this](const QDBusObjectPath &objPath, ObjectInterfaceMap interfacesAndProperties) {
+        auto desktopId = DUtil::unescapeFromObjectPath(objPath.path().split('/').last());
+        if (!match(index(0, 0), AppItemModel::DesktopIdRole, desktopId).isEmpty()) {
+            qCWarning(appsLog()) << "desktopId: " << desktopId << " already contains";
+            return;
+        }
+        appendRow(new AMAppItem(objPath, interfacesAndProperties));
+    });
+
+    connect(m_manager, &ObjectManager::InterfacesRemoved, this, [this](const QDBusObjectPath &objPath, const QStringList &interfaces) {
+        auto desktopId = DUtil::unescapeFromObjectPath(objPath.path().split('/').last());
+        auto res = match(index(0, 0), AppItemModel::DesktopIdRole, desktopId);
+        if (res.isEmpty()) {
+            qCWarning(appsLog()) << "failed find desktopId: " << desktopId;
+            return;
+        }
+        removeRow(res.first().row());
+    });
+
+    // load static desktop info from am
+    auto future = QtConcurrent::run([this]() {
+        auto apps = m_manager->GetManagedObjects().value();
+
+        for (auto app = apps.cbegin(); app != apps.cend(); app++) {
+            auto path = app.key();
+            if (!path.path().isEmpty()) {
+                auto c = new AMAppItem(path, app.value());
+                if (auto group = AppGroupManager::instance()->getAppGroupInfo(c->appId()); group != std::make_tuple(-1, -1, -1)) {
+                    c->setGroup({std::get<0>(group), std::get<1>(group), std::get<2>(group)});
+                }
+                appendRow(c);
+            }
+        }
+    });
+}
+}

--- a/applets/dde-apps/amappitemmodel.h
+++ b/applets/dde-apps/amappitemmodel.h
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include "appitemmodel.h"
+#include "objectmanager1interface.h"
+
+namespace apps
+{
+class AMAppItemModel : public AppItemModel
+{
+    Q_OBJECT
+
+public:
+    explicit AMAppItemModel(QObject *parent = nullptr);
+
+private:
+    ObjectManager *m_manager;
+};
+}

--- a/applets/dde-apps/api/types/am.h
+++ b/applets/dde-apps/api/types/am.h
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+// from am global.h
+#include <QDBusObjectPath>
+#include <QMap>
+#include <QString>
+
+using ObjectInterfaceMap = QMap<QString, QVariantMap>;
+using ObjectMap = QMap<QDBusObjectPath, ObjectInterfaceMap>;
+using QStringMap = QMap<QString, QString>;
+using PropMap = QMap<QString, QStringMap>;
+
+Q_DECLARE_METATYPE(ObjectInterfaceMap)
+Q_DECLARE_METATYPE(ObjectMap)
+Q_DECLARE_METATYPE(QStringMap)
+Q_DECLARE_METATYPE(PropMap)

--- a/applets/dde-apps/appgroup.cpp
+++ b/applets/dde-apps/appgroup.cpp
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "appgroup.h"
+#include "appgroupmanager.h"
+
+#include <QLoggingCategory>
+#include <algorithm>
+
+Q_LOGGING_CATEGORY(appGroupLog, "org.deepin.ds.dde-apps.appgroup")
+
+namespace apps
+{
+AppGroup::AppGroup(const QString &name, const QList<QStringList> &appIDs)
+    : QStandardItem()
+{
+    setName(name);
+    setAppItems(appIDs);
+}
+
+QString AppGroup::name() const
+{
+    return data(AppGroupManager::GroupNameRole).toString();
+}
+
+void AppGroup::setName(const QString &name)
+{
+    return setData(name, AppGroupManager::GroupNameRole);
+}
+
+QList<QStringList> AppGroup::appItems() const
+{
+    QList<QStringList> res;
+    auto pages = data(AppGroupManager::GroupAppItemsRole).toList();
+    std::transform(pages.begin(), pages.end(), std::back_inserter(res), [](const QVariant &data) {
+        return data.toStringList();
+    });
+
+    return res;
+}
+
+void AppGroup::setAppItems(const QList<QStringList> &items)
+{
+    QVariantList data;
+    std::transform(items.begin(), items.end(), std::back_inserter(data), [](const QStringList &c) {
+        QVariantList tmp;
+        std::transform(c.begin(), c.end(), std::back_inserter(tmp), [](const QString &s) {
+            return s;
+        });
+        return tmp;
+    });
+    return setData(data, AppGroupManager::GroupAppItemsRole);
+}
+}

--- a/applets/dde-apps/appgroup.h
+++ b/applets/dde-apps/appgroup.h
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <QStandardItem>
+
+namespace apps
+{
+class AppGroup : public QStandardItem
+{
+public:
+    explicit AppGroup(const QString &name, const QList<QStringList> &appItemIDs);
+
+    QString name() const;
+    void setName(const QString &name);
+
+    QList<QStringList> appItems() const;
+    void setAppItems(const QList<QStringList> &items);
+};
+}

--- a/applets/dde-apps/appgroupmanager.cpp
+++ b/applets/dde-apps/appgroupmanager.cpp
@@ -1,0 +1,157 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "appgroupmanager.h"
+#include "appgroup.h"
+
+#include <QtConcurrent>
+
+namespace apps
+{
+static constexpr uint GROUP_MAX_ITEMS_PER_PAGE = 3 * 4;
+
+AppGroupManager *AppGroupManager::instance()
+{
+    static AppGroupManager *_instance = nullptr;
+    if (_instance == nullptr) {
+        _instance = new AppGroupManager;
+    }
+
+    return _instance;
+}
+AppGroupManager::AppGroupManager(QObject *parent)
+    : QStandardItemModel(parent)
+    , m_config(Dtk::Core::DConfig::create("org.deepin.dde.shell", "org.deepin.ds.dde-apps", "", this))
+    , m_dumpTimer(new QTimer(this))
+{
+    m_dumpTimer->setSingleShot(true);
+    m_dumpTimer->setInterval(1000);
+    connect(m_dumpTimer, &QTimer::timeout, this, [this]() {
+        dumpAppGroupInfo();
+    });
+
+    connect(this, &AppGroupManager::dataChanged, this, &AppGroupManager::dumpAppGroupInfo);
+
+    loadAppGroupInfo();
+}
+
+QVariant AppGroupManager::data(const QModelIndex &index, int role) const
+{
+    if (!index.isValid())
+        return QVariant();
+
+    if (role == GroupIdRole) {
+        return index.row();
+    }
+
+    return QStandardItemModel::data(index, role);
+}
+
+std::tuple<int, int, int> AppGroupManager::getAppGroupInfo(const QString &appId)
+{
+    std::tuple<int, int, int> res = {-1, -1, -1};
+    do {
+        int groupPos, pagePos;
+        std::tie(groupPos, pagePos) = m_map.value(appId, std::make_tuple<int, int>(-1, -1));
+        auto groupIndex = index(groupPos, 0);
+
+        if (!groupIndex.isValid())
+            break;
+
+        auto pages = groupIndex.data(GroupAppItemsRole).toList();
+        if (pages.length() == 0)
+            break;
+
+        auto items = pages.value(pagePos).toStringList();
+        if (items.length() == 0)
+            break;
+
+        auto itemPos = items.indexOf(appId);
+        res = std::make_tuple(groupPos, pagePos, itemPos);
+    } while (0);
+
+    return res;
+}
+
+void AppGroupManager::setAppGroupInfo(const QString &appId, std::tuple<int, int, int> groupInfo)
+{
+    int groupPos, pagePos, itemPos;
+    std::tie(groupPos, pagePos, itemPos) = groupInfo;
+
+    auto groupIndex = index(groupPos, 0);
+    if (!groupIndex.isValid()) {
+        return;
+    }
+
+    auto appItems = groupIndex.data(GroupAppItemsRole).value<QList<QStringList>>();
+
+    for (int i = pagePos; i < appItems.length() - 1; i++) {
+        appItems[i].insert(itemPos, appId);
+        m_map.insert(appId, std::make_tuple(groupPos, pagePos));
+
+        // 本页最后一位元素插入到下页
+        if (appItems[i].length() > GROUP_MAX_ITEMS_PER_PAGE) {
+            auto item = appItems[i].takeLast();
+
+            appItems[i + 1].insert(0, item);
+            m_map.insert(item, std::make_tuple(groupPos, i + 1));
+        }
+    }
+
+    if (appItems.length() > 1 && appItems.last().length() > GROUP_MAX_ITEMS_PER_PAGE) {
+        auto item = appItems.last().takeLast();
+        appItems.append({item});
+    }
+
+    if (pagePos > appItems.length()) {
+        appItems.append({appId});
+    }
+
+    QVariantList data;
+    std::transform(appItems.begin(), appItems.end(), std::back_inserter(data), [](const QStringList &items) {
+        QVariantList tmp;
+        std::transform(items.begin(), items.end(), std::back_inserter(tmp), [](const auto &item) {
+            return QVariant::fromValue(item);
+        });
+        return tmp;
+    });
+
+    setData(groupIndex, data);
+}
+
+void AppGroupManager::loadAppGroupInfo()
+{
+    auto groups = m_config->value("Groups").toList();
+    for (int i = 0; i < groups.length(); i++) {
+        auto group = groups[i].toMap();
+        auto name = group.value("name", "").toString();
+        auto pages = group.value("appItems", QVariantList()).toList();
+        QList<QStringList> items;
+
+        for (int j = 0; j < pages.length(); j++) {
+            auto page = pages[j].toStringList();
+            items << page;
+            std::for_each(page.begin(), page.end(), [this, i, j](const QString &item) {
+                m_map.insert(item, std::make_tuple(i, j));
+            });
+        }
+        auto p = new AppGroup(name, items);
+        appendRow(p);
+    }
+}
+
+void AppGroupManager::dumpAppGroupInfo()
+{
+    QVariantList list;
+    for (int i = 0; i < rowCount(); i++) {
+        auto data = index(i, 0);
+        QVariantMap valueMap;
+        valueMap.insert("name", data.data(GroupNameRole));
+        valueMap.insert("appItems", data.data(GroupAppItemsRole));
+        list << valueMap;
+    }
+
+    m_config->setValue("Groups", list);
+}
+}

--- a/applets/dde-apps/appgroupmanager.h
+++ b/applets/dde-apps/appgroupmanager.h
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <DConfig>
+#include <QHash>
+#include <QObject>
+#include <QTimer>
+
+#include <QStandardItemModel>
+#include <tuple>
+
+namespace apps
+{
+class AppGroup;
+/*! \brief AppGroupManager is a interface to manager all groups.
+ *
+ *  The life cycle of all groups and the appitems of the group are manager by this class.
+ */
+class AppGroupManager : public QStandardItemModel
+{
+    Q_OBJECT
+
+public:
+    enum Roles {
+        GroupIdRole = Qt::UserRole + 1,
+        GroupNameRole,
+        GroupAppItemsRole,
+        ExtendRole = 0x1000,
+    };
+
+    static AppGroupManager *instance();
+
+    QVariant data(const QModelIndex &index, int role = GroupIdRole) const override;
+
+    std::tuple<int, int, int> getAppGroupInfo(const QString &appId);
+    void setAppGroupInfo(const QString &appId, std::tuple<int, int, int> groupInfo);
+
+private:
+    AppGroupManager(QObject *parent = nullptr);
+    void loadAppGroupInfo();
+    void dumpAppGroupInfo();
+
+private:
+    QHash<QString, std::tuple<int, int>> m_map;
+    QTimer *m_dumpTimer;
+    Dtk::Core::DConfig *m_config;
+};
+}

--- a/applets/dde-apps/appitem.cpp
+++ b/applets/dde-apps/appitem.cpp
@@ -1,0 +1,186 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "appitem.h"
+#include "appgroupmanager.h"
+#include "appitemmodel.h"
+#include "appsdockedhelper.h"
+#include "appslaunchtimes.h"
+
+#include <tuple>
+
+namespace apps
+{
+AppItem::AppItem(const QString &appid)
+{
+    setAppId(appid);
+
+    int groupPos, pagePos, itemPos;
+    std::tie(groupPos, pagePos, itemPos) = AppGroupManager::instance()->getAppGroupInfo(appId());
+    QVariantList data = {groupPos, pagePos, itemPos};
+    setData(data, AppItemModel::GroupRole);
+
+    auto launchedTimes = AppsLaunchTimesHelper::instance()->getLaunchedTimesFor(appId());
+    setData(launchedTimes, AppItemModel::LaunchedTimesRole);
+}
+
+void AppItem::launch(const QString &action, const QStringList &fields, const QVariantMap &options)
+{
+    Q_UNUSED(action)
+    Q_UNUSED(fields)
+    Q_UNUSED(options)
+
+    setLaunchedTimes(launchedTimes() + 1);
+}
+
+QString AppItem::appId() const
+{
+    return data(AppItemModel::DesktopIdRole).toString();
+}
+
+void AppItem::setAppId(const QString &appid)
+{
+    return setData(appid, AppItemModel::DesktopIdRole);
+}
+
+QString AppItem::appName() const
+{
+    return data(AppItemModel::NameRole).toString();
+}
+
+void AppItem::setAppName(const QString &appName)
+{
+    return setData(appName, AppItemModel::NameRole);
+}
+
+QString AppItem::appIconName() const
+{
+    return data(AppItemModel::IconNameRole).toString();
+}
+
+void AppItem::setAppIconName(const QString &appIconName)
+{
+    return setData(appIconName, AppItemModel::IconNameRole);
+}
+
+QString AppItem::startupWMClass() const
+{
+    return data(AppItemModel::StartUpWMClassRole).toString();
+}
+
+void AppItem::setStartupWMclass(const QString &wmClass)
+{
+    return setData(wmClass, AppItemModel::StartUpWMClassRole);
+}
+
+bool AppItem::noDisplay() const
+{
+    return data(AppItemModel::NoDisplayRole).toBool();
+}
+
+void AppItem::setNoDisPlay(bool noDisplay)
+{
+    return setData(noDisplay, AppItemModel::NoDisplayRole);
+}
+
+AppItemModel::DDECategories AppItem::ddeCategories() const
+{
+    return data(AppItemModel::DDECategoryRole).value<AppItemModel::DDECategories>();
+}
+
+void AppItem::setDDECategories(const AppItemModel::DDECategories &categories)
+{
+    return setData(categories, AppItemModel::DDECategoryRole);
+}
+
+QString AppItem::actions() const
+{
+    return data(AppItemModel::ActionsRole).toString();
+}
+
+void AppItem::setActions(const QString &actions)
+{
+    return setData(actions, AppItemModel::ActionsRole);
+}
+
+quint64 AppItem::lastLaunchedTime() const
+{
+    return data(AppItemModel::LastLaunchedTimeRole).toULongLong();
+}
+
+void AppItem::setLastLaunchedTime(const quint64 &time)
+{
+    return setData(time, AppItemModel::LastLaunchedTimeRole);
+}
+
+quint64 AppItem::installedTime() const
+{
+    return data(AppItemModel::InstalledTimeRole).toULongLong();
+}
+
+void AppItem::setInstalledTime(const quint64 &time)
+{
+    return setData(time, AppItemModel::InstalledTimeRole);
+}
+
+quint64 AppItem::launchedTimes() const
+{
+    return data(AppItemModel::LaunchedTimesRole).toULongLong();
+}
+
+void AppItem::setLaunchedTimes(const quint64 &times)
+{
+    AppsLaunchTimesHelper::instance()->setLaunchTimesFor(appId(), times);
+    return setData(times, AppItemModel::LaunchedTimesRole);
+}
+
+QList<int> AppItem::group() const
+{
+    return data(AppItemModel::GroupRole).value<QList<int>>();
+}
+
+void AppItem::setGroup(const QList<int> &group)
+{
+    if (group.size() != 3)
+        return;
+    auto groupPos = group[0];
+    auto pagePos = group[1];
+    auto itemPos = group[2];
+    AppGroupManager::instance()->setAppGroupInfo(appId(), std::make_tuple(groupPos, pagePos, itemPos));
+    QVariantList data = {groupPos, pagePos, itemPos};
+    return setData(data, AppItemModel::GroupRole);
+}
+
+bool AppItem::docked() const
+{
+    return data(AppItemModel::DockedRole).toBool();
+}
+
+void AppItem::setDocked(bool docked)
+{
+    AppsDockedHelper::instance()->setDocked(appId(), docked);
+    return setData(docked, AppItemModel::DockedRole);
+}
+
+bool AppItem::onDesktop() const
+{
+    return data(AppItemModel::OnDesktopRole).toBool();
+}
+
+void AppItem::setOnDesktop(bool on)
+{
+    return setData(on, AppItemModel::OnDesktopRole);
+}
+
+bool AppItem::autoStart() const
+{
+    return data(AppItemModel::AutoStartRole).toBool();
+}
+
+void AppItem::setAutoStart(bool start)
+{
+    return setData(start, AppItemModel::AutoStartRole);
+}
+
+}

--- a/applets/dde-apps/appitem.h
+++ b/applets/dde-apps/appitem.h
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include "appitemmodel.h"
+#include <QStandardItem>
+
+namespace apps
+{
+class AppItem : public QStandardItem
+{
+public:
+    AppItem(const QString &appid);
+
+    // action
+    virtual void launch(const QString &action = {}, const QStringList &fields = {}, const QVariantMap &options = {});
+
+    // desktop file static data
+    QString appId() const;
+    void setAppId(const QString &appid);
+
+    QString appName() const;
+    void setAppName(const QString &name);
+
+    QString appIconName() const;
+    void setAppIconName(const QString &appIconName);
+
+    QString startupWMClass() const;
+    void setStartupWMclass(const QString &wmClass);
+
+    bool noDisplay() const;
+    void setNoDisPlay(bool noDisplay);
+
+    AppItemModel::DDECategories ddeCategories() const;
+    void setDDECategories(const AppItemModel::DDECategories &categories);
+
+    QString actions() const;
+    void setActions(const QString &actions);
+
+    // desktop file peripheral data
+    virtual quint64 lastLaunchedTime() const;
+    virtual void setLastLaunchedTime(const quint64 &time);
+
+    virtual quint64 installedTime() const;
+    virtual void setInstalledTime(const quint64 &time);
+
+    virtual quint64 launchedTimes() const;
+    virtual void setLaunchedTimes(const quint64 &times);
+
+    virtual QList<int> group() const;
+    virtual void setGroup(const QList<int> &group);
+
+    virtual bool docked() const;
+    virtual void setDocked(bool docked);
+
+    virtual bool onDesktop() const;
+    virtual void setOnDesktop(bool onDesktop);
+
+    virtual bool autoStart() const;
+    virtual void setAutoStart(bool autoStart);
+};
+}

--- a/applets/dde-apps/appitemmodel.cpp
+++ b/applets/dde-apps/appitemmodel.cpp
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "appitemmodel.h"
+#include "appgroupmanager.h"
+
+namespace apps
+{
+AppItemModel::AppItemModel(QObject *parent)
+    : QStandardItemModel(parent)
+{
+    AppGroupManager::instance();
+}
+
+QHash<int, QByteArray> AppItemModel::roleNames() const
+{
+    return {{AppItemModel::DesktopIdRole, QByteArrayLiteral("desktopId")},
+            {AppItemModel::NameRole, QByteArrayLiteral("name")},
+            {AppItemModel::IconNameRole, QByteArrayLiteral("iconName")},
+            {AppItemModel::StartUpWMClassRole, QByteArrayLiteral("startupWMClass")},
+            {AppItemModel::NoDisplayRole, QByteArrayLiteral("noDisplay")},
+            {AppItemModel::ActionsRole, QByteArrayLiteral("actions")},
+            {AppItemModel::DDECategoryRole, QByteArrayLiteral("ddeCategory")},
+            {AppItemModel::InstalledTimeRole, QByteArrayLiteral("installedTime")},
+            {AppItemModel::LastLaunchedTimeRole, QByteArrayLiteral("lastLaunchedTime")},
+            {AppItemModel::LaunchedTimesRole, QByteArrayLiteral("launchedTimes")},
+            {AppItemModel::DockedRole, QByteArrayLiteral("docked")},
+            {AppItemModel::OnDesktopRole, QByteArrayLiteral("onDesktop")},
+            {AppItemModel::AutoStartRole, QByteArrayLiteral("autoStart")},
+            {AppItemModel::GroupRole, QByteArrayLiteral("group")}};
+}
+}

--- a/applets/dde-apps/appitemmodel.cpp
+++ b/applets/dde-apps/appitemmodel.cpp
@@ -10,7 +10,6 @@ namespace apps
 AppItemModel::AppItemModel(QObject *parent)
     : QStandardItemModel(parent)
 {
-    AppGroupManager::instance();
 }
 
 QHash<int, QByteArray> AppItemModel::roleNames() const

--- a/applets/dde-apps/appitemmodel.h
+++ b/applets/dde-apps/appitemmodel.h
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include "appgroupmanager.h"
+#include <QStandardItemModel>
+
+namespace apps
+{
+class AppItemModel : public QStandardItemModel
+{
+public:
+    enum Roles {
+        DesktopIdRole = AppGroupManager::ExtendRole,
+        NameRole,
+        IconNameRole,
+        StartUpWMClassRole,
+        NoDisplayRole,
+        ActionsRole,
+        DDECategoryRole,
+        InstalledTimeRole,
+        LastLaunchedTimeRole,
+        LaunchedTimesRole,
+        DockedRole,
+        OnDesktopRole,
+        AutoStartRole,
+        GroupRole,
+    };
+    Q_ENUM(Roles)
+
+    // This is different from the menu-spec Main Categories list.
+    enum DDECategories {
+        Internet, // 网络模式
+        Chat, // 社交模式
+        Music, // 音乐模式
+        Video, // 视频模式
+        Graphics, // 图形图像
+        Game, //
+        Office, // 办公模式
+        Reading, // 阅读模式
+        Development, // 编程开发模式
+        System, // 系统管理模式
+        Others,
+    };
+    Q_ENUM(DDECategories)
+
+    explicit AppItemModel(QObject *parent = nullptr);
+    QHash<int, QByteArray> roleNames() const override;
+};
+}

--- a/applets/dde-apps/appsapplet.cpp
+++ b/applets/dde-apps/appsapplet.cpp
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "appsapplet.h"
+#include "amappitemmodel.h"
+#include "appgroupmanager.h"
+#include "pluginfactory.h"
+
+#include <DUtil>
+#include <QtConcurrent>
+
+namespace apps
+{
+AppsApplet::AppsApplet(QObject *parent)
+    : DApplet(parent)
+    , m_groupModel(AppGroupManager::instance())
+    , m_appModel(new AMAppItemModel(this))
+{
+}
+
+AppsApplet::~AppsApplet()
+{
+}
+
+bool AppsApplet::load()
+{
+    return true;
+}
+
+QAbstractItemModel *AppsApplet::groupModel() const
+{
+    return AppGroupManager::instance();
+}
+
+QAbstractItemModel *AppsApplet::appModel() const
+{
+    return m_appModel;
+}
+
+D_APPLET_CLASS(AppsApplet)
+}
+
+#include "appsapplet.moc"

--- a/applets/dde-apps/appsapplet.h
+++ b/applets/dde-apps/appsapplet.h
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include "applet.h"
+#include "dsglobal.h"
+
+#include <QAbstractListModel>
+
+DS_USE_NAMESPACE
+
+namespace apps
+{
+class AppItem;
+class AppsApplet : public DApplet
+{
+    Q_OBJECT
+    Q_PROPERTY(QAbstractItemModel *appModel READ appModel CONSTANT FINAL)
+    Q_PROPERTY(QAbstractItemModel *appGroupModel READ groupModel CONSTANT FINAL)
+
+public:
+    explicit AppsApplet(QObject *parent = nullptr);
+    ~AppsApplet();
+
+    bool load() override;
+
+    QAbstractItemModel *appModel() const;
+    QAbstractItemModel *groupModel() const;
+
+private:
+    QAbstractItemModel *m_groupModel;
+    QAbstractItemModel *m_appModel;
+};
+}

--- a/applets/dde-apps/appsdockedhelper.cpp
+++ b/applets/dde-apps/appsdockedhelper.cpp
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "appsdockedhelper.h"
+
+#include <QJsonDocument>
+#include <QJsonObject>
+
+#include <qcontainerfwd.h>
+#include <yaml-cpp/yaml.h>
+
+namespace apps
+{
+AppsDockedHelper *AppsDockedHelper::instance()
+{
+    static AppsDockedHelper *_instance = nullptr;
+
+    if (_instance == nullptr) {
+        _instance = new AppsDockedHelper;
+    }
+
+    return _instance;
+}
+
+AppsDockedHelper::AppsDockedHelper(QObject *parent)
+    : QObject(parent)
+    , m_config(DConfig::create(QStringLiteral("org.deepin.dde.shell"), QStringLiteral("org.deepin.ds.dock.taskmanager"), QString(), this))
+{
+    // TODO: remove yaml and rewrite this
+    auto updateDockedDesktopfiles = [this]() {
+        m_dockedDesktopIDs.clear();
+        auto dcokedDesktopFilesStrList = m_config->value("Docked_Items").toStringList();
+        foreach (auto dcokedDesktopFilesStr, dcokedDesktopFilesStrList) {
+            YAML::Node node;
+            try {
+                node = YAML::Load("{" + dcokedDesktopFilesStr.toStdString() + "}");
+            } catch (YAML::Exception) {
+                qWarning() << "unable to parse docked desktopfiles";
+            }
+
+            if (!node.IsMap())
+                continue;
+            auto dockedItem = QJsonObject();
+            for (auto it = node.begin(); it != node.end(); ++it) {
+                auto key = it->first.as<std::string>();
+                auto value = it->second.as<std::string>();
+                dockedItem[QString::fromStdString(key)] = QString::fromStdString(value);
+            }
+            if (dockedItem["type"] == "amAPP") {
+                m_dockedDesktopIDs.insert(dockedItem["id"].toString());
+            }
+        }
+    };
+
+    connect(m_config, &DConfig::valueChanged, this, [this, updateDockedDesktopfiles](const QString &key) {
+        if (key != "Docked_Items")
+            return;
+        updateDockedDesktopfiles();
+    });
+
+    updateDockedDesktopfiles();
+}
+
+bool AppsDockedHelper::isDocked(const QString &appItemId) const
+{
+    return m_dockedDesktopIDs.contains(appItemId.chopped(8));
+}
+
+void AppsDockedHelper::setDocked(const QString &appId, bool docked)
+{
+    // TODO
+}
+}

--- a/applets/dde-apps/appsdockedhelper.h
+++ b/applets/dde-apps/appsdockedhelper.h
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <DConfig>
+#include <QObject>
+
+DCORE_USE_NAMESPACE
+
+namespace apps
+{
+class AppsDockedHelper : public QObject
+{
+    Q_OBJECT
+
+public:
+    static AppsDockedHelper *instance();
+
+    bool isDocked(const QString &appId) const;
+    void setDocked(const QString &appId, bool docked);
+
+private:
+    AppsDockedHelper(QObject *parent = nullptr);
+
+private:
+    DConfig *m_config;
+    QSet<QString> m_dockedDesktopIDs;
+};
+}

--- a/applets/dde-apps/appslaunchtimes.cpp
+++ b/applets/dde-apps/appslaunchtimes.cpp
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "appslaunchtimes.h"
+
+namespace apps
+{
+AppsLaunchTimesHelper *AppsLaunchTimesHelper::instance()
+{
+    static AppsLaunchTimesHelper *_instance = nullptr;
+    if (_instance == nullptr) {
+        _instance = new AppsLaunchTimesHelper;
+    }
+
+    return _instance;
+}
+
+AppsLaunchTimesHelper::AppsLaunchTimesHelper(QObject *parent)
+    : QObject(parent)
+    , m_launchTimesConfig(DConfig::create("org.deepin.dde.application-manager", "org.deepin.dde.am", "", this))
+{
+    if (m_launchTimesConfig->isValid()) {
+        m_data = m_launchTimesConfig->value("appsLaunchedTimes").toMap();
+    }
+
+    connect(m_launchTimesConfig, &DConfig::valueChanged, this, [this](const QString &key) {
+        if (key == "appsLaunchedTimes") {
+            m_data = m_launchTimesConfig->value("appsLaunchedTimes").toMap();
+        }
+    });
+}
+
+void AppsLaunchTimesHelper::setLaunchTimesFor(const QString &desktopId, quint64 launchTimes)
+{
+    if (launchTimes == 0) {
+        m_data.remove(desktopId);
+    } else {
+        m_data[desktopId] = launchTimes;
+    }
+
+    // TODO: write list
+    m_launchTimesConfig->setValue("appsLaunchedTimes", m_data);
+}
+
+quint64 AppsLaunchTimesHelper::getLaunchedTimesFor(const QString &desktopId)
+{
+    return m_data.value(desktopId, 0).toULongLong();
+}
+
+}

--- a/applets/dde-apps/appslaunchtimes.h
+++ b/applets/dde-apps/appslaunchtimes.h
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <DConfig>
+#include <QObject>
+
+DCORE_USE_NAMESPACE
+
+namespace apps
+{
+class AppsLaunchTimesHelper : public QObject
+{
+    Q_OBJECT
+
+public:
+    void setLaunchTimesFor(const QString &desktopId, quint64 launchTimes);
+    quint64 getLaunchedTimesFor(const QString &desktopId);
+    static AppsLaunchTimesHelper *instance();
+
+private:
+    AppsLaunchTimesHelper(QObject *parent = nullptr);
+
+private:
+    DConfig *m_launchTimesConfig;
+    QVariantMap m_data;
+};
+}

--- a/applets/dde-apps/categoryutils.cpp
+++ b/applets/dde-apps/categoryutils.cpp
@@ -1,0 +1,293 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "categoryutils.h"
+
+#include <QMultiMap>
+
+CategoryUtils::Categorytype CategoryUtils::parseBestMatchedCategory(QStringList categories)
+{
+    // 统计应用类型
+    QMap<Categorytype, int> categoriesMap;
+    for (const auto &category : categories) {
+        QString lCategory = category.toLower();
+        QList<Categorytype> tys;
+        Categorytype ty = CategoryUtils::parseDDECategoryString(lCategory);
+        if (ty != Categorytype::CategoryErr)
+            tys.push_back(ty);
+        else if (CategoryUtils::parseXdgCategoryString(lCategory).size() > 0) {
+            tys.append(CategoryUtils::parseXdgCategoryString(lCategory));
+        }
+
+        for (const auto &ty : tys)
+            categoriesMap[ty]++;
+    }
+
+    categoriesMap.remove(Categorytype::CategoryOthers);
+    if (categoriesMap.size() == 0)
+        return Categorytype::CategoryOthers;
+
+    // 计算最多的类型
+    int max = 0;
+    Categorytype ty{Categorytype::CategoryOthers};
+    for (auto iter = categoriesMap.begin(); iter != categoriesMap.end(); iter++) {
+        if (iter.value() > max) {
+            max = iter.value();
+            ty = iter.key();
+        }
+    }
+
+    QList<Categorytype> maxCatogories{ty};
+    for (auto iter = categoriesMap.begin(); iter != categoriesMap.end(); iter++) {
+        if (iter.key() != ty && iter.value() == max) {
+            maxCatogories.push_back(iter.key());
+        }
+    }
+
+    if (maxCatogories.size() == 1)
+        return maxCatogories[0];
+
+    std::sort(maxCatogories.begin(), maxCatogories.end());
+
+    // 检查是否同时存在音乐和视频播放器
+    QPair<bool, bool> found;
+    for (auto iter = maxCatogories.begin(); iter != maxCatogories.end(); iter++) {
+        if (*iter == Categorytype::CategoryMusic)
+            found.first = true;
+        else if (*iter == Categorytype::CategoryVideo)
+            found.second = true;
+    }
+
+    if (found.first && found.second)
+        return Categorytype::CategoryVideo;
+
+    return maxCatogories[0];
+}
+
+CategoryUtils::Categorytype CategoryUtils::parseDDECategoryString(QString str)
+{
+    static const QMap<QString, Categorytype> name2ty{
+        {"internet", Categorytype::CategoryInternet},
+        {"chat", Categorytype::CategoryChat},
+        {"music", Categorytype::CategoryMusic},
+        {"video", Categorytype::CategoryVideo},
+        {"graphics", Categorytype::CategoryGraphics},
+        {"office", Categorytype::CategoryOffice},
+        {"game", Categorytype::CategoryGame},
+        {"reading", Categorytype::CategoryReading},
+        {"development", Categorytype::CategoryDevelopment},
+        {"system", Categorytype::CategorySystem},
+        {"others", Categorytype::CategoryOthers},
+    };
+    return name2ty.find(str) != name2ty.end() ? name2ty[str] : Categorytype::CategoryErr;
+}
+
+QList<CategoryUtils::Categorytype> CategoryUtils::parseXdgCategoryString(QString str)
+{
+    static const QMultiMap<QString, Categorytype> xname2ty{
+        {"2dgraphics", Categorytype::CategoryGraphics},
+        {"3dgraphics", Categorytype::CategoryGraphics},
+        {"accessibility", Categorytype::CategorySystem},
+        {"accessories", Categorytype::CategoryOthers},
+        {"actiongame", Categorytype::CategoryGame},
+        {"advancedsettings", Categorytype::CategorySystem},
+        {"adventuregame", Categorytype::CategoryGame},
+        {"amusement", Categorytype::CategoryGame},
+        {"applet", Categorytype::CategoryOthers},
+        {"arcadegame", Categorytype::CategoryGame},
+        {"archiving", Categorytype::CategorySystem},
+        {"art", Categorytype::CategoryOffice},
+        {"artificialintelligence", Categorytype::CategoryOffice},
+        {"astronomy", Categorytype::CategoryOffice},
+        {"audio", Categorytype::CategoryMusic},
+        {"audiovideo", Categorytype::CategoryMusic},
+        {"audiovideo", Categorytype::CategoryVideo},
+        {"audiovideoediting", Categorytype::CategoryMusic},
+        {"audiovideoediting", Categorytype::CategoryVideo},
+        {"biology", Categorytype::CategoryOffice},
+        {"blocksgame", Categorytype::CategoryGame},
+        {"boardgame", Categorytype::CategoryGame},
+        {"building", Categorytype::CategoryDevelopment},
+        {"calculator", Categorytype::CategorySystem},
+        {"calendar", Categorytype::CategorySystem},
+        {"cardgame", Categorytype::CategoryGame},
+        {"cd", Categorytype::CategoryMusic},
+        {"chart", Categorytype::CategoryOffice},
+        {"chat", Categorytype::CategoryChat},
+        {"chemistry", Categorytype::CategoryOffice},
+        {"clock", Categorytype::CategorySystem},
+        {"compiz", Categorytype::CategorySystem},
+        {"compression", Categorytype::CategorySystem},
+        {"computerscience", Categorytype::CategoryOffice},
+        {"consoleonly", Categorytype::CategoryOthers},
+        {"contactmanagement", Categorytype::CategoryChat},
+        {"core", Categorytype::CategoryOthers},
+        {"debugger", Categorytype::CategoryDevelopment},
+        {"desktopsettings", Categorytype::CategorySystem},
+        {"desktoputility", Categorytype::CategorySystem},
+        {"development", Categorytype::CategoryDevelopment},
+        {"dialup", Categorytype::CategorySystem},
+        {"dictionary", Categorytype::CategoryOffice},
+        {"discburning", Categorytype::CategorySystem},
+        {"documentation", Categorytype::CategoryOffice},
+        {"editors", Categorytype::CategoryOthers},
+        {"education", Categorytype::CategoryOffice},
+        {"electricity", Categorytype::CategoryOffice},
+        {"electronics", Categorytype::CategoryOffice},
+        {"email", Categorytype::CategoryInternet},
+        {"emulator", Categorytype::CategoryGame},
+        {"engineering", Categorytype::CategorySystem},
+        {"favorites", Categorytype::CategoryOthers},
+        {"filemanager", Categorytype::CategorySystem},
+        {"filesystem", Categorytype::CategorySystem},
+        {"filetools", Categorytype::CategorySystem},
+        {"filetransfer", Categorytype::CategoryInternet},
+        {"finance", Categorytype::CategoryOffice},
+        {"game", Categorytype::CategoryGame},
+        {"geography", Categorytype::CategoryOffice},
+        {"geology", Categorytype::CategoryOffice},
+        {"geoscience", Categorytype::CategoryOthers},
+        {"gnome", Categorytype::CategorySystem},
+        {"gpe", Categorytype::CategoryOthers},
+        {"graphics", Categorytype::CategoryGraphics},
+        {"guidesigner", Categorytype::CategoryDevelopment},
+        {"hamradio", Categorytype::CategoryOffice},
+        {"hardwaresettings", Categorytype::CategorySystem},
+        {"ide", Categorytype::CategoryDevelopment},
+        {"imageprocessing", Categorytype::CategoryGraphics},
+        {"instantmessaging", Categorytype::CategoryChat},
+        {"internet", Categorytype::CategoryInternet},
+        {"ircclient", Categorytype::CategoryChat},
+        {"kde", Categorytype::CategorySystem},
+        {"kidsgame", Categorytype::CategoryGame},
+        {"literature", Categorytype::CategoryOffice},
+        {"logicgame", Categorytype::CategoryGame},
+        {"math", Categorytype::CategoryOffice},
+        {"medicalsoftware", Categorytype::CategoryOffice},
+        {"meteorology", Categorytype::CategoryOthers},
+        {"midi", Categorytype::CategoryMusic},
+        {"mixer", Categorytype::CategoryMusic},
+        {"monitor", Categorytype::CategorySystem},
+        {"motif", Categorytype::CategoryOthers},
+        {"multimedia", Categorytype::CategoryVideo},
+        {"music", Categorytype::CategoryMusic},
+        {"network", Categorytype::CategoryInternet},
+        {"news", Categorytype::CategoryReading},
+        {"numericalanalysis", Categorytype::CategoryOffice},
+        {"ocr", Categorytype::CategoryGraphics},
+        {"office", Categorytype::CategoryOffice},
+        {"p2p", Categorytype::CategoryInternet},
+        {"packagemanager", Categorytype::CategorySystem},
+        {"panel", Categorytype::CategorySystem},
+        {"pda", Categorytype::CategorySystem},
+        {"photography", Categorytype::CategoryGraphics},
+        {"physics", Categorytype::CategoryOffice},
+        {"pim", Categorytype::CategoryOthers},
+        {"player", Categorytype::CategoryMusic},
+        {"player", Categorytype::CategoryVideo},
+        {"playonlinux", Categorytype::CategoryOthers},
+        {"presentation", Categorytype::CategoryOffice},
+        {"printing", Categorytype::CategoryOffice},
+        {"profiling", Categorytype::CategoryDevelopment},
+        {"projectmanagement", Categorytype::CategoryOffice},
+        {"publishing", Categorytype::CategoryOffice},
+        {"puzzlegame", Categorytype::CategoryGame},
+        {"rastergraphics", Categorytype::CategoryGraphics},
+        {"recorder", Categorytype::CategoryMusic},
+        {"recorder", Categorytype::CategoryVideo},
+        {"remoteaccess", Categorytype::CategorySystem},
+        {"revisioncontrol", Categorytype::CategoryDevelopment},
+        {"robotics", Categorytype::CategoryOffice},
+        {"roleplaying", Categorytype::CategoryGame},
+        {"scanning", Categorytype::CategoryOffice},
+        {"science", Categorytype::CategoryOffice},
+        {"screensaver", Categorytype::CategoryOthers},
+        {"sequencer", Categorytype::CategoryMusic},
+        {"settings", Categorytype::CategorySystem},
+        {"security", Categorytype::CategorySystem},
+        {"simulation", Categorytype::CategoryGame},
+        {"sportsgame", Categorytype::CategoryGame},
+        {"spreadsheet", Categorytype::CategoryOffice},
+        {"strategygame", Categorytype::CategoryGame},
+        {"system", Categorytype::CategorySystem},
+        {"systemsettings", Categorytype::CategorySystem},
+        {"technical", Categorytype::CategoryOthers},
+        {"telephony", Categorytype::CategorySystem},
+        {"telephonytools", Categorytype::CategorySystem},
+        {"terminalemulator", Categorytype::CategorySystem},
+        {"texteditor", Categorytype::CategoryOffice},
+        {"texttools", Categorytype::CategoryOffice},
+        {"transiation", Categorytype::CategoryDevelopment},
+        {"translation", Categorytype::CategoryReading},
+        {"trayicon", Categorytype::CategorySystem},
+        {"tuner", Categorytype::CategoryMusic},
+        {"tv", Categorytype::CategoryVideo},
+        {"utility", Categorytype::CategorySystem},
+        {"vectorgraphics", Categorytype::CategoryGraphics},
+        {"video", Categorytype::CategoryVideo},
+        {"videoconference", Categorytype::CategoryInternet},
+        {"viewer", Categorytype::CategoryGraphics},
+        {"webbrowser", Categorytype::CategoryInternet},
+        {"webdevelopment", Categorytype::CategoryDevelopment},
+        {"wine", Categorytype::CategoryOthers},
+        {"wine-programs-accessories", Categorytype::CategoryOthers},
+        {"wordprocessor", Categorytype::CategoryOffice},
+        {"x-alsa", Categorytype::CategoryMusic},
+        {"x-bible", Categorytype::CategoryReading},
+        {"x-bluetooth", Categorytype::CategorySystem},
+        {"x-debian-applications-emulators", Categorytype::CategoryGame},
+        {"x-digital_processing", Categorytype::CategorySystem},
+        {"x-enlightenment", Categorytype::CategorySystem},
+        {"x-geeqie", Categorytype::CategoryGraphics},
+        {"x-gnome-networksettings", Categorytype::CategorySystem},
+        {"x-gnome-personalsettings", Categorytype::CategorySystem},
+        {"x-gnome-settings-panel", Categorytype::CategorySystem},
+        {"x-gnome-systemsettings", Categorytype::CategorySystem},
+        {"x-gnustep", Categorytype::CategorySystem},
+        {"x-islamic-software", Categorytype::CategoryReading},
+        {"x-jack", Categorytype::CategoryMusic},
+        {"x-kde-edu-misc", Categorytype::CategoryReading},
+        {"x-kde-internet", Categorytype::CategorySystem},
+        {"x-kde-more", Categorytype::CategorySystem},
+        {"x-kde-utilities-desktop", Categorytype::CategorySystem},
+        {"x-kde-utilities-file", Categorytype::CategorySystem},
+        {"x-kde-utilities-peripherals", Categorytype::CategorySystem},
+        {"x-kde-utilities-pim", Categorytype::CategorySystem},
+        {"x-lxde-settings", Categorytype::CategorySystem},
+        {"x-mandriva-office-publishing", Categorytype::CategoryOthers},
+        {"x-mandrivalinux-internet-other", Categorytype::CategorySystem},
+        {"x-mandrivalinux-office-other", Categorytype::CategoryOffice},
+        {"x-mandrivalinux-system-archiving-backup", Categorytype::CategorySystem},
+        {"x-midi", Categorytype::CategoryMusic},
+        {"x-misc", Categorytype::CategorySystem},
+        {"x-multitrack", Categorytype::CategoryMusic},
+        {"x-novell-main", Categorytype::CategorySystem},
+        {"x-quran", Categorytype::CategoryReading},
+        {"x-red-hat-base", Categorytype::CategorySystem},
+        {"x-red-hat-base-only", Categorytype::CategorySystem},
+        {"x-red-hat-extra", Categorytype::CategorySystem},
+        {"x-red-hat-serverconfig", Categorytype::CategorySystem},
+        {"x-religion", Categorytype::CategoryReading},
+        {"x-sequencers", Categorytype::CategoryMusic},
+        {"x-sound", Categorytype::CategoryMusic},
+        {"x-sun-supported", Categorytype::CategorySystem},
+        {"x-suse-backup", Categorytype::CategorySystem},
+        {"x-suse-controlcenter-lookandfeel", Categorytype::CategorySystem},
+        {"x-suse-controlcenter-system", Categorytype::CategorySystem},
+        {"x-suse-core", Categorytype::CategorySystem},
+        {"x-suse-core-game", Categorytype::CategoryGame},
+        {"x-suse-core-office", Categorytype::CategoryOffice},
+        {"x-suse-sequencer", Categorytype::CategoryMusic},
+        {"x-suse-yast", Categorytype::CategorySystem},
+        {"x-suse-yast-high_availability", Categorytype::CategorySystem},
+        {"x-synthesis", Categorytype::CategorySystem},
+        {"x-turbolinux-office", Categorytype::CategoryOffice},
+        {"x-xfce", Categorytype::CategorySystem},
+        {"x-xfce-toplevel", Categorytype::CategorySystem},
+        {"x-xfcesettingsdialog", Categorytype::CategorySystem},
+        {"x-ximian-main", Categorytype::CategorySystem},
+    };
+
+    return {xname2ty.values(str)};
+}

--- a/applets/dde-apps/categoryutils.h
+++ b/applets/dde-apps/categoryutils.h
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <QList>
+
+namespace CategoryUtils
+{
+
+enum class Categorytype {
+    CategoryInternet,
+    CategoryChat,
+    CategoryMusic,
+    CategoryVideo,
+    CategoryGraphics,
+    CategoryGame,
+    CategoryOffice,
+    CategoryReading,
+    CategoryDevelopment,
+    CategorySystem,
+    CategoryOthers,
+    CategoryErr,
+};
+
+Categorytype parseBestMatchedCategory(QStringList categories);
+Categorytype parseDDECategoryString(QString str);
+QList<Categorytype> parseXdgCategoryString(QString str);
+
+}

--- a/applets/dde-apps/configs/org.deepin.ds.dde-apps.json
+++ b/applets/dde-apps/configs/org.deepin.ds.dde-apps.json
@@ -1,0 +1,16 @@
+{
+	"magic": "dsg.config.meta",
+	"version": "1.0",
+	"contents": {
+		"Groups": {
+			"value": [],
+			"serial": 0,
+			"flags": [],
+			"name": "App Group",
+			"name[zh_CN]": "程序组",
+			"description": "用于记录运行过程中产生的程序组信息",
+			"permissions": "readwrite",
+			"visibility": "private"
+		}
+	}
+}

--- a/applets/dde-apps/package/metadata.json
+++ b/applets/dde-apps/package/metadata.json
@@ -1,0 +1,7 @@
+{
+    "Plugin": {
+        "Version": "1.0",
+        "Id": "org.deepin.ds.dde-apps",
+        "Category": "DDE"
+    }
+}

--- a/debian/control
+++ b/debian/control
@@ -32,7 +32,7 @@ Build-Depends:
  libdtk6declarative, qml6-module-qtquick-controls2-styles-chameleon, qt6-declarative-private-dev,
  libyaml-cpp-dev,
  qtbase5-dev, qtbase5-private-dev, qtwayland5-dev-tools, qtwayland5-private-dev, libdtkgui-dev, libdtkwidget-dev, libdtkcore5-bin,
- qt6-l10n-tools, qt6-svg-dev, dde-tray-loader-dev (>= 0.0.11)
+ qt6-l10n-tools, qt6-svg-dev, dde-tray-loader-dev (>= 0.0.11), dde-application-manager-api(>= 1.2.16)
 Standards-Version: 3.9.8
 Homepage: http://www.deepin.org
 

--- a/debian/dde-shell.install
+++ b/debian/dde-shell.install
@@ -12,10 +12,13 @@ usr/lib/*/dde-shell/org.deepin.ds.dde-appearance*
 usr/share/dde-shell/org.deepin.ds.dde-appearance*/
 usr/lib/*/dde-shell/org.deepin.ds.dde-am*
 usr/share/dde-shell/org.deepin.ds.dde-am*/
+usr/lib/*/dde-shell/org.deepin.ds.dde-apps*
+usr/share/dde-shell/org.deepin.ds.dde-apps*/
 usr/share/dsg/configs/org.deepin.ds.dock/
 usr/share/dsg/configs/org.deepin.dde.shell/org.deepin.dde.shell.json
 usr/share/dsg/configs/org.deepin.dde.shell/org.deepin.ds.dock.tray.json
 usr/share/dsg/configs/org.deepin.dde.shell/org.deepin.ds.dock.json
 usr/share/dsg/configs/org.deepin.dde.shell/org.deepin.ds.dock.taskmanager.json
+usr/share/dsg/configs/org.deepin.dde.shell/org.deepin.ds.dde-apps.json
 usr/share/dde-shell/*/translations
 usr/share/dde-dock/icons/dcc-setting/*.svg

--- a/panels/dock/taskmanager/CMakeLists.txt
+++ b/panels/dock/taskmanager/CMakeLists.txt
@@ -49,6 +49,7 @@ qt_add_dbus_adaptor(DBUS_INTERFACES
 
 add_library(dock-taskmanager SHARED ${DBUS_INTERFACES}
     abstractwindow.h
+    abstractwindowmonitor.cpp
     abstractwindowmonitor.h
     abstractitem.h
     abstractitem.cpp
@@ -56,6 +57,8 @@ add_library(dock-taskmanager SHARED ${DBUS_INTERFACES}
     appitem.h
     itemmodel.cpp
     itemmodel.h
+    rolecombinemodel.cpp
+    rolecombinemodel.h
     desktopfileabstractparser.cpp
     desktopfileabstractparser.h
     desktopfileamparser.cpp
@@ -86,7 +89,7 @@ target_link_libraries(dock-taskmanager PRIVATE
 
 if (BUILD_WITH_X11)
     target_compile_definitions(dock-taskmanager PRIVATE BUILD_WITH_X11=)
-    pkg_check_modules(XCB REQUIRED IMPORTED_TARGET xcb xcb-res xcb-ewmh)
+    pkg_check_modules(TaskmanagerXcb REQUIRED IMPORTED_TARGET xcb xcb-res xcb-ewmh xcb-icccm)
     find_package(Dtk${DTK_VERSION_MAJOR} REQUIRED COMPONENTS Widget)
     target_sources(dock-taskmanager PRIVATE
         x11preview.h
@@ -101,7 +104,7 @@ if (BUILD_WITH_X11)
     )
 
     target_link_libraries(dock-taskmanager PUBLIC
-        PkgConfig::XCB
+        PkgConfig::TaskmanagerXcb
         Qt${QT_VERSION_MAJOR}::Widgets
         Dtk${DTK_VERSION_MAJOR}::Widget
     )

--- a/panels/dock/taskmanager/abstractwindow.h
+++ b/panels/dock/taskmanager/abstractwindow.h
@@ -19,16 +19,20 @@ class AbstractWindow : public QObject
     Q_OBJECT
     Q_PROPERTY(uint32_t id READ id)
     Q_PROPERTY(pid_t pid READ pid NOTIFY pidChanged FINAL)
+    Q_PROPERTY(QStringList identity READ identity NOTIFY identityChanged FINAL)
     Q_PROPERTY(QString icon READ icon NOTIFY iconChanged FINAL)
     Q_PROPERTY(QString title READ title NOTIFY titleChanged FINAL)
     Q_PROPERTY(bool isActive READ isActive NOTIFY isActiveChanged FINAL)
     Q_PROPERTY(bool shouldSkip READ shouldSkip NOTIFY shouldSkipChanged FINAL)
 
 public:
+    enum Roles { winIdRole = Qt::UserRole + 1, pidRole, identityRole, winIconRole, winTitleRole, activeRole, shouldSkipRole };
+    Q_ENUM(Roles)
     virtual ~AbstractWindow() {};
 
     virtual uint32_t id() = 0;
     virtual pid_t pid() = 0;
+    virtual QStringList identity() = 0;
     virtual QString icon() = 0;
     virtual QString title() = 0;
     virtual bool isActive() = 0;
@@ -61,17 +65,9 @@ protected:
 private:
     QPointer<AppItem> m_appitem;
 
-private:
-    virtual void updatePid() = 0;
-    virtual void updateIcon() = 0;
-    virtual void updateTitle() = 0;
-    virtual void updateIsActive() = 0;
-    virtual void updateShouldSkip() = 0;
-    virtual void updateAllowClose() = 0;
-    virtual void updateIsMinimized() = 0;
-
 Q_SIGNALS:
     void pidChanged();
+    void identityChanged();
     void iconChanged();
     void titleChanged();
     void isActiveChanged();

--- a/panels/dock/taskmanager/abstractwindowmonitor.cpp
+++ b/panels/dock/taskmanager/abstractwindowmonitor.cpp
@@ -1,0 +1,108 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "abstractwindowmonitor.h"
+#include "abstractwindow.h"
+
+namespace dock
+{
+AbstractWindowMonitor::AbstractWindowMonitor(QObject *parent)
+    : QAbstractListModel(parent)
+{
+}
+
+QHash<int, QByteArray> AbstractWindowMonitor::roleNames() const
+{
+    return {{AbstractWindow::winIdRole, "winId"},
+            {AbstractWindow::pidRole, "pid"},
+            {AbstractWindow::identityRole, "identity"},
+            {AbstractWindow::winIconRole, "icon"},
+            {AbstractWindow::winTitleRole, "title"},
+            {AbstractWindow::activeRole, "isActive"},
+            {AbstractWindow::shouldSkipRole, "shouldSkip"}};
+}
+
+int AbstractWindowMonitor::rowCount(const QModelIndex &parent) const
+{
+    return m_trackedWindows.size();
+}
+
+QVariant AbstractWindowMonitor::data(const QModelIndex &index, int role) const
+{
+    auto pos = index.row();
+    if (pos >= m_trackedWindows.size())
+        return QVariant();
+    auto window = m_trackedWindows[pos];
+
+    switch (role) {
+    case AbstractWindow::winIdRole:
+        return window->id();
+    case AbstractWindow::pidRole:
+        return window->pid();
+    case AbstractWindow::identityRole:
+        return window->identity();
+    case AbstractWindow::winIconRole:
+        return window->icon();
+    case AbstractWindow::winTitleRole:
+        return window->title();
+    case AbstractWindow::activeRole:
+        return window->isActive();
+    case AbstractWindow::shouldSkipRole:
+        return window->shouldSkip();
+    }
+
+    return QVariant();
+}
+
+void AbstractWindowMonitor::trackWindow(AbstractWindow *window)
+{
+    beginInsertRows(QModelIndex(), m_trackedWindows.size(), m_trackedWindows.size() + 1);
+    m_trackedWindows.append(window);
+    endInsertRows();
+
+    connect(window, &AbstractWindow::pidChanged, this, [this, window]() {
+        auto pos = m_trackedWindows.indexOf(window);
+        auto modelIndex = index(pos);
+        Q_EMIT dataChanged(modelIndex, modelIndex, {AbstractWindow::pidRole});
+    });
+    connect(window, &AbstractWindow::identityChanged, this, [this, window]() {
+        auto pos = m_trackedWindows.indexOf(window);
+        auto modelIndex = index(pos);
+        Q_EMIT dataChanged(modelIndex, modelIndex, {AbstractWindow::identityRole});
+    });
+    connect(window, &AbstractWindow::iconChanged, this, [this, window]() {
+        auto pos = m_trackedWindows.indexOf(window);
+        auto modelIndex = index(pos);
+        Q_EMIT dataChanged(modelIndex, modelIndex, {AbstractWindow::winIconRole});
+    });
+    connect(window, &AbstractWindow::titleChanged, this, [this, window]() {
+        auto pos = m_trackedWindows.indexOf(window);
+        auto modelIndex = index(pos);
+        Q_EMIT dataChanged(modelIndex, modelIndex, {AbstractWindow::winTitleRole});
+    });
+
+    connect(window, &AbstractWindow::isActiveChanged, this, [this, window]() {
+        auto pos = m_trackedWindows.indexOf(window);
+        auto modelIndex = index(pos);
+        Q_EMIT dataChanged(modelIndex, modelIndex, {AbstractWindow::activeRole});
+    });
+    connect(window, &AbstractWindow::shouldSkipChanged, this, [this, window]() {
+        auto pos = m_trackedWindows.indexOf(window);
+        auto modelIndex = index(pos);
+        Q_EMIT dataChanged(modelIndex, modelIndex, {AbstractWindow::shouldSkipRole});
+    });
+}
+
+void AbstractWindowMonitor::destroyWindow(AbstractWindow *window)
+{
+    auto pos = m_trackedWindows.indexOf(window);
+    if (pos == -1)
+        return;
+
+    beginRemoveRows(QModelIndex(), pos, pos + 1);
+    m_trackedWindows.removeOne(window);
+    endRemoveRows();
+}
+
+}

--- a/panels/dock/taskmanager/abstractwindowmonitor.h
+++ b/panels/dock/taskmanager/abstractwindowmonitor.h
@@ -4,26 +4,33 @@
 
 #pragma once
 
-#include "dsglobal.h"
 #include "abstractwindow.h"
 
 #include <cstdint>
 
+#include <QAbstractListModel>
 #include <QObject>
-
 
 namespace dock {
 class AppItem;
-class AbstractWindowMonitor : public QObject
+class AbstractWindowMonitor : public QAbstractListModel
 {
     Q_OBJECT
 
 public:
-    AbstractWindowMonitor(QObject* parent = nullptr): QObject(parent){};
+    QHash<int, QByteArray> roleNames() const override;
+    int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+    QVariant data(const QModelIndex &index, int role = AbstractWindow::winIdRole) const override;
+
+    void trackWindow(AbstractWindow *window);
+    void destroyWindow(AbstractWindow *window);
+
+    AbstractWindowMonitor(QObject *parent = nullptr);
     virtual void start() = 0;
     virtual void stop() = 0;
     virtual void clear() = 0;
 
+    // TODO: remove this when Modelized finizhed.
     virtual QPointer<AbstractWindow> getWindowByWindowId(ulong windowId) = 0;
 
     virtual void presentWindows(QList<uint32_t> windowsId) = 0;
@@ -34,5 +41,8 @@ public:
 Q_SIGNALS:
     void windowAdded(QPointer<AbstractWindow> window);
     void WindowMonitorShutdown();
+
+private:
+    QList<AbstractWindow *> m_trackedWindows;
 };
 }

--- a/panels/dock/taskmanager/appitem.cpp
+++ b/panels/dock/taskmanager/appitem.cpp
@@ -52,7 +52,7 @@ QString AppItem::type() const
 
 QString AppItem::icon() const
 {
-    if (m_currentActiveWindow.isNull() || (m_desktopfileParser && m_desktopfileParser->isValied().first))
+    if (m_currentActiveWindow.isNull() || m_currentActiveWindow->icon().isEmpty() || (m_desktopfileParser && m_desktopfileParser->isValied().first))
         return m_desktopfileParser ? m_desktopfileParser->desktopIcon() : "application-default-icon";
     else {
         return m_currentActiveWindow->icon();

--- a/panels/dock/taskmanager/rolecombinemodel.cpp
+++ b/panels/dock/taskmanager/rolecombinemodel.cpp
@@ -1,0 +1,208 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "rolecombinemodel.h"
+
+#include <algorithm>
+
+RoleCombineModel::RoleCombineModel(QAbstractItemModel *major, QAbstractItemModel *minor, int majorRoles, CombineFunc func, QObject *parent)
+    : QAbstractProxyModel(parent)
+{
+    setSourceModel(major);
+    m_minor = minor;
+    // create minor row & column map
+    int rowCount = major->rowCount();
+    int columnCount = major->columnCount();
+    for (int i = 0; i < rowCount; i++) {
+        for (int j = 0; j < columnCount; j++) {
+            QModelIndex majorIndex = major->index(i, j);
+            QModelIndex minorIndex = func(majorIndex.data(majorRoles), m_minor);
+            if (majorIndex.isValid() && minorIndex.isValid())
+                m_indexMap[qMakePair(i, j)] = qMakePair(minorIndex.row(), minorIndex.column());
+        }
+    }
+
+    connect(sourceModel(), &QAbstractItemModel::rowsInserted, this, [this, majorRoles, func](const QModelIndex &parent, int first, int last) {
+        beginInsertRows(index(parent.row(), parent.column()), first, last);
+        for (int i = first; i < last; i++) {
+            QModelIndex majorIndex = sourceModel()->index(i, 0);
+            QModelIndex minorIndex = func(majorIndex.data(majorRoles), m_minor);
+            if (majorIndex.isValid() && minorIndex.isValid())
+                m_indexMap[qMakePair(i, 0)] = qMakePair(minorIndex.row(), minorIndex.column());
+        }
+        endInsertRows();
+    });
+    connect(sourceModel(), &QAbstractItemModel::columnsInserted, this, [this, majorRoles, func](const QModelIndex &parent, int first, int last) {
+        beginInsertColumns(index(parent.row(), parent.column()), first, last);
+        for (int j = first; j < last; j++) {
+            QModelIndex majorIndex = sourceModel()->index(0, j);
+            QModelIndex minorIndex = func(majorIndex.data(majorRoles), m_minor);
+            if (majorIndex.isValid() && minorIndex.isValid())
+                m_indexMap[qMakePair(0, j)] = qMakePair(minorIndex.row(), minorIndex.column());
+        }
+        endInsertColumns();
+    });
+
+    connect(sourceModel(), &QAbstractItemModel::rowsRemoved, this, [this](const QModelIndex &parent, int first, int last) {
+        beginRemoveRows(index(parent.row(), parent.column()), first, last);
+        for (int i = first; i < last; i++) {
+            if (m_indexMap.contains(qMakePair(i, 0))) {
+                m_indexMap.remove(qMakePair(i, 0));
+            }
+        }
+        endRemoveRows();
+    });
+    connect(sourceModel(), &QAbstractItemModel::columnsRemoved, this, [this](const QModelIndex &parent, int first, int last) {
+        beginRemoveColumns(index(parent.row(), parent.column()), first, last);
+        for (int j = first; j < last; j++) {
+            if (m_indexMap.contains(qMakePair(0, j))) {
+                m_indexMap.remove(qMakePair(0, j));
+            }
+        }
+        endRemoveColumns();
+    });
+
+    // connect changedSignal
+    connect(major,
+            &QAbstractItemModel::dataChanged,
+            this,
+            [this, majorRoles, func](const QModelIndex &topLeft, const QModelIndex &bottomRight, const QList<int> &roles) {
+                for (int i = topLeft.row(); i <= bottomRight.row(); i++) {
+                    for (int j = topLeft.column(); j <= bottomRight.column(); j++) {
+                        QModelIndex majorIndex = sourceModel()->index(i, j);
+                        QModelIndex minorIndex = func(majorIndex.data(majorRoles), m_minor);
+                        if (majorIndex.isValid() && minorIndex.isValid())
+                            m_indexMap[qMakePair(i, j)] = qMakePair(minorIndex.row(), minorIndex.column());
+                    }
+                }
+
+                Q_EMIT dataChanged(index(topLeft.row(), topLeft.column()),
+                                   index(bottomRight.row(), bottomRight.column()),
+                                   roles + (roles.contains(majorRoles) ? m_minorRolesMap.values() : QList<int>()));
+            });
+
+    // appended roles from minor datachanged
+    connect(m_minor,
+            &QAbstractItemModel::dataChanged,
+            this,
+            [this, majorRoles, func](const QModelIndex &topLeft, const QModelIndex &bottomRight, const QList<int> &roles) {
+                for (int i = topLeft.row(); i <= bottomRight.row(); i++) {
+                    for (int j = topLeft.column(); j <= bottomRight.column(); j++) {
+                        auto majorPos = m_indexMap.key(qMakePair(i, j), qMakePair(-1, -1));
+                        if (-1 == majorPos.first && -1 == majorPos.second)
+                            continue;
+
+                        auto majorIndex = sourceModel()->index(majorPos.first, majorPos.second);
+                        if (!majorIndex.isValid())
+                            continue;
+
+                        auto minorIndex = func(majorIndex.data(majorRoles), m_minor);
+                        if (!minorIndex.isValid())
+                            continue;
+
+                        m_indexMap[majorPos] = qMakePair(minorIndex.row(), minorIndex.column());
+                        Q_EMIT dataChanged(majorIndex, majorIndex, m_minorRolesMap.values());
+                    }
+                }
+            });
+
+    connect(m_minor, &QAbstractItemModel::rowsInserted, this, [this, majorRoles, func](const QModelIndex &parent, int first, int last) {
+        auto rowCount = sourceModel()->rowCount();
+        auto columnCount = sourceModel()->columnCount();
+        for (int i = 0; i < rowCount; i++) {
+            for (int j = 0; j < columnCount; j++) {
+                // alreay bind, pass this
+                if (m_indexMap.contains(qMakePair(i, j)))
+                    continue;
+
+                QModelIndex majorIndex = sourceModel()->index(i, j);
+                QModelIndex minorIndex = func(majorIndex.data(majorRoles), m_minor);
+                if (majorIndex.isValid() && minorIndex.isValid())
+                    m_indexMap[qMakePair(i, j)] = qMakePair(minorIndex.row(), minorIndex.column());
+            }
+        }
+    });
+
+    // TODO: support columsInserted
+
+    // create minor role map
+    auto minorRolenames = m_minor->roleNames();
+    auto thisRoleNames = roleNames();
+    std::for_each(minorRolenames.constBegin(), minorRolenames.constEnd(), [&minorRolenames, &thisRoleNames, this](auto &roleName) {
+        m_minorRolesMap.insert(thisRoleNames.key(roleName), minorRolenames.key(roleName));
+    });
+}
+
+QHash<int, QByteArray> RoleCombineModel::roleNames() const
+{
+    auto roleNames = sourceModel()->roleNames();
+    auto keys = sourceModel()->roleNames().keys();
+    auto lastRole = *(std::max_element(keys.constBegin(), keys.constEnd()));
+    auto minorRoleNames = m_minor->roleNames().values();
+    std::for_each(minorRoleNames.constBegin(), minorRoleNames.constEnd(), [&lastRole, &roleNames, this](auto &roleName) {
+        roleNames.insert(++lastRole, roleName);
+    });
+
+    return roleNames;
+}
+
+int RoleCombineModel::rowCount(const QModelIndex &parent) const
+{
+    return sourceModel()->rowCount();
+}
+
+int RoleCombineModel::columnCount(const QModelIndex &parent) const
+{
+    return sourceModel()->columnCount();
+}
+
+QVariant RoleCombineModel::data(const QModelIndex &index, int role) const
+{
+    if (m_minorRolesMap.contains(role)) {
+        int row, column;
+        std::tie(row, column) = m_indexMap.value(qMakePair(index.row(), index.column()), qMakePair(-1, -1));
+        return m_minor->data(m_minor->index(row, column), m_minorRolesMap[role]);
+    } else {
+        return sourceModel()->data(sourceModel()->index(index.row(), index.column()), role);
+    }
+}
+
+bool RoleCombineModel::hasIndex(int row, int column, const QModelIndex &parent) const
+{
+    return sourceModel()->hasIndex(row, column, parent);
+}
+
+QModelIndex RoleCombineModel::index(int row, int column, const QModelIndex &parent) const
+{
+    if (!hasIndex(row, column, parent))
+        return QModelIndex();
+
+    auto index = sourceModel()->index(row, column);
+    return createIndex(row, column, index.internalPointer());
+}
+
+QModelIndex RoleCombineModel::parent(const QModelIndex &child) const
+{
+    return QModelIndex();
+}
+
+QAbstractItemModel *RoleCombineModel::majorModel() const
+{
+    return sourceModel();
+}
+
+QAbstractItemModel *RoleCombineModel::minorModel() const
+{
+    return m_minor;
+}
+
+QModelIndex RoleCombineModel::mapToSource(const QModelIndex &proxyIndex) const
+{
+    return sourceModel()->index(proxyIndex.row(), proxyIndex.column());
+}
+
+QModelIndex RoleCombineModel::mapFromSource(const QModelIndex &sourceIndex) const
+{
+    return index(sourceIndex.row(), sourceIndex.column());
+}

--- a/panels/dock/taskmanager/rolecombinemodel.h
+++ b/panels/dock/taskmanager/rolecombinemodel.h
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <QAbstractListModel>
+#include <QAbstractProxyModel>
+
+typedef QModelIndex (*CombineFunc)(QVariant, QAbstractItemModel *);
+
+class RoleCombineModel : public QAbstractProxyModel
+{
+    Q_OBJECT
+    Q_PROPERTY(QAbstractItemModel majorModel READ majorModel CONSTANT FINAL)
+    Q_PROPERTY(QAbstractItemModel minorModel READ minorModel CONSTANT FINAL)
+
+public:
+    RoleCombineModel(QAbstractItemModel *major, QAbstractItemModel *minor, int majorRoles, CombineFunc func, QObject *parent = nullptr);
+
+    int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+    int columnCount(const QModelIndex &parent = QModelIndex()) const override;
+    QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
+    QHash<int, QByteArray> roleNames() const override;
+
+    bool hasIndex(int row, int column, const QModelIndex &parent = QModelIndex()) const;
+    Q_INVOKABLE virtual QModelIndex index(int row, int column, const QModelIndex &parent = QModelIndex()) const override;
+    Q_INVOKABLE virtual QModelIndex parent(const QModelIndex &child) const override;
+
+    QAbstractItemModel *majorModel() const;
+    QAbstractItemModel *minorModel() const;
+
+    QModelIndex mapToSource(const QModelIndex &proxyIndex) const override;
+    QModelIndex mapFromSource(const QModelIndex &sourceIndex) const override;
+
+private:
+    QAbstractItemModel *m_minor;
+
+    // Hash table used to map this QModelIndex row & column 2 origin QModelIndex row & column.
+    QMap<QPair<int, int>, QPair<int, int>> m_indexMap;
+    // Hash table map role in this model to role in origin model.
+    QHash<int, int> m_minorRolesMap;
+};

--- a/panels/dock/taskmanager/taskmanager.cpp
+++ b/panels/dock/taskmanager/taskmanager.cpp
@@ -4,20 +4,24 @@
 
 #include "appitem.h"
 
+#include "abstractwindow.h"
+#include "abstractwindowmonitor.h"
+#include "desktopfileamparser.h"
+#include "desktopfileparserfactory.h"
+#include "dsglobal.h"
 #include "globals.h"
 #include "itemmodel.h"
-#include "taskmanager.h"
 #include "pluginfactory.h"
-#include "abstractwindow.h"
+#include "pluginloader.h"
+#include "rolecombinemodel.h"
+#include "taskmanager.h"
 #include "taskmanageradaptor.h"
-#include "desktopfileamparser.h"
 #include "taskmanagersettings.h"
 #include "treelandwindowmonitor.h"
-#include "abstractwindowmonitor.h"
-#include "desktopfileparserfactory.h"
 
-#include <QStringLiteral>
 #include <QGuiApplication>
+#include <QStringLiteral>
+#include <qtimer.h>
 
 #ifdef BUILD_WITH_X11
 #include "x11windowmonitor.h"
@@ -76,8 +80,55 @@ bool TaskManager::init()
     QDBusConnection::sessionBus().registerObject("/org/deepin/ds/Dock/TaskManager", "org.deepin.ds.Dock.TaskManager", this);
 
     DApplet::init();
-    if (m_windowMonitor)
-        m_windowMonitor->start();
+
+    auto findApplet = [this](QString pluginId) {
+        QList<DS_NAMESPACE::DApplet *> ret;
+        auto root = qobject_cast<DS_NAMESPACE::DContainment *>(DS_NAMESPACE::DPluginLoader::instance()->rootApplet());
+
+        QQueue<DS_NAMESPACE::DContainment *> containments;
+        containments.enqueue(root);
+        while (!containments.isEmpty()) {
+            DS_NAMESPACE::DContainment *containment = containments.dequeue();
+            for (const auto applet : containment->applets()) {
+                if (auto item = qobject_cast<DS_NAMESPACE::DContainment *>(applet)) {
+                    containments.enqueue(item);
+                }
+                if (applet->pluginId() == pluginId)
+                    ret << applet;
+            }
+        }
+        return ret;
+    };
+
+    auto c = findApplet("org.deepin.ds.dde-apps");
+    if (c.size() > 0) {
+        auto model = c.first()->property("appModel").value<QAbstractItemModel *>();
+        m_activeAppModel =
+            new RoleCombineModel(m_windowMonitor.data(), model, AbstractWindow::identityRole, [](QVariant data, QAbstractItemModel *model) -> QModelIndex {
+                auto roleNames = model->roleNames();
+                QList<QByteArray> identifiedOrders = {"desktopId", "startupWMClass", "name", "iconName"};
+
+                auto indentifies = data.toStringList();
+                for (auto id : indentifies) {
+                    if (id.isEmpty())
+                        continue;
+
+                    for (auto identifiedOrder : identifiedOrders) {
+                        auto res = model->match(model->index(0, 0), roleNames.key(identifiedOrder), id);
+                        if (res.size() > 0 && res.first().isValid()) {
+                            return res.first();
+                        }
+                    }
+                }
+
+                return QModelIndex();
+            });
+    }
+
+    QTimer::singleShot(500, [this]() {
+        if (m_windowMonitor)
+            m_windowMonitor->start();
+    });
     return true;
 }
 
@@ -89,7 +140,22 @@ ItemModel* TaskManager::dataModel()
 void TaskManager::handleWindowAdded(QPointer<AbstractWindow> window)
 {
     if (!window || window->shouldSkip() || window->getAppItem() != nullptr) return;
-    auto desktopfile = DESKTOPFILEFACTORY::createByWindow(window);
+
+    // TODO: remove below code and use use model replaced.
+    QModelIndexList res;
+    if (m_activeAppModel) {
+        qDebug() << m_activeAppModel->rowCount();
+        res = m_activeAppModel->match(m_activeAppModel->index(0, 0), AbstractWindow::winIdRole, window->id());
+    }
+
+    QSharedPointer<DesktopfileAbstractParser> desktopfile = nullptr;
+    if (res.size() > 0) {
+        desktopfile = DESKTOPFILEFACTORY::createById(res.first().data(m_activeAppModel->roleNames().key("desktopId")).toString(), "amAPP");
+    }
+
+    if (!desktopfile || !desktopfile->isValied().first) {
+        desktopfile = DESKTOPFILEFACTORY::createByWindow(window);
+    }
 
     auto appitem = desktopfile->getAppItem();
 

--- a/panels/dock/taskmanager/taskmanager.h
+++ b/panels/dock/taskmanager/taskmanager.h
@@ -4,10 +4,11 @@
 
 #pragma once
 
-#include "itemmodel.h"
-#include "containment.h"
 #include "abstractwindow.h"
 #include "abstractwindowmonitor.h"
+#include "containment.h"
+#include "itemmodel.h"
+#include "rolecombinemodel.h"
 
 #include <QPointer>
 
@@ -58,6 +59,7 @@ private:
 
 private:
     QScopedPointer<AbstractWindowMonitor> m_windowMonitor;
+    RoleCombineModel *m_activeAppModel = nullptr;
 };
 
 }

--- a/panels/dock/taskmanager/treelandwindow.cpp
+++ b/panels/dock/taskmanager/treelandwindow.cpp
@@ -35,6 +35,11 @@ pid_t ForeignToplevelHandle::pid() const
     return m_pid;
 }
 
+QString ForeignToplevelHandle::appid() const
+{
+    return m_appId;
+}
+
 QString ForeignToplevelHandle::title() const
 {
     return m_title;
@@ -123,6 +128,11 @@ pid_t TreeLandWindow::pid()
     return m_foreignToplevelHandle ? m_foreignToplevelHandle->pid() : 0;
 }
 
+QStringList TreeLandWindow::identity()
+{
+    return {m_foreignToplevelHandle ? m_foreignToplevelHandle->appid() : ""};
+}
+
 QString TreeLandWindow::icon()
 {
     return "";
@@ -131,10 +141,6 @@ QString TreeLandWindow::icon()
 QString TreeLandWindow::title()
 {
     return m_foreignToplevelHandle ? m_foreignToplevelHandle->title() : "";
-}
-
-void TreeLandWindow::updateIsActive()
-{
 }
 
 bool TreeLandWindow::isActive()
@@ -195,35 +201,6 @@ void TreeLandWindow::setWindowIconGeometry(const QWindow* baseWindow, const QRec
 {
     auto waylandWindow = dynamic_cast<QtWaylandClient::QWaylandWindow*>(baseWindow->handle());
     m_foreignToplevelHandle->set_rectangle(waylandWindow->surface(), gemeotry.x(), gemeotry.y(), gemeotry.width(), gemeotry.height());
-}
-
-void TreeLandWindow::updatePid()
-{
-
-}
-void TreeLandWindow::updateIcon()
-{
-
-}
-
-void TreeLandWindow::updateTitle()
-{
-
-}
-
-void TreeLandWindow::updateShouldSkip()
-{
-
-}
-
-void TreeLandWindow::updateAllowClose()
-{
-
-}
-
-void TreeLandWindow::updateIsMinimized()
-{
-
 }
 
 bool TreeLandWindow::isReady()

--- a/panels/dock/taskmanager/treelandwindow.h
+++ b/panels/dock/taskmanager/treelandwindow.h
@@ -23,6 +23,7 @@ public:
     bool isReady() const;
     uint32_t id() const;
     pid_t pid() const;
+    QString appid() const;
     QString title() const;
     QList<uint32_t> state() const;
 
@@ -73,6 +74,7 @@ public:
 
     uint32_t id() override;
     pid_t pid() override;
+    QStringList identity() override;
     QString icon() override;
     QString title() override;
     bool isActive() override;
@@ -89,14 +91,6 @@ public:
     void setWindowIconGeometry(const QWindow* baseWindow, const QRect& gemeotry) override;
 
 private:
-    void updatePid() override;
-    void updateIcon() override;
-    void updateTitle() override;
-    void updateIsActive() override;
-    void updateShouldSkip() override;
-    void updateAllowClose() override;
-    void updateIsMinimized() override;
-
     void setForeignToplevelHandle(ForeignToplevelHandle* handle);
 
     bool isReady();

--- a/panels/dock/taskmanager/treelandwindowmonitor.cpp
+++ b/panels/dock/taskmanager/treelandwindowmonitor.cpp
@@ -169,6 +169,7 @@ void TreeLandWindowMonitor::handleForeignToplevelHandleAdded()
     }
 
     window->setForeignToplevelHandle(handle);
+    trackWindow(window.get());
 
     if (window->isReady())
         Q_EMIT AbstractWindowMonitor::windowAdded(static_cast<QPointer<AbstractWindow>>(window.get()));
@@ -183,6 +184,7 @@ void TreeLandWindowMonitor::handleForeignToplevelHandleRemoved()
 
     auto id = handle->id();
     auto window = m_windows.value(id, nullptr);
+    destroyWindow(window.get());
 
     if (window) {
         m_windows.remove(id);

--- a/panels/dock/taskmanager/x11utils.cpp
+++ b/panels/dock/taskmanager/x11utils.cpp
@@ -256,6 +256,21 @@ MotifWMHints X11Utils::getWindowMotifWMHints(const xcb_window_t& window)
     return ret;
 }
 
+QStringList X11Utils::getWindowWMClass(const xcb_window_t &window)
+{
+    xcb_icccm_get_wm_class_reply_t wmClassReply;
+    xcb_get_property_cookie_t wmClassCookie;
+    wmClassCookie = xcb_icccm_get_wm_class(m_connection, window);
+    if (xcb_icccm_get_wm_class_reply(m_connection, wmClassCookie, &wmClassReply, nullptr)) {
+        QString instanceName = wmClassReply.instance_name;
+        QString className = wmClassReply.class_name;
+        xcb_icccm_get_wm_class_reply_wipe(&wmClassReply);
+        return {instanceName, className};
+    }
+
+    return {};
+}
+
 QList<xcb_atom_t> X11Utils::getWindowTypes(const xcb_window_t &window)
 {
     QList<xcb_atom_t> ret;

--- a/panels/dock/taskmanager/x11utils.h
+++ b/panels/dock/taskmanager/x11utils.h
@@ -57,6 +57,7 @@ public:
     QList<xcb_window_t> getWindowClientList(const xcb_window_t& window);
     QList<xcb_atom_t> getWindowAllowedActions(const xcb_window_t& window);
     MotifWMHints getWindowMotifWMHints(const xcb_window_t& window);
+    QStringList getWindowWMClass(const xcb_window_t &window);
 
     void minimizeWindow(const xcb_window_t& window);
     void maxmizeWindow(const xcb_window_t& window);

--- a/panels/dock/taskmanager/x11window.cpp
+++ b/panels/dock/taskmanager/x11window.cpp
@@ -45,6 +45,15 @@ pid_t X11Window::pid()
     return m_pid;
 }
 
+QStringList X11Window::identity()
+{
+    if (m_identity.isEmpty()) {
+        m_identity = X11->getWindowWMClass(m_windowID);
+    }
+
+    return m_identity;
+}
+
 QString X11Window::icon()
 {
     if (m_icon.isEmpty()) {
@@ -155,6 +164,16 @@ void X11Window::updatePid()
     m_pid = X11->getWindowPid(m_windowID);
     if (oldPid != m_pid)
         Q_EMIT AbstractWindow::pidChanged();
+}
+
+void X11Window::updateIdentify()
+{
+    auto newWmclas = X11->getWindowWMClass(m_windowID);
+    if (newWmclas == m_identity)
+        return;
+
+    m_identity = newWmclas;
+    Q_EMIT identityChanged();
 }
 
 void X11Window::updateIcon()

--- a/panels/dock/taskmanager/x11window.h
+++ b/panels/dock/taskmanager/x11window.h
@@ -22,6 +22,7 @@ public:
     ~X11Window();
     virtual uint32_t id() override;
     virtual pid_t pid() override;
+    virtual QStringList identity() override;
     virtual QString icon() override;
     virtual QString title() override;
     virtual bool isActive() override;
@@ -42,13 +43,14 @@ private:
     X11Window(xcb_window_t winid, QObject *parent = nullptr);
 
 private:
-    virtual void updatePid() override;
-    virtual void updateIcon() override;
-    virtual void updateTitle() override;
-    virtual void updateIsActive() override;
-    virtual void updateShouldSkip() override;
-    virtual void updateAllowClose() override;
-    virtual void updateIsMinimized() override;
+    void updatePid();
+    void updateIdentify();
+    void updateIcon();
+    void updateTitle();
+    void updateIsActive();
+    void updateShouldSkip();
+    void updateAllowClose();
+    void updateIsMinimized();
 
     void updateMotifWmHints();
 
@@ -68,6 +70,7 @@ private:
 private:
     xcb_window_t m_windowID;
     pid_t m_pid;
+    QStringList m_identity;
     QString m_icon;
     QString m_title;
 

--- a/panels/dock/taskmanager/x11windowmonitor.cpp
+++ b/panels/dock/taskmanager/x11windowmonitor.cpp
@@ -157,6 +157,7 @@ void X11WindowMonitor::onWindowMapped(xcb_window_t xcb_window)
 
     uint32_t value_list[] = { XCB_EVENT_MASK_PROPERTY_CHANGE | XCB_EVENT_MASK_STRUCTURE_NOTIFY | XCB_EVENT_MASK_VISIBILITY_CHANGE};
     xcb_change_window_attributes(X11->getXcbConnection(), xcb_window, XCB_CW_EVENT_MASK, value_list);
+    trackWindow(window.get());
     Q_EMIT AbstractWindowMonitor::windowAdded(static_cast<QPointer<AbstractWindow>>(window.get()));
 }
 
@@ -164,6 +165,7 @@ void X11WindowMonitor::onWindowDestoried(xcb_window_t xcb_window)
 {
     auto window = m_windows.value(xcb_window, nullptr);
     if (window) {
+        destroyWindow(window.get());
         m_windows.remove(xcb_window);
     }
 }


### PR DESCRIPTION
- 新增dde-apps模块用于提供dde-shell中所有desktop文件的信息
- 使用 wmclass/appid 等用于窗口身份的识别，而不是仅仅调用AMdbus