### PR TITLE
fix: dock with no item inside

### DIFF
--- a/panels/dock/OverflowContainer.qml
+++ b/panels/dock/OverflowContainer.qml
@@ -52,13 +52,15 @@ Item {
         for (let child of listView.contentItem.visibleChildren) {
             width = calculateImplicitWidth(width, child.implicitWidth)
         }
-        return width
+        // TODO: abvoe qt6.8 implicitSize to 0 will make size to 0 default.
+        // so make minimum implicitSize to 1, find why and remove below
+        return Math.max(width, 1)
     }
     implicitHeight: {
         let height = 0
         for (let child of listView.contentItem.visibleChildren) {
             height = calculateImplicitHeight(height, child.implicitHeight)
         }
-        return height
+        return Math.max(height, 1)
     }
 }

--- a/panels/dock/taskmanager/CMakeLists.txt
+++ b/panels/dock/taskmanager/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 find_package(Qt${QT_VERSION_MAJOR} ${REQUIRED_QT_VERSION} REQUIRED COMPONENTS DBus WaylandClient)
 find_package(yaml-cpp REQUIRED)
-find_package(TreeLandProtocols REQUIRED)
+find_package(TreelandProtocols REQUIRED)
 
 set_source_files_properties(
     ${CMAKE_CURRENT_SOURCE_DIR}/api/amdbus/org.desktopspec.ApplicationManager1.Application.xml


### PR DESCRIPTION
qt6.8 default size policy has changed, temporarily modify the minimum size

log: as title