### PR TITLE
fix: Can't get appList for notification

### DIFF
--- a/frame/appletbridge.cpp
+++ b/frame/appletbridge.cpp
@@ -65,6 +65,12 @@ bool DAppletBridge::isValid() const
     return plugin.isValid();
 }
 
+QString DAppletBridge::pluginId() const
+{
+    D_DC(DAppletBridge);
+    return d->m_pluginId;
+}
+
 QList<DAppletProxy *> DAppletBridge::applets() const
 {
     D_DC(DAppletBridge);

--- a/frame/appletbridge.h
+++ b/frame/appletbridge.h
@@ -24,6 +24,7 @@ public:
     virtual ~DAppletBridge() override;
 
     bool isValid() const;
+    QString pluginId() const;
 
     QList<DAppletProxy *> applets() const;
     DAppletProxy *applet() const;

--- a/panels/notification/server/dbusadaptor.cpp
+++ b/panels/notification/server/dbusadaptor.cpp
@@ -51,11 +51,6 @@ DDENotificationDbusAdaptor::DDENotificationDbusAdaptor(QObject *parent)
     : QDBusAbstractAdaptor(parent)
 {
     setAutoRelaySignals(true);
-
-    connect(manager(), &NotificationManager::AppAdded, this, &DDENotificationDbusAdaptor::AppAdded);
-    connect(manager(), &NotificationManager::AppAdded, this, &DDENotificationDbusAdaptor::AppRemoved);
-    connect(manager(), &NotificationManager::AppInfoChanged, this, &DDENotificationDbusAdaptor::AppInfoChanged);
-    connect(manager(), &NotificationManager::SystemInfoChanged, this, &DDENotificationDbusAdaptor::SystemInfoChanged);
 }
 
 NotificationManager *DDENotificationDbusAdaptor::manager() const

--- a/panels/notification/server/dbusadaptor.h
+++ b/panels/notification/server/dbusadaptor.h
@@ -71,7 +71,7 @@ Q_SIGNALS:
     void SystemSettingChanged(const QString &settings);
     void SystemInfoChanged(uint configItem, const QDBusVariant &value);
 
-    void RecordAdded(const QString &storageId);
+    void NotificationStateChanged(qint64 id, int processedType);
     void RecordCountChanged(uint count);
 };
 

--- a/panels/notification/server/notificationmanager.h
+++ b/panels/notification/server/notificationmanager.h
@@ -50,8 +50,7 @@ Q_SIGNALS:
     void AppAdded(const QString &id);
     void AppRemoved(const QString &id);
 
-signals:
-    void notificationStateChanged(qint64 id, int processedType);
+    void NotificationStateChanged(qint64 id, int processedType);
 
 public Q_SLOTS:
     // Standard Notifications dbus implementation

--- a/panels/notification/server/notificationsetting.cpp
+++ b/panels/notification/server/notificationsetting.cpp
@@ -18,7 +18,7 @@ namespace notification {
 static const QString InvalidApp {"DS-Invalid-Apps"};
 namespace {
 enum Roles {
-    DesktopIdRole = Qt::UserRole + 1,
+    DesktopIdRole = 0x1000,
     NameRole,
     IconNameRole,
     StartUpWMClassRole,
@@ -31,7 +31,7 @@ enum Roles {
     DockedRole,
     OnDesktopRole,
     AutoStartRole,
-    ModelExtendedRole = 0x1000
+    GroupRole,
 };
 }
 
@@ -58,11 +58,16 @@ NotificationSetting::NotificationSetting(QObject *parent)
     });
 }
 
-void NotificationSetting::setAppAccessor(QAbstractListModel *model)
+void NotificationSetting::setAppAccessor(QAbstractItemModel *model)
 {
     m_appAccessor = model;
     QObject::connect(m_appAccessor, &QAbstractItemModel::rowsInserted, this, &NotificationSetting::onAppsChanged);
     QObject::connect(m_appAccessor, &QAbstractItemModel::rowsRemoved, this, &NotificationSetting::onAppsChanged);
+}
+
+QAbstractItemModel *NotificationSetting::appAccessor() const
+{
+    return m_appAccessor;
 }
 
 void NotificationSetting::setAppValue(const QString &id, AppConfigItem item, const QVariant &value)
@@ -234,7 +239,7 @@ QList<NotificationSetting::AppItem> NotificationSetting::appItemsImpl() const
     QList<NotificationSetting::AppItem> apps;
     apps.reserve(m_appAccessor->rowCount());
     for (int i = 0; i < m_appAccessor->rowCount(); i++) {
-        const auto index = m_appAccessor->index(i);
+        const auto index = m_appAccessor->index(i, 0);
         const auto nodisplay = m_appAccessor->data(index, NoDisplayRole).toBool();
         if (nodisplay)
             continue;

--- a/panels/notification/server/notificationsetting.h
+++ b/panels/notification/server/notificationsetting.h
@@ -15,7 +15,7 @@ namespace Core {
 }
 }
 
-class QAbstractListModel;
+class QAbstractItemModel;
 namespace notification {
 
 class NotificationSetting : public QObject
@@ -52,7 +52,8 @@ public:
 public:
     explicit NotificationSetting(QObject *parent = nullptr);
 
-    void setAppAccessor(QAbstractListModel *model);
+    void setAppAccessor(QAbstractItemModel *model);
+    QAbstractItemModel *appAccessor() const;
 
     void setAppValue(const QString &id, AppConfigItem item, const QVariant &value);
     QVariant appValue(const QString &id, AppConfigItem item);
@@ -83,7 +84,7 @@ private:
 
 private:
     Dtk::Core::DConfig *m_impl = nullptr;
-    QAbstractListModel *m_appAccessor = nullptr;
+    QAbstractItemModel *m_appAccessor = nullptr;
     QList<AppItem> m_appItems;
     QMutex m_appItemsMutex;
     QVariantMap m_appsInfo;

--- a/panels/notification/server/notifyserverapplet.cpp
+++ b/panels/notification/server/notifyserverapplet.cpp
@@ -51,7 +51,7 @@ bool NotifyServerApplet::init()
     new DbusAdaptor(m_manager);
     new DDENotificationDbusAdaptor(m_manager);
 
-    connect(m_manager, &NotificationManager::notificationStateChanged, this, &NotifyServerApplet::notificationStateChanged);
+    connect(m_manager, &NotificationManager::NotificationStateChanged, this, &NotifyServerApplet::notificationStateChanged);
 
     m_worker = new QThread();
     m_manager->moveToThread(m_worker);


### PR DESCRIPTION
Adapt the change of org.deepin.ds.dde-apps.
Add NotificationStateChange signal to expose notification's status.

task: https://pms.uniontech.com/task-view-365219.html
