### PR TITLE
fix: remove find DDEShell in bridge example

### DIFF
--- a/example/bridge-example/CMakeLists.txt
+++ b/example/bridge-example/CMakeLists.txt
@@ -2,8 +2,6 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-find_package(DDEShell REQUIRED)
-
 add_library(shell-apps-bridge-example SHARED
     exampleappletitem.cpp
     exampleappletitem.h


### PR DESCRIPTION
移除示例代码中的一处查找

Log: