### PR TITLE
fix: incorrect margin in treeland for notification

### DIFF
--- a/panels/notification/bubble/package/main.qml
+++ b/panels/notification/bubble/package/main.qml
@@ -38,12 +38,13 @@ Window {
     DLayerShellWindow.topMargin: windowMargin(0)
     DLayerShellWindow.rightMargin: windowMargin(1)
     DLayerShellWindow.bottomMargin: windowMargin(2)
+    DLayerShellWindow.exclusionZone: -1
     palette: DTK.palette
     ColorSelector.family: Palette.CrystalColor
-    DWindow.windowEffect: PlatformHandle.EffectNoBorder | PlatformHandle.EffectNoShadow
+    // DWindow.windowEffect: PlatformHandle.EffectNoBorder | PlatformHandle.EffectNoShadow
     color: "transparent"
-    DWindow.windowRadius: 0
-    DWindow.enabled: false
+    // DWindow.windowRadius: 0
+    // DWindow.enabled: false
     // DWindow.enableBlurWindow: true
     screen: Qt.application.screens[0]
     // TODO `Qt.application.screens[0]` maybe invalid, why screen is changed.

--- a/panels/notification/center/package/main.qml
+++ b/panels/notification/center/package/main.qml
@@ -37,17 +37,18 @@ Window {
     // height: 800
     DLayerShellWindow.layer: DLayerShellWindow.LayerOverlay
     DLayerShellWindow.anchors: DLayerShellWindow.AnchorRight | DLayerShellWindow.AnchorTop | DLayerShellWindow.AnchorBottom
-    DLayerShellWindow.topMargin: windowMargin(0) + 10
-    DLayerShellWindow.rightMargin: windowMargin(1) + 10
-    DLayerShellWindow.bottomMargin: windowMargin(2) + 10
+    DLayerShellWindow.topMargin: windowMargin(0)
+    DLayerShellWindow.rightMargin: windowMargin(1)
+    DLayerShellWindow.bottomMargin: windowMargin(2)
+    DLayerShellWindow.exclusionZone: -1
     palette: DTK.palette
     ColorSelector.family: Palette.CrystalColor
-    DWindow.windowEffect: PlatformHandle.EffectNoBorder | PlatformHandle.EffectNoShadow
+    // DWindow.windowEffect: PlatformHandle.EffectNoBorder | PlatformHandle.EffectNoShadow
     // DWindow.windowRadius: DTK.platformTheme.windowRadius
     // DWindow.enableSystemResize: false
     // DWindow.enableSystemMove: false
-    DWindow.windowRadius: 0
-    DWindow.enabled: false
+    // DWindow.windowRadius: 0
+    // DWindow.enabled: false
     color: "transparent"
     // DWindow.enableBlurWindow: true
     screen: Qt.application.screens[0]
@@ -83,6 +84,7 @@ Window {
             top: parent.top
             left: parent.left
             margins: 10
+            rightMargin: 20
             bottom: parent.bottom
         }
 


### PR DESCRIPTION
Adjust UI for notification
Using exclusionZone to Adatp incorrect margin in treeland.
Drop DWindow's platformhandle.

pms: TASK-366403
