### PR TITLE
fix: tray is popped up when a plugin's visible changes

### DIFF
--- a/panels/dock/tray/package/TrayContainer.qml
+++ b/panels/dock/tray/package/TrayContainer.qml
@@ -173,6 +173,7 @@ Item {
             console.log("dropped", currentItemIndex, isBefore)
             DDT.TraySortOrderModel.dropToDockTray(surfaceId, Math.floor(currentItemIndex), isBefore);
             DDT.TraySortOrderModel.actionsAlwaysVisible = false
+            dropHoverIndex = -1
         }
 
         Timer {


### PR DESCRIPTION
set dropHoverIndex to default value(-1)  when dropping

Bug: https://pms.uniontech.com/bug-view-279739.html 
Log: