### PR TITLE
fix: dock will not hide on hideModeChanged by dbus

### DIFF
--- a/panels/dock/dockhelper.cpp
+++ b/panels/dock/dockhelper.cpp
@@ -27,6 +27,8 @@ DockHelper::DockHelper(DockPanel *parent)
     connect(parent, &DockPanel::rootObjectChanged, this, &DockHelper::initAreas);
     connect(parent, &DockPanel::showInPrimaryChanged, this, &DockHelper::updateAllDockWakeArea);
     connect(parent, &DockPanel::hideStateChanged, this, &DockHelper::updateAllDockWakeArea);
+    connect(parent, &DockPanel::hideModeChanged, m_hideTimer, static_cast<void (QTimer::*)()>(&QTimer::start));
+    connect(parent, &DockPanel::hideModeChanged, m_showTimer, static_cast<void (QTimer::*)()>(&QTimer::start));
     connect(parent, &DockPanel::positionChanged, this, [this](Position pos) {
         std::for_each(m_areas.begin(), m_areas.end(), [pos](const auto &area) {
             if (!area)

--- a/panels/dock/x11dockhelper.h
+++ b/panels/dock/x11dockhelper.h
@@ -88,6 +88,7 @@ private:
     QRect m_dockArea;
     QHash<xcb_window_t, WindowData*> m_windows;
     XcbEventFilter *m_xcbHelper;
+    QTimer *m_updateDockAreaTimer;
 };
 
 class X11DockWakeUpArea : public QObject, public DockWakeUpArea


### PR DESCRIPTION
1. when hideModeChanged to start show/hide timer
2. make the dock's rect is the original size so that the window rect obtained by xcb can correctly calculate whether it overlaps

log: as title
pms: BUG-293825