### PR TITLE
fix: default action can't work for notification

### DIFF
--- a/panels/notification/bubble/bubbleitem.cpp
+++ b/panels/notification/bubble/bubbleitem.cpp
@@ -244,9 +244,15 @@ QVariantList BubbleItem::actions() const
 void BubbleItem::updateActions()
 {
     QStringList actions = m_entity.actions();
-    if (actions.contains(QLatin1String("default"))) {
-        actions.removeAll(QLatin1String("default"));
+    const auto index = actions.indexOf(QLatin1String("default"));
+    if (index >= 0) {
+        // default Action maybe have text.
         m_defaultAction = QLatin1String("default");
+        if (actions.size() % 2 == 1) {
+            actions.remove(index);
+        } else {
+            actions.remove(index, 2);
+        }
     }
 
     Q_ASSERT(actions.size() % 2 != 1);

--- a/panels/notification/bubble/package/NormalBubble.qml
+++ b/panels/notification/bubble/package/NormalBubble.qml
@@ -52,8 +52,8 @@ D.Control {
             if (!bubble.defaultAction)
                 return
 
-            console.log("default action", bubble.index)
-            Applet.invokeDefaultAction(bubble.index, bubble.defaultAction)
+            console.log("default action notify", bubble.appName, bubble.defaultAction)
+            Applet.invokeAction(bubble.index, bubble.defaultAction)
         }
         property bool longPressed
         onPressAndHold: {

--- a/panels/notification/center/notifyitem.cpp
+++ b/panels/notification/center/notifyitem.cpp
@@ -117,9 +117,14 @@ QVariantList AppNotifyItem::actions() const
 void AppNotifyItem::updateActions()
 {
     QStringList actions = m_entity.actions();
-    if (actions.contains(QLatin1String("default"))) {
-        actions.removeAll(QLatin1String("default"));
-        m_defaultAction = QLatin1String("default");
+    const auto index = actions.indexOf(QLatin1String("default"));
+    if (index >= 0) {
+        // default Action maybe have text.
+        if (actions.size() % 2 == 1) {
+            actions.remove(index);
+        } else {
+            actions.remove(index, 2);
+        }
     }
 
     Q_ASSERT(actions.size() % 2 != 1);

--- a/panels/notification/common/notifyentity.cpp
+++ b/panels/notification/common/notifyentity.cpp
@@ -107,6 +107,11 @@ bool NotifyEntity::operator==(const NotifyEntity &other) const
     return false;
 }
 
+bool NotifyEntity::operator!=(const NotifyEntity &other) const
+{
+    return !(operator==(other));
+}
+
 bool NotifyEntity::isValid() const
 {
     return d && d->id > 0;

--- a/panels/notification/common/notifyentity.h
+++ b/panels/notification/common/notifyentity.h
@@ -44,6 +44,7 @@ public:
     NotifyEntity &operator=(NotifyEntity &&other);
 
     bool operator==(const NotifyEntity &other) const;
+    bool operator!=(const NotifyEntity &other) const;
 
     bool isValid() const;
 

--- a/panels/notification/server/dbusadaptor.cpp
+++ b/panels/notification/server/dbusadaptor.cpp
@@ -19,7 +19,7 @@ DbusAdaptor::DbusAdaptor(QObject *parent)
 
 QStringList DbusAdaptor::GetCapabilities()
 {
-    qDebug(notifyLog) << "GetCapabilities";
+    qInfo(notifyLog) << "GetCapabilities";
     return manager()->GetCapabilities();
 }
 
@@ -40,13 +40,13 @@ uint DbusAdaptor::Notify(const QString &appName, uint replacesId, const QString 
 
 void DbusAdaptor::CloseNotification(uint id)
 {
-    qDebug(notifyLog) << "Close notification" << id;
+    qInfo(notifyLog) << "Close notification" << id;
     manager()->CloseNotification(id);
 }
 
 void DbusAdaptor::GetServerInformation(QString &name, QString &vendor, QString &version, QString &specVersion)
 {
-    qDebug(notifyLog) << "GetServerInformation";
+    qInfo(notifyLog) << "GetServerInformation";
     manager()->GetServerInformation(name, vendor, version, specVersion);
 }
 
@@ -63,6 +63,7 @@ DDENotificationDbusAdaptor::DDENotificationDbusAdaptor(QObject *parent)
 
 QStringList DDENotificationDbusAdaptor::GetCapabilities()
 {
+    qInfo(notifyLog) << "GetCapabilities";
     return manager()->GetCapabilities();
 }
 
@@ -83,11 +84,13 @@ uint DDENotificationDbusAdaptor::Notify(const QString &appName, uint replacesId,
 
 void DDENotificationDbusAdaptor::CloseNotification(uint id)
 {
+    qInfo(notifyLog) << "Close Notification" << id;
     manager()->CloseNotification(id);
 }
 
 void DDENotificationDbusAdaptor::GetServerInformation(QString &name, QString &vendor, QString &version, QString &specVersion)
 {
+    qInfo(notifyLog) << "GetServerInformation";
     manager()->GetServerInformation(name, vendor, version, specVersion);
 }
 
@@ -118,7 +121,8 @@ void DDENotificationDbusAdaptor::SetAppInfo(const QString &appId, uint configIte
 
 QString DDENotificationDbusAdaptor::GetAppSetting(const QString &appName)
 {
-    return QString();
+    Q_UNUSED(appName)
+    return {};
 }
 
 void DDENotificationDbusAdaptor::SetAppSetting(const QString &settings)

--- a/panels/notification/server/notificationmanager.h
+++ b/panels/notification/server/notificationmanager.h
@@ -81,6 +81,7 @@ private:
 
 private slots:
     void onHandingPendingEntities();
+    void removePendingEntity(const NotifyEntity &entity);
 
 private:
     uint m_replacesCount = 0;


### PR DESCRIPTION
Default action maybe have text, and it's actionId is default.
Remove entity when manually closing it before timeout.
CloseNotification can't work.

pms: BUG-290767
