### PR TITLE
fix: Dock will not update hide state when window is destroyed

### DIFF
--- a/panels/dock/taskmanager/treelandwindow.cpp
+++ b/panels/dock/taskmanager/treelandwindow.cpp
@@ -118,6 +118,7 @@ TreeLandWindow::TreeLandWindow(uint32_t id, QObject *parent)
 TreeLandWindow::~TreeLandWindow()
 {
     qCDebug(waylandwindowLog()) << "wayland window destoryed";
+    emit stateChanged();
 }
 
 uint32_t TreeLandWindow::id()


### PR DESCRIPTION
Need emit stateChanged() signal when window is going to be destroyed

pms: BUG-297479
Log: Dock will not update hide state when window is destroyed