### PR TITLE
fix: ActionInvoked returned wrong id

### DIFF
--- a/panels/notification/common/dbaccessor.cpp
+++ b/panels/notification/common/dbaccessor.cpp
@@ -565,7 +565,7 @@ NotifyEntity DBAccessor::parseEntity(const QSqlQuery &query)
     entity.setHintString(hint);
     entity.setActionString(action);
     entity.setProcessedType(processedType);
-    entity.setBubbleId(id);
+    entity.setBubbleId(notifyId);
     entity.setReplacesId(replacesId);
 
     return entity;


### PR DESCRIPTION
as title

Log: ActionInvoked returned wrong id
Bug: https://pms.uniontech.com/bug-view-283561.html