### PR TITLE
chore: correct wrong dep

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -40,7 +40,7 @@ Homepage: http://www.deepin.org
 
 Package: libdde-shell
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, dde-tray-loader
+Depends: ${shlibs:Depends}, ${misc:Depends}
 Multi-Arch: same
 Description: DDE Shell library
  DDE Shell is a plugin system that integrates plugins developed based on this plugin system into DDE.
@@ -61,6 +61,7 @@ Depends: ${shlibs:Depends}, ${misc:Depends}, libdde-shell( =${binary:Version}),
   libdtk6declarative, qml6-module-qtquick-controls2-styles-chameleon,
   qml6-module-qtquick-layouts, qml6-module-qtquick-window,
   qml6-module-qt-labs-platform, qml6-module-qt-labs-qmlmodels,
+  dde-tray-loader
 Multi-Arch: same
 Description: An wrapper for developed based on dde-shell plugin system
 


### PR DESCRIPTION
dde-shell depneds dde-tray-loader not libdde-shell

log: as title