### PR TITLE
fix: closeButton was cliped for notification

### DIFF
--- a/panels/notification/bubble/package/main.qml
+++ b/panels/notification/bubble/package/main.qml
@@ -59,7 +59,7 @@ Window {
         anchors {
             centerIn: parent
             margins: 10
-            topMargin: 15
+            topMargin: 20
         }
 
         spacing: 10


### PR DESCRIPTION
Window has default radius in x11, so CloseButton will be clip,
We should set windowRadius to zero by PlatformHandle

pms: TASK-366403
