### PR TITLE
fix: launchpad hide at dropEvent

### DIFF
--- a/frame/popupwindow.cpp
+++ b/frame/popupwindow.cpp
@@ -14,9 +14,25 @@ void PopupWindow::mouseReleaseEvent(QMouseEvent *event)
 {
     QQuickWindowQmlImpl::mouseReleaseEvent(event);
     auto rect = geometry();
-    if (!rect.contains(event->globalPosition().toPoint())) {
+    if (!m_dragging && !rect.contains(event->globalPosition().toPoint()) && type() == Qt::Popup) {
         close();
     }
+    m_dragging = false;
+    m_pressing = false;
+}
+
+void PopupWindow::mousePressEvent(QMouseEvent *event)
+{
+    m_pressing = true;
+    return QQuickWindowQmlImpl::mousePressEvent(event);
+}
+
+void PopupWindow::mouseMoveEvent(QMouseEvent *event)
+{
+    if (m_pressing) {
+        m_dragging = true;
+    }
+    return QQuickWindowQmlImpl::mouseMoveEvent(event);
 }
 
 DS_END_NAMESPACE

--- a/frame/popupwindow.h
+++ b/frame/popupwindow.h
@@ -19,5 +19,11 @@ public:
 
 protected:
     void mouseReleaseEvent(QMouseEvent *event) override;
+    void mousePressEvent(QMouseEvent *event) override;
+    void mouseMoveEvent(QMouseEvent *event) override;
+
+private:
+    bool m_dragging;
+    bool m_pressing;
 };
 DS_END_NAMESPACE


### PR DESCRIPTION
When dragging occurs, the MouseReleaseEvent outside the popup will be a dropEvent,and the window will no longer be closed.

log: as title
pms: BUG-291969