### PR TITLE
fix: correct window recognition errors

### DIFF
--- a/panels/dock/taskmanager/taskmanager.cpp
+++ b/panels/dock/taskmanager/taskmanager.cpp
@@ -96,7 +96,7 @@ bool TaskManager::init()
                     }
 
                     for (auto identifiedOrder : identifiedOrders) {
-                        auto res = model->match(model->index(0, 0), roleNames.key(identifiedOrder), id);
+                        auto res = model->match(model->index(0, 0), roleNames.key(identifiedOrder), id, 1, Qt::MatchExactly | Qt::MatchWrap);
                         if (res.size() > 0 && res.first().isValid()) {
                             return res.first();
                         }


### PR DESCRIPTION
Recognition errors caused by using prefixes instead of full matches

log: as title