### PR TITLE
fix: drop strongInteractive of action for notification

### DIFF
--- a/panels/notification/plugin/NotifyItemContent.qml
+++ b/panels/notification/plugin/NotifyItemContent.qml
@@ -12,8 +12,6 @@ import org.deepin.ds.notification
 NotifyItem {
     id: root
 
-    height:Math.max(DStyle.Style.control.implicitHeight(root),
-                             actionPlaceHolder.active ? root.miniContentHeight + actionPlaceHolder.height : 0)
     property bool closeVisible: root.hovered || root.activeFocus
     property int miniContentHeight: NotifyStyle.contentItem.miniHeight
 
@@ -84,25 +82,6 @@ NotifyItem {
                     }
                     innerShadowColor1: null
                     innerShadowColor2: innerShadowColor1
-                }
-            }
-        }
-    }
-
-    Control {
-        id: actionPlaceHolder
-        anchors {
-            bottom: parent.bottom
-            bottomMargin: 8
-            right: parent.right
-            rightMargin: 8
-        }
-        contentItem: Loader {
-            active: !root.strongInteractive && root.actions.length > 0 && root.hovered
-            sourceComponent: NotifyAction {
-                actions: root.actions
-                onActionInvoked: function (actionId) {
-                    root.actionInvoked(actionId)
                 }
             }
         }
@@ -230,7 +209,7 @@ NotifyItem {
             }
 
             Loader {
-                active: root.strongInteractive && root.actions.length > 0
+                active: root.actions.length > 0
                 visible: active
                 Layout.alignment: Qt.AlignRight | Qt.AlignBottom
                 sourceComponent: NotifyAction {


### PR DESCRIPTION
Action is display in contentItem default, it avoids to hiding
Combobox's popup when the count of Action is more than two.
