### PR TITLE
fix: empty string can't represent AllApp for notification

### DIFF
--- a/panels/notification/center/NotifyAction.qml
+++ b/panels/notification/center/NotifyAction.qml
@@ -20,7 +20,7 @@ Control {
         height: 30
         NotifyActionButton {
             actionData: actions[0]
-            Layout.maximumWidth: 60
+            Layout.maximumWidth: 120
             Layout.preferredHeight: 30
             Layout.fillHeight: true
             Layout.alignment: Qt.AlignHCenter
@@ -29,7 +29,7 @@ Control {
         Loader {
             active: actions.length === 2
             visible: active
-            Layout.maximumWidth: 60
+            Layout.maximumWidth: 120
             Layout.preferredHeight: 30
             Layout.fillHeight: true
             Layout.alignment: Qt.AlignHCenter
@@ -41,7 +41,7 @@ Control {
         Loader {
             active: actions.length > 2
             visible: active
-            Layout.maximumWidth: 80
+            Layout.maximumWidth: 120
             Layout.alignment: Qt.AlignHCenter
             sourceComponent: ComboBox {
                 property var expandActions: actions.slice(1)
@@ -75,22 +75,13 @@ Control {
             actionInvoked(actionData.id)
         }
 
-        background: DP.ButtonPanel {
+        background: NotifyItemBackground {
             implicitHeight: 30
             implicitWidth: 50
-            button: actionButton
-            color1: Palette {
-                normal {
-                    common: ("transparent")
-                    crystal: Qt.rgba(0 / 255.0, 0 / 255.0, 0 / 255.0, 0.15)
-                }
-                normalDark {
-                    crystal: Qt.rgba(24 / 255.0, 24 / 255.0, 24 / 255.0, 1)
-                }
-            }
-            color2: color1
-            insideBorderColor: null
+            radius: 6
             outsideBorderColor: null
+            insideBorderColor: null
+            anchors.fill: parent
         }
     }
 }

--- a/panels/notification/center/NotifyHeader.qml
+++ b/panels/notification/center/NotifyHeader.qml
@@ -18,7 +18,7 @@ FocusScope {
     onHeaderClicked: function () {
         dataPanelLoader.active = !dataPanelLoader.active
         NotifyAccessor.fetchDataInfo()
-        dataPanel.show()
+        dataPanelLoader.item.show()
     }
     Loader {
         id: dataPanelLoader

--- a/panels/notification/center/NotifyItemContent.qml
+++ b/panels/notification/center/NotifyItemContent.qml
@@ -104,13 +104,6 @@ NotifyItem {
             onActionInvoked: function (actionId) {
                 root.actionInvoked(actionId)
             }
-            background: NotifyItemBackground {
-                radius: 6
-                implicitHeight: 30
-                implicitWidth: 50
-                outsideBorderColor: null
-                insideBorderColor: null
-            }
         }
     }
 

--- a/panels/notification/center/notifyaccessor.cpp
+++ b/panels/notification/center/notifyaccessor.cpp
@@ -269,7 +269,7 @@ void NotifyAccessor::addNotify(const QString &appName, const QString &content)
 void NotifyAccessor::fetchDataInfo()
 {
     QStringList info;
-    auto entityCount = fetchEntityCount();
+    auto entityCount = fetchEntityCount(DataAccessor::AllApp());
     auto apps = fetchApps();
     info.append(QString("notifyCount: %1, appCount: %2").arg(entityCount).arg(apps.size()));
     for (auto item : apps) {

--- a/panels/notification/center/notifyaccessor.h
+++ b/panels/notification/center/notifyaccessor.h
@@ -44,7 +44,7 @@ public:
     Q_INVOKABLE void openNotificationSetting();
 
     NotifyEntity fetchEntity(qint64 id) const;
-    int fetchEntityCount(const QString &appName = QString()) const;
+    int fetchEntityCount(const QString &appName) const;
     NotifyEntity fetchLastEntity(const QString &appName) const;
     QList<NotifyEntity> fetchEntities(const QString &appName, int maxCount = -1);
     QStringList fetchApps(int maxCount = -1) const;

--- a/panels/notification/center/notifymodel.cpp
+++ b/panels/notification/center/notifymodel.cpp
@@ -681,6 +681,8 @@ QVariant NotifyModel::data(const QModelIndex &index, int role) const
     } else if (role == NotifyRole::NotifyId) {
         return notify->id();
     } else if (role == NotifyRole::NotifyAppId) {
+        return notify->appId();
+    } else if (role == NotifyRole::NotifyAppName) {
         return notify->appName();
     } else if (role == NotifyRole::NotifyIconName) {
         return notify->entity().appIcon();
@@ -692,11 +694,11 @@ QVariant NotifyModel::data(const QModelIndex &index, int role) const
         return notify->actions();
     } else if (role == NotifyRole::NotifyDefaultAction) {
         return notify->defaultAction();
-    }  else if (role == NotifyRole::NotifyTime) {
+    } else if (role == NotifyRole::NotifyTime) {
         return notify->time();
     } else if (role == NotifyRole::NotifyPinned) {
         return notify->pinned();
-    }  else if (role == NotifyRole::NotifyStrongInteractive) {
+    } else if (role == NotifyRole::NotifyStrongInteractive) {
         return notify->strongInteractive();
     } else if (role == NotifyRole::NotifyContentIcon) {
         return notify->contentIcon();
@@ -744,21 +746,20 @@ void NotifyModel::updateTime()
 
 QHash<int, QByteArray> NotifyModel::roleNames() const
 {
-    static const QHash<int, QByteArray> roles {
-        {NotifyItemType, "type"},
-        {NotifyId, "id"},
-        {NotifyAppId, "appName"},
-        {NotifyIconName, "iconName"},
-        {NotifyActions, "actions"},
-        {NotifyDefaultAction, "defaultAction"},
-        {NotifyTime, "time"},
-        {NotifyTitle, "title"},
-        {NotifyContent, "content"},
-        {NotifyPinned, "pinned"},
-        {NotifyStrongInteractive, "strongInteractive"},
-        {NotifyContentIcon, "contentIcon"},
-        {NotifyOverlapCount, "overlapCount"}
-    };
+    static const QHash<int, QByteArray> roles{{NotifyItemType, "type"},
+                                              {NotifyId, "id"},
+                                              {NotifyAppId, "appId"},
+                                              {NotifyAppName, "appName"},
+                                              {NotifyIconName, "iconName"},
+                                              {NotifyActions, "actions"},
+                                              {NotifyDefaultAction, "defaultAction"},
+                                              {NotifyTime, "time"},
+                                              {NotifyTitle, "title"},
+                                              {NotifyContent, "content"},
+                                              {NotifyPinned, "pinned"},
+                                              {NotifyStrongInteractive, "strongInteractive"},
+                                              {NotifyContentIcon, "contentIcon"},
+                                              {NotifyOverlapCount, "overlapCount"}};
     return roles;
 }
 

--- a/panels/notification/center/notifymodel.h
+++ b/panels/notification/center/notifymodel.h
@@ -25,6 +25,7 @@ public:
     enum NotifyRole {
         NotifyItemType = Qt::UserRole + 1,
         NotifyId,
+        NotifyAppName,
         NotifyAppId,
         NotifyIconName,
         NotifyActions,

--- a/panels/notification/center/notifystagingmodel.cpp
+++ b/panels/notification/center/notifystagingmodel.cpp
@@ -57,7 +57,7 @@ void NotifyStagingModel::push(const NotifyEntity &entity)
     }
     {
         // update count
-        auto count = m_accessor->fetchEntityCount("", NotifyEntity::NotProcessed);
+        auto count = m_accessor->fetchEntityCount(DataAccessor::AllApp(), NotifyEntity::NotProcessed);
         updateOverlapCount(count);
     }
 
@@ -96,7 +96,7 @@ void NotifyStagingModel::remove(qint64 id)
         break;
     }
 
-    auto entities = m_accessor->fetchEntities("", NotifyEntity::NotProcessed, BubbleMaxCount + OverlayMaxCount);
+    auto entities = m_accessor->fetchEntities(DataAccessor::AllApp(), NotifyEntity::NotProcessed, BubbleMaxCount + OverlayMaxCount);
 
     if (row >= 0) {
         auto notify = m_appNotifies[row];
@@ -153,7 +153,7 @@ void NotifyStagingModel::open()
 {
     qDebug(notifyLog) << "Open staging model";
 
-    auto entities = m_accessor->fetchEntities("", NotifyEntity::NotProcessed, BubbleMaxCount + OverlayMaxCount);
+    auto entities = m_accessor->fetchEntities(DataAccessor::AllApp(), NotifyEntity::NotProcessed, BubbleMaxCount + OverlayMaxCount);
 
     qDebug(notifyLog) << "Fetched staging size" << entities.size();
     if (entities.size() <= 0)
@@ -186,6 +186,8 @@ QVariant NotifyStagingModel::data(const QModelIndex &index, int role) const
     if (role == NotifyRole::NotifyId) {
         return notify->id();
     } else if (role == NotifyRole::NotifyAppId) {
+        return notify->appId();
+    } else if (role == NotifyRole::NotifyAppName) {
         return notify->appName();
     } else if (role == NotifyRole::NotifyIconName) {
         return notify->entity().appIcon();
@@ -197,7 +199,7 @@ QVariant NotifyStagingModel::data(const QModelIndex &index, int role) const
         return notify->actions();
     } else if (role == NotifyRole::NotifyDefaultAction) {
         return notify->defaultAction();
-    }  else if (role == NotifyRole::NotifyTime) {
+    } else if (role == NotifyRole::NotifyTime) {
         return notify->time();
     } else if (role == NotifyRole::NotifyStrongInteractive) {
         return notify->strongInteractive();
@@ -237,20 +239,19 @@ NotifyEntity NotifyStagingModel::notifyById(qint64 id) const
 
 QHash<int, QByteArray> NotifyStagingModel::roleNames() const
 {
-    static const QHash<int, QByteArray> roles {
-        {NotifyItemType, "type"},
-        {NotifyId, "id"},
-        {NotifyAppId, "appName"},
-        {NotifyIconName, "iconName"},
-        {NotifyActions, "actions"},
-        {NotifyDefaultAction, "defaultAction"},
-        {NotifyTime, "time"},
-        {NotifyTitle, "title"},
-        {NotifyContent, "content"},
-        {NotifyStrongInteractive, "strongInteractive"},
-        {NotifyContentIcon, "contentIcon"},
-        {NotifyOverlapCount, "overlapCount"}
-    };
+    static const QHash<int, QByteArray> roles{{NotifyItemType, "type"},
+                                              {NotifyId, "id"},
+                                              {NotifyAppName, "appName"},
+                                              {NotifyAppId, "appId"},
+                                              {NotifyIconName, "iconName"},
+                                              {NotifyActions, "actions"},
+                                              {NotifyDefaultAction, "defaultAction"},
+                                              {NotifyTime, "time"},
+                                              {NotifyTitle, "title"},
+                                              {NotifyContent, "content"},
+                                              {NotifyStrongInteractive, "strongInteractive"},
+                                              {NotifyContentIcon, "contentIcon"},
+                                              {NotifyOverlapCount, "overlapCount"}};
     return roles;
 }
 

--- a/panels/notification/center/notifystagingmodel.h
+++ b/panels/notification/center/notifystagingmodel.h
@@ -25,6 +25,7 @@ public:
         NotifyItemType = Qt::UserRole + 1,
         NotifyId,
         NotifyAppId,
+        NotifyAppName,
         NotifyIconName,
         NotifyActions,
         NotifyDefaultAction,

--- a/panels/notification/common/dataaccessor.h
+++ b/panels/notification/common/dataaccessor.h
@@ -34,6 +34,10 @@ public:
     virtual void removeEntity(qint64 id) { Q_UNUSED(id); }
     virtual void removeEntityByApp(const QString &appName) { Q_UNUSED(appName); }
     virtual void clear() {}
+    inline static QString AllApp()
+    {
+        return QLatin1String("AllApp");
+    }
 };
 
 }

--- a/panels/notification/common/dbaccessor.cpp
+++ b/panels/notification/common/dbaccessor.cpp
@@ -228,7 +228,7 @@ int DBAccessor::fetchEntityCount(const QString &appName, int processedType) cons
     BENCHMARK();
 
     QSqlQuery query(m_connection);
-    if (appName.isEmpty()) {
+    if (appName == DataAccessor::AllApp()) {
         QString cmd = QString("SELECT COUNT(*) FROM notifications2 WHERE (ProcessedType = :processedType OR ProcessedType IS NULL)");
         query.prepare(cmd);
     } else {
@@ -255,16 +255,13 @@ NotifyEntity DBAccessor::fetchLastEntity(const QString &appName, int processedTy
     BENCHMARK();
 
     QSqlQuery query(m_connection);
-    if (appName.isEmpty()) {
-        QString cmd = QString("SELECT %1 FROM notifications2 WHERE (ProcessedType = :processedType OR ProcessedType IS NULL) ORDER BY CTime DESC LIMIT 1").arg(EntityFields.join(","));
-        query.prepare(cmd);
-        query.bindValue(":processedType", processedType);
-    } else {
-        QString cmd = QString("SELECT %1 FROM notifications2 WHERE AppName = :appName AND (ProcessedType = :processedType OR ProcessedType IS NULL) ORDER BY CTime DESC LIMIT 1").arg(EntityFields.join(","));
-        query.prepare(cmd);
-        query.bindValue(":appName", appName);
-        query.bindValue(":processedType", processedType);
-    }
+    QString cmd =
+        QString(
+            "SELECT %1 FROM notifications2 WHERE AppName = :appName AND (ProcessedType = :processedType OR ProcessedType IS NULL) ORDER BY CTime DESC LIMIT 1")
+            .arg(EntityFields.join(","));
+    query.prepare(cmd);
+    query.bindValue(":appName", appName);
+    query.bindValue(":processedType", processedType);
 
     if (!query.exec()) {
         qWarning(notifyDBLog) << "Query execution error:" << query.lastError().text();
@@ -285,7 +282,7 @@ QList<NotifyEntity> DBAccessor::fetchEntities(const QString &appName, int proces
     BENCHMARK();
 
     QSqlQuery query(m_connection);
-    if (appName.isEmpty()) {
+    if (appName == DataAccessor::AllApp()) {
         if (maxCount >= 0) {
             QString cmd = QString("SELECT %1 FROM notifications2 WHERE (ProcessedType = :processedType OR ProcessedType IS NULL) ORDER BY CTime DESC LIMIT :limit").arg(EntityFields.join(","));
             query.prepare(cmd);

--- a/panels/notification/server/notificationmanager.cpp
+++ b/panels/notification/server/notificationmanager.cpp
@@ -94,7 +94,7 @@ bool NotificationManager::registerDbusService()
 
 uint NotificationManager::recordCount() const
 {
-    return m_persistence->fetchEntityCount(QLatin1String(), NotifyEntity::Processed);
+    return m_persistence->fetchEntityCount(DataAccessor::AllApp(), NotifyEntity::Processed);
 }
 
 void NotificationManager::actionInvoked(qint64 id, uint bubbleId, const QString &actionKey)
@@ -112,6 +112,7 @@ void NotificationManager::actionInvoked(qint64 id, uint bubbleId, const QString 
 
 void NotificationManager::notificationClosed(qint64 id, uint bubbleId, uint reason)
 {
+    qDebug(notifyLog) << "Close notification id" << id << ", reason" << reason;
     updateEntityProcessed(id, reason);
 
     Q_EMIT NotificationClosed(bubbleId, reason);
@@ -166,6 +167,7 @@ uint NotificationManager::Notify(const QString &appName, uint replacesId, const 
             << ", expireTimeout:" << expireTimeout;
 
     if (calledFromDBus() && m_setting->systemValue(NotificationSetting::CloseNotification).toBool()) {
+        qDebug(notifyLog) << "Notify has been disabled by CloseNotification setting.";
         return 0;
     }
 
@@ -196,7 +198,7 @@ uint NotificationManager::Notify(const QString &appName, uint replacesId, const 
 
     bool lockScreenShow = true;
     bool dndMode = isDoNotDisturb();
-    bool systemNotification = m_systemApps.contains(appName);
+    bool systemNotification = m_systemApps.contains(appId);
     bool lockScreen = m_userSessionManager->locked();
     const bool desktopScreen = !lockScreen;
 
@@ -368,7 +370,7 @@ void NotificationManager::tryPlayNotificationSound(const NotifyEntity &entity, c
 
 void NotificationManager::emitRecordCountChanged()
 {
-    const auto count = m_persistence->fetchEntityCount(QLatin1String(), NotifyEntity::Processed);
+    const auto count = m_persistence->fetchEntityCount(DataAccessor::AllApp(), NotifyEntity::Processed);
     emit RecordCountChanged(count);
 }
 


### PR DESCRIPTION
AppName maybe is empty string, so we use an string to represent
AllApp.
Adjust action's background.

Task: https://pms.uniontech.com/task-view-366403.html
