### PR TITLE
fix: popup can not auto hide on treeland

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,11 @@
 dde-shell (1.99.8) UNRELEASED; urgency=medium
 
+  * fix popup can not hide on treeland
+
+ -- tsic404 <liuheng@depein.org>  Fri, 29 Nov 2024 17:30:18 +0800
+
+dde-shell (1.99.8) UNRELEASED; urgency=medium
+
   * fix: Adjust the effects level of kwin to Optimal-performance, multiTasks plugin can not hide(Bug: 286871)
   * fix: Display bubble icon normally(Bug: 286813)
 

--- a/frame/CMakeLists.txt
+++ b/frame/CMakeLists.txt
@@ -70,6 +70,8 @@ add_library(dde-shell-frame SHARED
     models/kextracolumnsproxymodel.cpp
     models/listtotableproxymodel.cpp
     quick/dsquickdrag.cpp
+    popupwindow.h
+    popupwindow.cpp
     ddeshell_qml.qrc
     dsutility.cpp
 )
@@ -98,6 +100,7 @@ PUBLIC
     Qt${QT_VERSION_MAJOR}::Gui
     Qt${QT_VERSION_MAJOR}::Quick
 PRIVATE
+    Qt${QT_VERSION_MAJOR}::QuickPrivate
     Qt${QT_VERSION_MAJOR}::Concurrent
     Qt${QT_VERSION_MAJOR}::GuiPrivate
     Qt${QT_VERSION_MAJOR}::WaylandClientPrivate

--- a/frame/plugin/CMakeLists.txt
+++ b/frame/plugin/CMakeLists.txt
@@ -12,6 +12,8 @@ add_library(dde-shell-plugin SHARED
 target_link_libraries(dde-shell-plugin
 PUBLIC
     dde-shell-frame
+PRIVATE
+    Qt${QT_VERSION_MAJOR}::QuickPrivate
 )
 
 string(REPLACE "." "/" URI_PATH ${URI})

--- a/frame/plugin/qmlplugin.cpp
+++ b/frame/plugin/qmlplugin.cpp
@@ -6,12 +6,13 @@
 #include "applet.h"
 #include "appletitem.h"
 #include "containmentitem.h"
-#include "panel.h"
 #include "dstypes.h"
-#include "private/dsqmlglobal_p.h"
-#include "quick/dsquickdrag_p.h"
 #include "layershell/dlayershellwindow.h"
 #include "models/listtotableproxymodel.h"
+#include "panel.h"
+#include "popupwindow.h"
+#include "private/dsqmlglobal_p.h"
+#include "quick/dsquickdrag_p.h"
 
 #include <qqml.h>
 
@@ -45,6 +46,7 @@ void QmlpluginPlugin::registerTypes(const char *uri)
     qmlRegisterUncreatableType<DLayerShellWindow>(uri, 1, 0, "DLayerShellWindow","LayerShell Attached");
     qmlRegisterUncreatableType<DQuickDrag>(uri, 1, 0, "DQuickDrag","DQuickDrag Attached");
     qmlRegisterType<ListToTableProxyModel>(uri, 1, 0, "DListToTableProxyModel");
+    qmlRegisterType<PopupWindow>(uri, 1, 0, "PopupWindow");
 
     dsRegisterType(uri, 1, 0, "PanelPopup");
     dsRegisterType(uri, 1, 0, "PanelToolTip");

--- a/frame/popupwindow.cpp
+++ b/frame/popupwindow.cpp
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "popupwindow.h"
+
+DS_BEGIN_NAMESPACE
+PopupWindow::PopupWindow(QWindow *parent)
+    : QQuickWindowQmlImpl(parent)
+{
+}
+
+void PopupWindow::mouseReleaseEvent(QMouseEvent *event)
+{
+    QQuickWindowQmlImpl::mouseReleaseEvent(event);
+    auto rect = geometry();
+    if (!rect.contains(event->globalPosition().toPoint())) {
+        close();
+    }
+}
+
+DS_END_NAMESPACE

--- a/frame/popupwindow.h
+++ b/frame/popupwindow.h
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include "dsglobal.h"
+#include <private/qquickwindowmodule_p.h>
+
+DS_BEGIN_NAMESPACE
+class PopupWindow : public QQuickWindowQmlImpl
+{
+    Q_OBJECT
+    Q_PROPERTY(QWindow *transientParent READ transientParent WRITE setTransientParent NOTIFY transientParentChanged)
+    QML_NAMED_ELEMENT(PopupWindow)
+
+public:
+    PopupWindow(QWindow *parent = nullptr);
+
+protected:
+    void mouseReleaseEvent(QMouseEvent *event) override;
+};
+DS_END_NAMESPACE

--- a/frame/qml/PanelPopupWindow.qml
+++ b/frame/qml/PanelPopupWindow.qml
@@ -8,7 +8,7 @@ import org.deepin.ds 1.0
 import org.deepin.dtk 1.0 as D
 import org.deepin.dtk.style 1.0 as DStyle
 
-Window {
+PopupWindow {
     id: root
 
     property real xOffset: 0
@@ -53,7 +53,7 @@ Window {
 
     width: 10
     height: 10
-    flags: (Qt.platform.pluginName === "xcb" ?  (Qt.Tool | Qt.WindowStaysOnTopHint) : Qt.Popup) 
+    flags: (Qt.platform.pluginName === "xcb" ?  (Qt.Tool | Qt.WindowStaysOnTopHint) : Qt.Popup)
     D.DWindow.enabled: true
     D.DWindow.windowRadius: D.DTK.platformTheme.windowRadius < 0 ? 4 : D.DTK.platformTheme.windowRadius
     D.DWindow.enableSystemResize: false

--- a/panels/dock/package/main.qml
+++ b/panels/dock/package/main.qml
@@ -54,6 +54,7 @@ Window {
     DLayerShellWindow.layer: DLayerShellWindow.LayerTop
     DLayerShellWindow.exclusionZone: Panel.hideMode === Dock.KeepShowing ? Applet.dockSize : 0
     DLayerShellWindow.scope: "dde-shell/dock"
+    DLayerShellWindow.keyboardInteractivity: DLayerShellWindow.KeyboardInteractivityOnDemand
 
     D.DWindow.enabled: true
     D.DWindow.windowRadius: 0


### PR DESCRIPTION
Qt popup get event from other window, so it's necessary to make dock can get focus. And add a PopupWindow to handle Popup auto hide.

log: as title