### PR TITLE
fix: Changing screen layout might make dock exclusion zone incorrect

### DIFF
--- a/frame/layershell/x11dlayershellemulation.h
+++ b/frame/layershell/x11dlayershellemulation.h
@@ -9,6 +9,7 @@
 
 #include <QObject>
 #include <QWindow>
+#include <QTimer>
 
 #include <xcb/xcb.h>
 #include <xcb/xproto.h>
@@ -31,5 +32,7 @@ private slots:
 private:
     QWindow* m_window;
     DLayerShellWindow* m_dlayerShellWindow;
+    QTimer m_positionChangedTimer;
+    QTimer m_exclusionZoneChangedTimer;
 };
 DS_END_NAMESPACE


### PR DESCRIPTION
Changing screen layout may not change the geometry of the screen binded to dock. (For example, the screen stay on top or left without resolution changed) So, connect slot to all screens instead.

pms: BUG-292677
Log: Changing screen layout might make dock exclusion zone incorrect