### PR TITLE
chore: don't ship the bridge example by default

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -6,9 +6,12 @@ find_package(Qt${QT_VERSION_MAJOR} ${REQUIRED_QT_VERSION} REQUIRED COMPONENTS Co
 
 add_subdirectory(applet-example)
 add_subdirectory(applet-example-data)
-add_subdirectory(bridge-example)
 add_subdirectory(containment-example)
 add_subdirectory(panel-example)
 add_subdirectory(layershell-example)
 add_subdirectory(osd-example)
 add_subdirectory(drag-example)
+
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    add_subdirectory(bridge-example)
+endif()


### PR DESCRIPTION
默认不构建/打包bridge示例，避免安装了example包的用户看到任务栏多出来
的组件而感到困惑。

Log: