### PR TITLE
feat: use treeland output manager to update primaryScreen info

### DIFF
--- a/shell/CMakeLists.txt
+++ b/shell/CMakeLists.txt
@@ -2,7 +2,10 @@
 #
 # SPDX-License-Identifier: CC0-1.0
 
-find_package(Qt${QT_VERSION_MAJOR} ${REQUIRED_QT_VERSION} REQUIRED COMPONENTS Widgets)
+find_package(Qt${QT_VERSION_MAJOR} ${REQUIRED_QT_VERSION} REQUIRED COMPONENTS Widgets Gui WaylandClient)
+find_package(TreelandProtocols REQUIRED)
+pkg_check_modules(WaylandClient REQUIRED IMPORTED_TARGET wayland-client)
+
 if (NOT DEFINED SYSTEMD_USER_UNIT_DIR)
     find_package(PkgConfig REQUIRED)
     pkg_check_modules(Systemd REQUIRED systemd)
@@ -15,8 +18,15 @@ add_executable(dde-shell
     appletloader.cpp
     shell.h
     shell.cpp
+    treelandoutputwatcher.h
+    treelandoutputwatcher.cpp
     dde-shell.qrc
     override_dtkdeclarative_qml.qrc
+)
+
+qt_generate_wayland_protocol_client_sources(dde-shell
+    FILES
+        ${TREELAND_PROTOCOLS_DATA_DIR}/treeland-output-manager-v1.xml
 )
 
 target_compile_definitions(dde-shell
@@ -27,9 +37,12 @@ PRIVATE
 target_link_libraries(dde-shell PRIVATE
     dde-shell-frame
     Qt${QT_VERSION_MAJOR}::Gui
+    Qt${QT_VERSION_MAJOR}::GuiPrivate
     Qt${QT_VERSION_MAJOR}::Widgets
+    Qt${QT_VERSION_MAJOR}::WaylandClient
     Dtk${DTK_VERSION_MAJOR}::Gui
     Qt${QT_VERSION_MAJOR}::DBus
+    PkgConfig::WaylandClient
 )
 
 configure_file(${CMAKE_SOURCE_DIR}/misc/dde-shell-plugin@.service.in

--- a/shell/shell.cpp
+++ b/shell/shell.cpp
@@ -3,14 +3,16 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "shell.h"
+#include "treelandoutputwatcher.h"
 
-#include <memory>
 #include <DConfig>
-#include <QLoggingCategory>
-#include <QQmlAbstractUrlInterceptor>
-#include <qmlengine.h>
 #include <QDBusConnection>
 #include <QDBusError>
+#include <QGuiApplication>
+#include <QLoggingCategory>
+#include <QQmlAbstractUrlInterceptor>
+#include <memory>
+#include <qmlengine.h>
 
 DS_BEGIN_NAMESPACE
 
@@ -39,7 +41,13 @@ public:
 Shell::Shell(QObject *parent)
     : QObject(parent)
 {
+    // Since Wayland has no concept of primaryScreen, it is necessary to rely on wayland private protocols
+    // to update the client's primaryScreen information
 
+    auto platformName = QGuiApplication::platformName();
+    if (QStringLiteral("wayland") == platformName) {
+        new TreelandOutputWatcher(this);
+    }
 }
 
 void Shell::installDtkInterceptor()

--- a/shell/treelandoutputwatcher.cpp
+++ b/shell/treelandoutputwatcher.cpp
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "treelandoutputwatcher.h"
+#include "wayland-treeland-output-manager-v1-client-protocol.h"
+
+#include <QGuiApplication>
+#include <QScreen>
+
+#include <qpa/qwindowsysteminterface.h>
+
+TreelandOutputWatcher::TreelandOutputWatcher(QObject *parent)
+    : QWaylandClientExtensionTemplate<TreelandOutputWatcher>(treeland_output_manager_v1_interface.version)
+{
+    setParent(parent);
+}
+
+TreelandOutputWatcher::~TreelandOutputWatcher()
+{
+    destroy();
+}
+
+void TreelandOutputWatcher::treeland_output_manager_v1_primary_output(const QString &output_name)
+{
+    if (qApp->primaryScreen()->name() == output_name)
+        return;
+
+    for (auto screen : qApp->screens()) {
+        if (screen->name() == output_name) {
+            QWindowSystemInterface::handlePrimaryScreenChanged(screen->handle());
+            return;
+        }
+    }
+}

--- a/shell/treelandoutputwatcher.h
+++ b/shell/treelandoutputwatcher.h
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include "qwayland-treeland-output-manager-v1.h"
+#include <QtWaylandClient/QWaylandClientExtension>
+
+class TreelandOutputWatcher : public QWaylandClientExtensionTemplate<TreelandOutputWatcher>, public QtWayland::treeland_output_manager_v1
+{
+    Q_OBJECT
+public:
+    TreelandOutputWatcher(QObject *parent = nullptr);
+    ~TreelandOutputWatcher();
+
+protected:
+    void treeland_output_manager_v1_primary_output(const QString &output_name) override;
+};


### PR DESCRIPTION
Since Wayland has no concept of primaryScreen. We create a TreelandOutputWatcher to update the client's primaryScreen information

log: as title