### PR TITLE
fix: db file can't create firstly for notification

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -56,6 +56,7 @@ Package: dde-shell
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, libdde-shell( =${binary:Version}),
   libqt6svg6, qml6-module-qt-labs-platform,
+  libqt6sql6-sqlite,
   qml6-module-qtquick-layouts, qml6-module-qtquick-window,
   libdtk6declarative, qml6-module-qtquick-controls2-styles-chameleon,
   qml6-module-qtquick-layouts, qml6-module-qtquick-window,

--- a/debian/dde-shell.install
+++ b/debian/dde-shell.install
@@ -26,3 +26,4 @@ usr/share/dde-dock/icons/dcc-setting/*.svg
 usr/lib/*/qt6/qml/org/deepin/ds/notificationcenter/*
 usr/lib/*/dde-shell/org.deepin.ds.notificationcenter*
 usr/share/dde-shell/org.deepin.ds.notificationcenter*/
+usr/lib/*/libds-notification-shared.so.*

--- a/panels/notification/CMakeLists.txt
+++ b/panels/notification/CMakeLists.txt
@@ -18,6 +18,10 @@ add_library(ds-notification-shared SHARED
     ${CMAKE_SOURCE_DIR}/panels/notification/common/dbaccessor.cpp
 )
 
+set_target_properties(ds-notification-shared PROPERTIES
+    VERSION ${CMAKE_PROJECT_VERSION}
+    SOVERSION ${CMAKE_PROJECT_VERSION_MAJOR}
+)
 target_include_directories(ds-notification-shared PUBLIC
     ${CMAKE_SOURCE_DIR}/panels/notification/common
 )


### PR DESCRIPTION
Create db file if not exist.
Add dependencies when packaging.

Task: https://pms.uniontech.com/task-view-366403.html
