### PR TITLE
fix: error displayed in stage for notification

### DIFF
--- a/panels/notification/center/NotifyCenter.qml
+++ b/panels/notification/center/NotifyCenter.qml
@@ -19,9 +19,6 @@ FocusScope {
     NotifyModel {
         id: notifyModel
     }
-    Component.onCompleted: {
-        notifyModel.open()
-    }
 
     Item {
         objectName: "notificationCenter"

--- a/panels/notification/center/NotifyStaging.qml
+++ b/panels/notification/center/NotifyStaging.qml
@@ -12,12 +12,10 @@ FocusScope {
 
     implicitWidth: 360
     implicitHeight: view.height
+    property var model: notifyModel
 
     NotifyStagingModel {
         id: notifyModel
-        Component.onCompleted: {
-            notifyModel.open()
-        }
     }
 
     ListView {

--- a/panels/notification/center/notificationcenterpanel.cpp
+++ b/panels/notification/center/notificationcenterpanel.cpp
@@ -87,6 +87,7 @@ bool NotificationCenterPanel::init()
                                  SLOT(onNotificationStateChanged(qint64, int)),
                                  Qt::QueuedConnection);
         notifycenter::NotifyAccessor::instance()->setDataUpdater(server);
+        notifycenter::NotifyAccessor::instance()->setEnabled(visible());
     } else {
         // old interface by dbus
         auto connection = QDBusConnection::sessionBus();
@@ -110,6 +111,7 @@ void NotificationCenterPanel::setVisible(bool newVisible)
     if (m_visible == newVisible)
         return;
     m_visible = newVisible;
+    notifycenter::NotifyAccessor::instance()->setEnabled(m_visible);
     setBubblePanelEnabled(!m_visible);
     emit visibleChanged();
 }

--- a/panels/notification/center/notifyaccessor.cpp
+++ b/panels/notification/center/notifyaccessor.cpp
@@ -91,6 +91,16 @@ void NotifyAccessor::setDataUpdater(QObject *updater)
     m_dataUpdater = updater;
 }
 
+bool NotifyAccessor::enabled() const
+{
+    return m_enabled;
+}
+
+void NotifyAccessor::setEnabled(bool enabled)
+{
+    m_enabled = enabled;
+}
+
 NotifyEntity NotifyAccessor::fetchEntity(qint64 id) const
 {
     qDebug(notifyLog) << "Fetch entity" << id;
@@ -273,6 +283,8 @@ void NotifyAccessor::fetchDataInfo()
 
 void NotifyAccessor::onNotificationStateChanged(qint64 id, int processedType)
 {
+    if (!enabled())
+        return;
     if (processedType == NotifyEntity::Processed) {
         emit entityReceived(id);
         emit stagingEntityClosed(id);

--- a/panels/notification/center/notifyaccessor.h
+++ b/panels/notification/center/notifyaccessor.h
@@ -35,6 +35,9 @@ public:
     void setDataAccessor(DataAccessor *accessor);
     void setDataUpdater(QObject *updater);
 
+    bool enabled() const;
+    void setEnabled(bool enabled);
+
     void invokeAction(const NotifyEntity &entity, const QString &actionId);
     void pinApplication(const QString &appName, bool pin);
     bool applicationPin(const QString &appName) const;
@@ -84,5 +87,6 @@ private:
     QStringList m_apps;
     bool m_debugging = false;
     QString m_dataInfo;
+    bool m_enabled = false;
 };
 }

--- a/panels/notification/center/package/main.qml
+++ b/panels/notification/center/package/main.qml
@@ -94,7 +94,16 @@ Window {
         NotifyStaging {
             id: notifyStaging
             implicitWidth: 360
-
+            Connections {
+                target: Panel
+                function onVisibleChanged() {
+                    if (Panel.visible) {
+                        notifyStaging.model.open()
+                    } else {
+                        notifyStaging.model.close()
+                    }
+                }
+            }
         }
 
         NotifyCenter {
@@ -102,8 +111,10 @@ Window {
             Connections {
                 target: Panel
                 function onVisibleChanged() {
-                    if (!Panel.visible) {
-                        notifyCenter.model.collapseAllApp()
+                    if (Panel.visible) {
+                        notifyCenter.model.open()
+                    } else {
+                        notifyCenter.model.close()
                     }
                 }
             }


### PR DESCRIPTION
Stage is still received notification before it's display,
We don't receive notification when it's invisible,
and clear the model when NotificationCenter closed.

Bug: https://pms.uniontech.com/bug-view-283969.html
