### PR TITLE
fix: reset width and height when popup closed

### DIFF
--- a/frame/qml/PanelPopupWindow.qml
+++ b/frame/qml/PanelPopupWindow.qml
@@ -80,8 +80,11 @@ PopupWindow {
 
     color: "transparent"
     onVisibleChanged: function (arg) {
-        if (!arg)
+        if (!arg) {
             currentItem = null
+            root.width = 10
+            root.height = 10
+        }
         if (!arg)
             DS.closeChildrenWindows(root)
     }


### PR DESCRIPTION
Different plugins have different panelPopup sizes. clicking different plugin, this prevents the incorrect size popup display when you click to close the popup.

Log: as title