### PR TITLE
fix: incorrect position of panel for notification

### DIFF
--- a/panels/dock/dockpanel.cpp
+++ b/panels/dock/dockpanel.cpp
@@ -382,6 +382,14 @@ void DockPanel::setDockScreen(QScreen *screen)
     m_dockScreen = screen;
     window()->setScreen(m_dockScreen);
     Q_EMIT dockScreenChanged(m_dockScreen);
+    Q_EMIT screenNameChanged();
+}
+
+QString DockPanel::screenName() const
+{
+    if (!m_dockScreen)
+        return {};
+    return m_dockScreen->name();
 }
 }
 

--- a/panels/dock/dockpanel.h
+++ b/panels/dock/dockpanel.h
@@ -31,6 +31,7 @@ class DockPanel : public DS_NAMESPACE::DPanel, public QDBusContext
     Q_PROPERTY(ItemAlignment itemAlignment READ itemAlignment WRITE setItemAlignment NOTIFY itemAlignmentChanged FINAL)
     Q_PROPERTY(IndicatorStyle indicatorStyle READ indicatorStyle WRITE setIndicatorStyle NOTIFY indicatorStyleChanged FINAL)
     Q_PROPERTY(bool showInPrimary READ showInPrimary WRITE setShowInPrimary NOTIFY showInPrimaryChanged FINAL)
+    Q_PROPERTY(QString screenName READ screenName NOTIFY screenNameChanged FINAL)
 
     Q_PROPERTY(bool debugMode READ debugMode FINAL CONSTANT)
 
@@ -79,6 +80,7 @@ public:
     void setHideState(HideState newHideState);
     QScreen* dockScreen();
     void setDockScreen(QScreen *screen);
+    QString screenName() const;
 
 private Q_SLOTS:
     void onWindowGeometryChanged();
@@ -99,6 +101,7 @@ Q_SIGNALS:
     void indicatorStyleChanged(IndicatorStyle style);
     void showInPrimaryChanged(bool showInPrimary);
     void dockScreenChanged(QScreen *screen);
+    void screenNameChanged();
     void requestClosePopup();
 
 private:

--- a/panels/notification/bubble/package/main.qml
+++ b/panels/notification/bubble/package/main.qml
@@ -18,24 +18,16 @@ Window {
         if (!dockApplet)
             return 0
 
-        let dockRect = dockApplet.frontendWindowRect
-        let rect = Qt.rect(root.screen.virtualX, root.screen.virtualY, root.screen.width, root.screen.height)
-        if (!containsPos(rect, Qt.point(dockRect.x, dockRect.y)))
+        let dockScreen = dockApplet.screenName
+        let screen = root.screen.name
+        let dockHideState = dockApplet.hideState
+        let dockIsHide = dockHideState === 2
+        if (dockScreen !== screen || dockIsHide)
             return 0
 
         let dockSize = dockApplet.dockSize
         let dockPosition = dockApplet.position
         return dockPosition === position ? dockSize : 0
-    }
-
-    function containsPos(rect1, pos) {
-        if (rect1.x <= pos.x &&
-                rect1.y <= pos.y &&
-                (rect1.x + rect1.width > pos.x) &&
-                (rect1.y + rect1.height > pos.y)) {
-            return true
-        }
-        return false
     }
 
     visible: Applet.visible

--- a/panels/notification/center/package/main.qml
+++ b/panels/notification/center/package/main.qml
@@ -17,24 +17,16 @@ Window {
         if (!dockApplet)
             return 0
 
-        let dockRect = dockApplet.frontendWindowRect
-        let rect = Qt.rect(root.screen.virtualX, root.screen.virtualY, root.screen.width, root.screen.height)
-        if (!containsPos(rect, Qt.point(dockRect.x, dockRect.y)))
+        let dockScreen = dockApplet.screenName
+        let screen = root.screen.name
+        let dockHideState = dockApplet.hideState
+        let dockIsHide = dockHideState === 2
+        if (dockScreen !== screen || dockIsHide)
             return 0
 
         let dockSize = dockApplet.dockSize
         let dockPosition = dockApplet.position
         return dockPosition === position ? dockSize : 0
-    }
-
-    function containsPos(rect1, pos) {
-        if (rect1.x <= pos.x &&
-                rect1.y <= pos.y &&
-                (rect1.x + rect1.width > pos.x) &&
-                (rect1.y + rect1.height > pos.y)) {
-            return true
-        }
-        return false
     }
 
     // visible: true


### PR DESCRIPTION
Using screenName instead of position to adjust dock and notification
is on the same screen.

Bug: https://pms.uniontech.com/bug-view-284191.html
