### PR TITLE
fix: empty icon on task manager in some cases

### DIFF
--- a/panels/dock/taskmanager/taskmanager.cpp
+++ b/panels/dock/taskmanager/taskmanager.cpp
@@ -129,16 +129,17 @@ void TaskManager::handleWindowAdded(QPointer<AbstractWindow> window)
     }
 
     QSharedPointer<DesktopfileAbstractParser> desktopfile = nullptr;
+    QString desktopId;
     if (res.size() > 0) {
-        desktopfile = DESKTOPFILEFACTORY::createById(res.first().data(m_activeAppModel->roleNames().key("desktopId")).toString(), "amAPP");
+        desktopId = res.first().data(m_activeAppModel->roleNames().key("desktopId")).toString();
+    }
+
+    if (!desktopId.isEmpty()) {
+        desktopfile = DESKTOPFILEFACTORY::createById(desktopId, "amAPP");
     }
 
     if (desktopfile.isNull() || !desktopfile->isValied().first) {
-        if (res.size() > 0) {
-            desktopfile = DESKTOPFILEFACTORY::createById(res.first().data(m_activeAppModel->roleNames().key("desktopId")).toString(), "asbtractAPP");
-        } else {
-            desktopfile = DESKTOPFILEFACTORY::createByWindow(window);
-        }
+        desktopfile = DESKTOPFILEFACTORY::createByWindow(window);
     }
 
     auto appitem = desktopfile->getAppItem();


### PR DESCRIPTION
修复部分场景下可能导致错误识别 desktopId,导致任务栏图标被隐藏.

Log: