### PR TITLE
refactor: adjust relationship between AppGroupModel and AMAppItemModel

### DIFF
--- a/applets/dde-apps/amappitem.cpp
+++ b/applets/dde-apps/amappitem.cpp
@@ -19,7 +19,7 @@ static const QString DEFAULT_KEY = "default";
 static QString locale = QLocale::system().name();
 
 AMAppItem::AMAppItem(const QDBusObjectPath &path, QObject *parent)
-    : AppItem(DUtil::unescapeFromObjectPath(path.path().split('/').last()))
+    : AppItem(DUtil::unescapeFromObjectPath(path.path().split('/').last()), AppItemModel::AppItemType)
     , Application(AM_DBUS_SERVICE, path.path(), QDBusConnection::sessionBus(), parent)
 {
 }

--- a/applets/dde-apps/amappitemmodel.cpp
+++ b/applets/dde-apps/amappitemmodel.cpp
@@ -57,9 +57,6 @@ AMAppItemModel::AMAppItemModel(QObject *parent)
             auto path = app.key();
             if (!path.path().isEmpty()) {
                 auto c = new AMAppItem(path, app.value());
-                if (auto group = AppGroupManager::instance()->getAppGroupInfo(c->appId()); group != std::make_tuple(-1, -1, -1)) {
-                    c->setGroup({std::get<0>(group), std::get<1>(group), std::get<2>(group)});
-                }
                 appendRow(c);
             }
         }

--- a/applets/dde-apps/appgroup.cpp
+++ b/applets/dde-apps/appgroup.cpp
@@ -4,6 +4,7 @@
 
 #include "appgroup.h"
 #include "appgroupmanager.h"
+#include "appitemmodel.h"
 
 #include <QLoggingCategory>
 #include <algorithm>
@@ -11,21 +12,16 @@
 Q_LOGGING_CATEGORY(appGroupLog, "org.deepin.ds.dde-apps.appgroup")
 
 namespace apps {
-AppGroup::AppGroup(const QString &name, const QList<QStringList> &appIDs)
-    : QStandardItem()
+AppGroup::AppGroup(const QString &groupId, const QString &name, const QList<QStringList> &appIDs)
+    : AppItem(groupId, AppItemModel::FolderItemType)
 {
-    setName(name);
+    if (groupId == QStringLiteral("internal/folder/0")) {
+        setItemsPerPage(4 * 8);
+    } else {
+        setItemsPerPage(3 * 4);
+    }
+    setAppName(name);
     setAppItems(appIDs);
-}
-
-QString AppGroup::name() const
-{
-    return data(AppGroupManager::GroupNameRole).toString();
-}
-
-void AppGroup::setName(const QString &name)
-{
-    return setData(name, AppGroupManager::GroupNameRole);
 }
 
 QList<QStringList> AppGroup::appItems() const
@@ -51,5 +47,11 @@ void AppGroup::setAppItems(const QList<QStringList> &items)
     });
     return setData(data, AppGroupManager::GroupAppItemsRole);
 }
+
+void AppGroup::setItemsPerPage(int number)
+{
+    return setData(number, AppGroupManager::GroupItemsPerPageRole);
+}
+
 }
 

--- a/applets/dde-apps/appgroup.h
+++ b/applets/dde-apps/appgroup.h
@@ -4,18 +4,20 @@
 
 #pragma once
 
-#include <QStandardItem>
+#include "appitem.h"
 
 namespace apps {
-class AppGroup : public QStandardItem
+class AppGroup : public AppItem
 {
 public:
-    explicit AppGroup(const QString &name, const QList<QStringList> &appItemIDs);
+    explicit AppGroup(const QString &groupId, const QString &name, const QList<QStringList> &appItemIDs);
 
     QString name() const;
     void setName(const QString &name);
 
     QList<QStringList> appItems() const;
     void setAppItems(const QList<QStringList> &items);
+
+    void setItemsPerPage(int number);
 };
 }

--- a/applets/dde-apps/appgroupmanager.h
+++ b/applets/dde-apps/appgroupmanager.h
@@ -13,6 +13,7 @@
 #include <tuple>
 
 namespace apps {
+class AMAppItemModel;
 class AppGroup;
 /*! \brief AppGroupManager is a interface to manager all groups.
  *
@@ -25,12 +26,11 @@ class AppGroupManager : public QStandardItemModel
 public:
     enum Roles {
         GroupIdRole = Qt::UserRole + 1,
-        GroupNameRole,
+        GroupItemsPerPageRole,
         GroupAppItemsRole,
         ExtendRole = 0x1000,
     };
-
-    static AppGroupManager* instance();
+    explicit AppGroupManager(AMAppItemModel * referenceModel, QObject* parent = nullptr);
 
     QVariant data(const QModelIndex &index, int role = GroupIdRole) const override;
 
@@ -38,11 +38,12 @@ public:
     void setAppGroupInfo(const QString &appId, std::tuple<int, int, int> groupInfo);
 
 private:
-    AppGroupManager(QObject* parent = nullptr);
     void loadAppGroupInfo();
     void dumpAppGroupInfo();
+    QString assignGroupId() const;
 
 private:
+    AMAppItemModel * m_referenceModel;
     QHash<QString, std::tuple<int, int>> m_map;
     QTimer* m_dumpTimer;
     Dtk::Core::DConfig *m_config;

--- a/applets/dde-apps/appitem.cpp
+++ b/applets/dde-apps/appitem.cpp
@@ -11,14 +11,10 @@
 #include <tuple>
 
 namespace apps {
-AppItem::AppItem(const QString &appid)
+AppItem::AppItem(const QString &appid, AppItemModel::AppTypes appType)
 {
     setAppId(appid);
-
-    int groupPos, pagePos, itemPos;
-    std::tie(groupPos, pagePos, itemPos) = AppGroupManager::instance()->getAppGroupInfo(appId());
-    QVariantList data = {groupPos, pagePos, itemPos};
-    setData(data, AppItemModel::GroupRole);
+    setAppType(appType);
 
     auto launchedTimes = AppsLaunchTimesHelper::instance()->getLaunchedTimesFor(appId());
     setData(launchedTimes, AppItemModel::LaunchedTimesRole);
@@ -41,6 +37,16 @@ QString AppItem::appId() const
 void AppItem::setAppId(const QString &appid)
 {
     return setData(appid, AppItemModel::DesktopIdRole);
+}
+
+AppItemModel::AppTypes AppItem::appType() const
+{
+    return data(AppItemModel::AppTypeRole).value<AppItemModel::AppTypes>();
+}
+
+void AppItem::setAppType(AppItemModel::AppTypes appType)
+{
+    return setData(appType, AppItemModel::AppTypeRole);
 }
 
 QString AppItem::appName() const
@@ -132,23 +138,6 @@ void AppItem::setLaunchedTimes(const quint64 &times)
 {
     AppsLaunchTimesHelper::instance()->setLaunchTimesFor(appId(), times);
     return setData(times, AppItemModel::LaunchedTimesRole);
-}
-
-QList<int> AppItem::group() const
-{
-    return data(AppItemModel::GroupRole).value<QList<int>>();
-}
-
-void AppItem::setGroup(const QList<int> &group)
-{
-    if (group.size() != 3)
-        return;
-    auto groupPos = group[0];
-    auto pagePos = group[1];
-    auto itemPos = group[2];
-    AppGroupManager::instance()->setAppGroupInfo(appId(), std::make_tuple(groupPos, pagePos, itemPos));
-    QVariantList data = {groupPos, pagePos, itemPos};
-    return setData(data, AppItemModel::GroupRole);
 }
 
 bool AppItem::docked() const

--- a/applets/dde-apps/appitem.h
+++ b/applets/dde-apps/appitem.h
@@ -11,7 +11,7 @@ namespace apps {
 class AppItem : public QStandardItem
 {
 public:
-    AppItem(const QString &appid);
+    AppItem(const QString &appid, AppItemModel::AppTypes appType);
 
     // action
     virtual void launch(const QString &action = {}, const QStringList &fields = {}, const QVariantMap &options = {});
@@ -19,6 +19,9 @@ public:
     // desktop file static data
     QString appId() const;
     void setAppId(const QString &appid);
+
+    AppItemModel::AppTypes appType() const;
+    void setAppType(AppItemModel::AppTypes appType);
 
     QString appName() const;
     void setAppName(const QString &name);

--- a/applets/dde-apps/appitemmodel.cpp
+++ b/applets/dde-apps/appitemmodel.cpp
@@ -9,7 +9,6 @@ namespace apps {
 AppItemModel::AppItemModel(QObject *parent)
     : QStandardItemModel(parent)
 {
-    AppGroupManager::instance();
 }
 
 QHash<int, QByteArray> AppItemModel::roleNames() const
@@ -27,6 +26,6 @@ QHash<int, QByteArray> AppItemModel::roleNames() const
             {AppItemModel::DockedRole, QByteArrayLiteral("docked")},
             {AppItemModel::OnDesktopRole, QByteArrayLiteral("onDesktop")},
             {AppItemModel::AutoStartRole, QByteArrayLiteral("autoStart")},
-            {AppItemModel::GroupRole, QByteArrayLiteral("group")}};
+            {AppItemModel::AppTypeRole, QByteArrayLiteral("appType")}};
 }
 }

--- a/applets/dde-apps/appitemmodel.h
+++ b/applets/dde-apps/appitemmodel.h
@@ -25,9 +25,15 @@ public:
         DockedRole,
         OnDesktopRole,
         AutoStartRole,
-        GroupRole,
+        AppTypeRole,
     };
     Q_ENUM(Roles)
+
+    enum AppTypes {
+        AppItemType,
+        FolderItemType,
+    };
+    Q_ENUM(AppTypes)
 
     // This is different from the menu-spec Main Categories list.
     enum DDECategories {

--- a/applets/dde-apps/appsapplet.cpp
+++ b/applets/dde-apps/appsapplet.cpp
@@ -14,8 +14,8 @@ namespace apps
 {
 AppsApplet::AppsApplet(QObject *parent)
     : DApplet(parent)
-    , m_groupModel(AppGroupManager::instance())
     , m_appModel(new AMAppItemModel(this))
+    , m_groupModel(new AppGroupManager(m_appModel, this))
 {
 }
 
@@ -31,7 +31,7 @@ bool AppsApplet::load()
 
 QAbstractItemModel *AppsApplet::groupModel() const
 {
-    return AppGroupManager::instance();
+    return m_groupModel;
 }
 
 QAbstractItemModel *AppsApplet::appModel() const

--- a/applets/dde-apps/appsapplet.h
+++ b/applets/dde-apps/appsapplet.h
@@ -12,6 +12,7 @@
 DS_USE_NAMESPACE
 
 namespace apps {
+class AMAppItemModel;
 class AppItem;
 class AppsApplet : public DApplet
 {
@@ -29,7 +30,7 @@ public:
     QAbstractItemModel *groupModel() const;
 
 private:
+    AMAppItemModel *m_appModel;
     QAbstractItemModel *m_groupModel;
-    QAbstractItemModel *m_appModel;
 };
 }

--- a/panels/notification/server/notificationsetting.cpp
+++ b/panels/notification/server/notificationsetting.cpp
@@ -31,7 +31,7 @@ enum Roles {
     DockedRole,
     OnDesktopRole,
     AutoStartRole,
-    GroupRole,
+    AppTypeRole,
 };
 }
 


### PR DESCRIPTION
调整 AppGroupModel 与 AMAppItemModel 的关系，其它部分暂未调整。

变化说明：

1. 目前决定复用 AppGroupManager，后续可能需要补充一些实现（目前没处理分组内容为空后清除分组的行为，也没自动为所有未分组的应用分配分组）
2. AppGroupManager 不再是单例
3. AMAppItem 和 AppGroup 现在都是 AppItem 的子类了，便于后续直接组合对应的两个模型
4. AMAppsModel 不再提供分组信息（后续在组合模型提供，分组信息的数据源仍由 AppGroupManager 管理）

后续待调整内容：

1. 暴漏的 appsModel 转为一个组合模型，同时包含这两个模型的数据
5. 处理应用组的初始化、位置信息更新等行为，确保每个应用总是有分组信息