### PR TITLE
fix: tray is popped up when a plugin's visible changes

### DIFF
--- a/panels/dock/x11dockhelper.cpp
+++ b/panels/dock/x11dockhelper.cpp
@@ -86,6 +86,10 @@ void XcbEventFilter::processEnterLeave(xcb_window_t win, bool enter)
         }
     }
 
+    if (m_helper->dockerWinid() != win) {
+        return;
+    }
+
 // dock enter/leave
     m_helper->updateEnterState(enter);
 }
@@ -101,7 +105,7 @@ bool XcbEventFilter::nativeEventFilter(const QByteArray &eventType, void *messag
         auto eN = reinterpret_cast<xcb_enter_notify_event_t *>(xcb_event);
         qCDebug(dockX11Log) << "enter event winId:" << eN->event;
         if (m_timer->isActive()) {
-            if (!inTriggerArea(eN->event)) {
+            if (m_helper->dockerWinid() == eN->event && !inTriggerArea(eN->event)) {
                 m_timer->stop();
                 break;
             }
@@ -364,6 +368,7 @@ X11DockHelper::X11DockHelper(DockPanel* panel)
     connect(panel, &DockPanel::showInPrimaryChanged, this, &X11DockHelper::updateDockArea);
     connect(panel, &DockPanel::dockScreenChanged, this, &X11DockHelper::updateDockArea);
     connect(panel, &DockPanel::rootObjectChanged, this, [ this, panel ] {
+        m_dockWinid = panel->window()->winId();
         connect(panel->window(), &QWindow::visibleChanged, this, &X11DockHelper::updateWindowState, Qt::UniqueConnection);
         updateWindowState();
     });

--- a/panels/dock/x11dockhelper.h
+++ b/panels/dock/x11dockhelper.h
@@ -96,6 +96,7 @@ public:
     X11DockHelper(DockPanel* panel);
     HideState hideState() override;
     QList<DockTriggerArea*> triggerAreas() const { return m_areas; }
+    xcb_window_t dockerWinid() { return m_dockWinid; }
 
 public Q_SLOTS:
     void updateDockTriggerArea() override;
@@ -134,6 +135,7 @@ private:
     dock::HideState m_smartHideState;
     QHash<xcb_window_t, WindowData*> m_windows;
     XcbEventFilter *m_xcbHelper;
+    xcb_window_t m_dockWinid;
 };
 }
 


### PR DESCRIPTION
set dropHoverIndex to default value(-1)  when dropping

Bug: https://pms.uniontech.com/bug-view-279739.html
Log: