### PR TITLE
KExtraColumnsProxyModel: port to Qt 6.8's QIdentityProxyModel::setHandleSourceLayoutChanges

### DIFF
--- a/frame/models/kextracolumnsproxymodel.cpp
+++ b/frame/models/kextracolumnsproxymodel.cpp
@@ -38,6 +38,11 @@ KExtraColumnsProxyModel::KExtraColumnsProxyModel(QObject *parent)
     : QIdentityProxyModel(parent)
     , d_ptr(new KExtraColumnsProxyModelPrivate(this))
 {
+    // The handling of persistent model indexes assumes mapToSource can be called for any index
+    // This breaks for the extra column, so we'll have to do it ourselves
+#if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
+    setHandleSourceLayoutChanges(false);
+#endif
 }
 
 KExtraColumnsProxyModel::~KExtraColumnsProxyModel()
@@ -96,6 +101,7 @@ void KExtraColumnsProxyModel::setSourceModel(QAbstractItemModel *model)
     if (model) {
         // The handling of persistent model indexes assumes mapToSource can be called for any index
         // This breaks for the extra column, so we'll have to do it ourselves
+#if QT_VERSION < QT_VERSION_CHECK(6, 8, 0)
         disconnect(model,
                    SIGNAL(layoutAboutToBeChanged(QList<QPersistentModelIndex>, QAbstractItemModel::LayoutChangeHint)),
                    this,
@@ -104,6 +110,7 @@ void KExtraColumnsProxyModel::setSourceModel(QAbstractItemModel *model)
                    SIGNAL(layoutChanged(QList<QPersistentModelIndex>, QAbstractItemModel::LayoutChangeHint)),
                    this,
                    SLOT(_q_sourceLayoutChanged(QList<QPersistentModelIndex>, QAbstractItemModel::LayoutChangeHint)));
+#endif
         connect(model,
                 SIGNAL(layoutAboutToBeChanged(QList<QPersistentModelIndex>, QAbstractItemModel::LayoutChangeHint)),
                 this,


### PR DESCRIPTION
Upstream change: kitemmodels [1a5e6e8dc6cf8656c0a66a63c3acb541978c9e08](https://github.com/KDE/kitemmodels/commit/1a5e6e8dc6cf8656c0a66a63c3acb541978c9e08)
