### PR TITLE
Popup size

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 CMAKE_MINIMUM_REQUIRED(VERSION 3.10)
 
-set(DS_VERSION "0.0.34" CACHE STRING "Define project version")
+set(DS_VERSION "1.99.0" CACHE STRING "Define project version")
 project(DDEShell
     VERSION "${DS_VERSION}"
     DESCRIPTION "dde-shell"

--- a/debian/control
+++ b/debian/control
@@ -32,7 +32,7 @@ Build-Depends:
  libqt6svg6,
  libdtk6declarative, qml6-module-qtquick-controls2-styles-chameleon, qt6-declarative-private-dev,
  libyaml-cpp-dev,
- qt6-l10n-tools, qt6-svg-dev, dde-tray-loader-dev (>= 1.99.5),
+ qt6-l10n-tools, qt6-svg-dev, dde-tray-loader-dev (> 1.99.6),
  dde-application-manager-api (>= 1.2.16), dde-control-center-dev (>= 6.0.73)
 Standards-Version: 3.9.8
 Homepage: http://www.deepin.org

--- a/frame/popupwindow.cpp
+++ b/frame/popupwindow.cpp
@@ -8,6 +8,8 @@ DS_BEGIN_NAMESPACE
 PopupWindow::PopupWindow(QWindow *parent)
     : QQuickWindowQmlImpl(parent)
 {
+    setMinimumHeight(10);
+    setMinimumWidth(10);
 }
 
 void PopupWindow::mouseReleaseEvent(QMouseEvent *event)

--- a/frame/qml/PanelPopupWindow.qml
+++ b/frame/qml/PanelPopupWindow.qml
@@ -51,6 +51,20 @@ PopupWindow {
         return value
     }
 
+    // FIXME: The contentItem of QQuickWindow originally maintains the same size as the Window in the resizeEvent of QQuickWindow,
+    // but there will be inconsistencies under Wayland. Maybe it is a bug of QtWayland.
+    Binding {
+        target: root.contentItem
+        property: "width"
+        value: root.width
+    }
+
+    Binding {
+        target: root.contentItem
+        property: "height"
+        value: root.height
+    }
+
     width: 10
     height: 10
     flags: (Qt.platform.pluginName === "xcb" ?  (Qt.Tool | Qt.WindowStaysOnTopHint) : Qt.Popup)

--- a/panels/dock/CMakeLists.txt
+++ b/panels/dock/CMakeLists.txt
@@ -148,6 +148,7 @@ qt_add_qml_module(dock-plugin
 qt_generate_wayland_protocol_server_sources(dock-plugin
     FILES
         ${DDE_TRAY_LOADER_PROTOCOL}
+        ${WaylandProtocols_DATADIR}/staging/fractional-scale/fractional-scale-v1.xml
 )
 
 target_link_libraries(dock-plugin PUBLIC

--- a/panels/dock/DockCompositor.qml
+++ b/panels/dock/DockCompositor.qml
@@ -24,6 +24,7 @@ Item {
     property ListModel fixedPluginSurfaces: ListModel {}
 
     property var compositor: waylandCompositor
+    property var panelScale: 1.0
 
     signal pluginSurfacesUpdated()
     signal popupCreated(var popup)
@@ -106,6 +107,11 @@ Item {
             onRequestShutdown: {
                 dockCompositor.requestShutdown()
             }
+        }
+
+        PluginScaleManager{
+            id: pluginScaleManager
+            pluginScale: dockCompositor.panelScale * 120
         }
     }
 }

--- a/panels/dock/dockpanel.cpp
+++ b/panels/dock/dockpanel.cpp
@@ -137,6 +137,8 @@ bool DockPanel::init()
             else {
                 m_dockScreen = window()->screen();
             }
+            rootObject()->installEventFilter(this);
+            Q_EMIT devicePixelRatioChanged(window()->devicePixelRatio());
         }
     });
 
@@ -390,6 +392,22 @@ QString DockPanel::screenName() const
     if (!m_dockScreen)
         return {};
     return m_dockScreen->name();
+}
+
+qreal DockPanel::devicePixelRatio() const
+{
+    if (!window())
+        return 1.0;
+    return window()->devicePixelRatio();
+}
+
+bool DockPanel::eventFilter(QObject *watched, QEvent *event)
+{
+    if (watched == window() && event->type() == QEvent::DevicePixelRatioChange) {
+        Q_EMIT devicePixelRatioChanged(window()->devicePixelRatio());
+    }
+
+    return false;
 }
 }
 

--- a/panels/dock/dockpanel.h
+++ b/panels/dock/dockpanel.h
@@ -33,6 +33,8 @@ class DockPanel : public DS_NAMESPACE::DPanel, public QDBusContext
     Q_PROPERTY(bool showInPrimary READ showInPrimary WRITE setShowInPrimary NOTIFY showInPrimaryChanged FINAL)
     Q_PROPERTY(QString screenName READ screenName NOTIFY screenNameChanged FINAL)
 
+    Q_PROPERTY(qreal devicePixelRatio READ devicePixelRatio NOTIFY devicePixelRatioChanged FINAL)
+
     Q_PROPERTY(bool debugMode READ debugMode FINAL CONSTANT)
 
 public:
@@ -82,6 +84,11 @@ public:
     void setDockScreen(QScreen *screen);
     QString screenName() const;
 
+    qreal devicePixelRatio() const;
+
+protected:
+    bool eventFilter(QObject *watched, QEvent *event) override;
+
 private Q_SLOTS:
     void onWindowGeometryChanged();
     void launcherVisibleChanged(bool visible);
@@ -103,6 +110,7 @@ Q_SIGNALS:
     void dockScreenChanged(QScreen *screen);
     void screenNameChanged();
     void requestClosePopup();
+    void devicePixelRatioChanged(qreal ratio);
 
 private:
     ColorTheme m_theme;

--- a/panels/dock/loadtrayplugins.cpp
+++ b/panels/dock/loadtrayplugins.cpp
@@ -118,9 +118,6 @@ void LoadTrayPlugins::setProcessEnv(QProcess *process)
     if (!process) return;
 
     QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
-    env.insert("QT_SCALE_FACTOR", QString::number(qApp->devicePixelRatio()));
-    env.insert("D_DXCB_DISABLE_OVERRIDE_HIDPI", "1");
-
     // TODO: use protocols to determine the environment instead of environment variables
     env.remove("DDE_CURRENT_COMPOSITOR");
 

--- a/panels/dock/package/main.qml
+++ b/panels/dock/package/main.qml
@@ -552,6 +552,10 @@ Window {
             return Qt.size(Panel.frontendWindowRect.width, Panel.frontendWindowRect.height)
         })
 
+        DockCompositor.panelScale = Qt.binding(function(){
+            return Panel.devicePixelRatio
+        })
+
         dock.itemIconSizeBase = dock.dockItemMaxSize
         dock.visible = Panel.hideState !== Dock.Hide
         changeDragAreaAnchor()

--- a/panels/dock/taskmanager/treelandwindowmonitor.cpp
+++ b/panels/dock/taskmanager/treelandwindowmonitor.cpp
@@ -118,6 +118,10 @@ void TreeLandWindowMonitor::presentWindows(QList<uint32_t> windows)
 
 void TreeLandWindowMonitor::showItemPreview(const QPointer<AppItem> &item, QObject* relativePositionItem, int32_t previewXoffset, int32_t previewYoffset, uint32_t direction)
 {
+    if (!m_foreignToplevelManager->isActive()) {
+        return;
+    }
+
     if (m_dockPreview.isNull()) {
         auto window = qobject_cast<QWindow*>(relativePositionItem);
         if (!window) return;

--- a/panels/dock/tray/ShellSurfaceItemProxy.qml
+++ b/panels/dock/tray/ShellSurfaceItemProxy.qml
@@ -16,13 +16,12 @@ Item {
     property bool hovered: hoverHandler.hovered
     property bool pressed: tapHandler.pressed
 
-    width: impl.width
-    height: impl.height
-    implicitWidth: width
-    implicitHeight: height
+    implicitWidth: shellSurface.width
+    implicitHeight: shellSurface.height
 
     ShellSurfaceItem {
         id: impl
+        anchors.fill: parent
         shellSurface: root.shellSurface
         inputEventsEnabled: root.inputEventsEnabled
 

--- a/panels/dock/tray/package/ActionLegacyTrayPluginDelegate.qml
+++ b/panels/dock/tray/package/ActionLegacyTrayPluginDelegate.qml
@@ -40,8 +40,8 @@ AppletItemButton {
     contentItem: Item {
         id: pluginItem
         property var plugin: DockCompositor.findSurface(model.surfaceId)
-        implicitHeight: surfaceItem.height
-        implicitWidth: surfaceItem.width
+        implicitHeight: plugin.height
+        implicitWidth: plugin.width
 
         property var itemGlobalPoint: {
             var a = pluginItem
@@ -84,7 +84,7 @@ AppletItemButton {
 
         ShellSurfaceItem {
             id: surfaceItem
-            anchors.centerIn: parent
+            anchors.fill: parent
             shellSurface: pluginItem.plugin
         }
 


### PR DESCRIPTION
- 修复popup不完整问题
    问题在于QQUickWindow的contentItem尺寸和QQUickWindow没有保持一致导致的，理论上应该是一致的，但是实际出现了不一致的情况，所以临时使用了Binding将两者尺寸绑定到一起并加了FIXME

- 修复popup缩放问题
    popup的缩放之前是通过环境变量设置过去的，但是treeland下支持动态改动缩放，导致缩放不能动态的更着变更。

    1. 去掉环境变量使用wayland 分数缩放协议来做缩放的动态调整
    2. 通过协议提交尺寸，而不是通过buffer来计算尺寸，因为output级别的缩放仅支持整数缩放而不支持分数缩放，会导致尺寸计算不太正确，所以直接使用协议设置对应的尺寸过来。依赖dde-tray-loader 对应的提交https://github.com/linuxdeepin/dde-tray-loader/pull/211