### PR TITLE
fix: Avoid showing tooltip while clicking show-desktop button

### DIFF
--- a/panels/dock/showdesktop/package/showdesktop.qml
+++ b/panels/dock/showdesktop/package/showdesktop.qml
@@ -38,6 +38,7 @@ AppletItem {
         }
 
         onClicked: {
+            toolTip.close()
             Applet.toggleShowDesktop()
         }
         onHoveredChanged: {


### PR DESCRIPTION
Disable tooltip until hover off

Bug: https://pms.uniontech.com/bug-view-281843.html
Log: Avoid showing tooltip while clicking show-desktop button