### PR TITLE
fix: dbus_message protocol error for notification

### DIFF
--- a/panels/notification/server/dbusadaptor.cpp
+++ b/panels/notification/server/dbusadaptor.cpp
@@ -28,11 +28,11 @@ uint DbusAdaptor::Notify(const QString &appName, uint replacesId, const QString 
                          int expireTimeout)
 {
     uint id = manager()->Notify(appName, replacesId, appIcon, summary, body, actions, hints, expireTimeout);
-    if (id == std::numeric_limits<uint>::max()) {
+    if (id == 0) {
         QDBusError error(QDBusError::InternalError, "Notify failed.");
         QDBusMessage reply = QDBusMessage::createError(error);
 
-        return QDBusConnection::sessionBus().send(reply);
+        QDBusConnection::sessionBus().send(reply);
     }
 
     return id;
@@ -72,11 +72,11 @@ uint DDENotificationDbusAdaptor::Notify(const QString &appName, uint replacesId,
     int expireTimeout)
 {
     uint id = manager()->Notify(appName, replacesId, appIcon, summary, body, actions, hints, expireTimeout);
-    if (id == std::numeric_limits<uint>::max()) {
+    if (id == 0) {
         QDBusError error(QDBusError::InternalError, "Notify failed.");
         QDBusMessage reply = QDBusMessage::createError(error);
 
-        return QDBusConnection::sessionBus().send(reply);
+        QDBusConnection::sessionBus().send(reply);
     }
 
     return id;

--- a/panels/notification/server/notificationmanager.cpp
+++ b/panels/notification/server/notificationmanager.cpp
@@ -240,7 +240,8 @@ uint NotificationManager::Notify(const QString &appName, uint replacesId, const 
     if (entity.processedType() != NotifyEntity::None) {
         qint64 id = m_persistence->addEntity(entity);
         if (id == -1) {
-            return std::numeric_limits<uint>::max();
+            qWarning(notifyLog) << "Failed on saving DB, bubbleId:" << entity.bubbleId() << ", appName" << appName;
+            return 0;
         }
 
         entity.setId(id);


### PR DESCRIPTION
std::numeric_limits<unit>::max() cause dbus_message protocol error.