### PR TITLE
feat: show desktop adapted to treeland

### DIFF
--- a/panels/dock/showdesktop/CMakeLists.txt
+++ b/panels/dock/showdesktop/CMakeLists.txt
@@ -2,13 +2,27 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+find_package(PkgConfig REQUIRED)
+find_package(Qt${QT_VERSION_MAJOR} ${REQUIRED_QT_VERSION} COMPONENTS WaylandClient)
+find_package(TreelandProtocols REQUIRED)
+pkg_check_modules(WaylandClient REQUIRED IMPORTED_TARGET wayland-client)
+
 add_library(dock-showdesktop SHARED
     showdesktop.cpp
     showdesktop.h
+    treelandwindowmanager.cpp
+    treelandwindowmanager.h
+)
+
+qt_generate_wayland_protocol_client_sources(dock-showdesktop
+    FILES
+        ${TREELAND_PROTOCOLS_DATA_DIR}/treeland-window-management-v1.xml
 )
 
 target_link_libraries(dock-showdesktop PRIVATE
     dde-shell-frame
+    Qt${QT_VERSION_MAJOR}::WaylandClient
+    PkgConfig::WaylandClient
 )
 
 ds_install_package(PACKAGE org.deepin.ds.dock.showdesktop TARGET dock-showdesktop)

--- a/panels/dock/showdesktop/showdesktop.cpp
+++ b/panels/dock/showdesktop/showdesktop.cpp
@@ -2,9 +2,10 @@
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-#include "applet.h"
 #include "showdesktop.h"
+#include "applet.h"
 #include "pluginfactory.h"
+#include "treelandwindowmanager.h"
 
 #include <QProcess>
 #include <QGuiApplication>
@@ -17,23 +18,32 @@ namespace dock {
 
 ShowDesktop::ShowDesktop(QObject *parent)
     : DApplet(parent)
+    , m_windowManager(nullptr)
 {
 
 }
 
 bool ShowDesktop::load()
 {
-    return QStringLiteral("xcb") == QGuiApplication::platformName();
+    return true;
 }
 
 bool ShowDesktop::init()
 {
+    if (QStringLiteral("wayland") == QGuiApplication::platformName()) {
+        m_windowManager = new TreelandWindowManager(this);
+    }
     DApplet::init();
     return true;
 }
 
 void ShowDesktop::toggleShowDesktop()
 {
+    if (m_windowManager) {
+        m_windowManager->desktopToggle();
+        return;
+    }
+
     QProcess::startDetached("/usr/lib/deepin-daemon/desktop-toggle", QStringList());
 }
 

--- a/panels/dock/showdesktop/showdesktop.h
+++ b/panels/dock/showdesktop/showdesktop.h
@@ -6,6 +6,7 @@
 
 #include "applet.h"
 #include "dsglobal.h"
+#include "treelandwindowmanager.h"
 
 namespace dock {
 
@@ -19,6 +20,9 @@ public:
 
     Q_INVOKABLE void toggleShowDesktop();
     Q_INVOKABLE bool checkNeedShowDesktop();
+
+private:
+    TreelandWindowManager *m_windowManager;
 };
 
 }

--- a/panels/dock/showdesktop/treelandwindowmanager.cpp
+++ b/panels/dock/showdesktop/treelandwindowmanager.cpp
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "treelandwindowmanager.h"
+#include "qwayland-treeland-window-management-v1.h"
+#include "wayland-treeland-window-management-v1-client-protocol.h"
+
+namespace dock
+{
+TreelandWindowManager::TreelandWindowManager(QObject *parent)
+    : QWaylandClientExtensionTemplate<TreelandWindowManager>(treeland_window_management_v1_interface.version)
+    , m_desktopState(desktop_state_normal)
+{
+    setParent(parent);
+}
+
+void TreelandWindowManager::desktopToggle()
+{
+    if (isActive()) {
+        set_desktop(m_desktopState == desktop_state_show ? desktop_state_normal : desktop_state_show);
+    }
+}
+
+void TreelandWindowManager::treeland_window_management_v1_show_desktop(uint32_t state)
+{
+    if (state != m_desktopState) {
+        m_desktopState = state;
+    }
+}
+}

--- a/panels/dock/showdesktop/treelandwindowmanager.h
+++ b/panels/dock/showdesktop/treelandwindowmanager.h
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include "qwayland-treeland-window-management-v1.h"
+#include <QtWaylandClient/QWaylandClientExtension>
+#include <cstdint>
+
+namespace dock
+{
+
+class TreelandWindowManager : public QWaylandClientExtensionTemplate<TreelandWindowManager>, public QtWayland::treeland_window_management_v1
+{
+public:
+    explicit TreelandWindowManager(QObject *parent);
+
+    void desktopToggle();
+
+protected:
+    void treeland_window_management_v1_show_desktop(uint32_t state) override;
+
+private:
+    uint32_t m_desktopState;
+};
+}


### PR DESCRIPTION
On treeland call treeland protools to show desktop

log: as title