### PR TITLE
fix: should also remove virtual API from appitem.h

### DIFF
--- a/applets/dde-apps/appitem.h
+++ b/applets/dde-apps/appitem.h
@@ -51,9 +51,6 @@ public:
     virtual quint64 launchedTimes() const;
     virtual void setLaunchedTimes(const quint64 &times);
 
-    virtual QList<int> group() const;
-    virtual void setGroup(const QList<int> &group);
-
     virtual bool docked() const;
     virtual void setDocked(bool docked);
 


### PR DESCRIPTION
应当一并移除 AppItem 中的两个对应接口

Log: