### PR TITLE
fix: headers not installed correctly

### DIFF
--- a/frame/CMakeLists.txt
+++ b/frame/CMakeLists.txt
@@ -75,7 +75,7 @@ add_library(dde-shell-frame SHARED
 )
 
 set_target_properties(dde-shell-frame PROPERTIES
-    PUBLIC_HEADER ${PUBLIC_HEADERS}
+    PUBLIC_HEADER "${PUBLIC_HEADERS}"
 )
 
 qt_generate_wayland_protocol_client_sources(dde-shell-frame FILES


### PR DESCRIPTION
设置属性应当使用 "${PUBLIC_HEADERS}" 确保所有 header 都被设置恰当属性