### PR TITLE
fix: compile error

### DIFF
--- a/frame/containment.h
+++ b/frame/containment.h
@@ -6,8 +6,6 @@
 
 #include "applet.h"
 
-Q_MOC_INCLUDE(<appletitemmodel.h>)
-
 #include <DObject>
 #include <QVariant>
 
@@ -44,3 +42,5 @@ protected:
 };
 
 DS_END_NAMESPACE
+
+Q_DECLARE_OPAQUE_POINTER(DS_NAMESPACE::DAppletItemModel *)


### PR DESCRIPTION
Can't find appletitemmodel.h when using Q_OBJECT to inherit form
DPanel.

Task: https://pms.uniontech.com/task-view-365879.html
