### PR TITLE
feat: Add deepin-shell-action for notification

### DIFF
--- a/applets/dde-shutdown/package/metadata.json
+++ b/applets/dde-shutdown/package/metadata.json
@@ -2,6 +2,7 @@
     "Plugin": {
         "Version": "1.0",
         "Id": "org.deepin.ds.dde-shutdown",
-        "Category": "DDE"
+        "Category": "DDE",
+        "Visibility": "Public"
     }
 }

--- a/panels/notification/server/notificationmanager.h
+++ b/panels/notification/server/notificationmanager.h
@@ -78,6 +78,7 @@ private:
 
     QString appIdByAppName(const QString &appName) const;
     void doActionInvoked(const NotifyEntity &entity, const QString &actionId);
+    bool invokeShellAction(const QString &data);
 
 private slots:
     void onHandingPendingEntities();


### PR DESCRIPTION
Support to call dde-shell's plugin function by notification's action.

e.g: call org.deepin.ds.dde-shell's Shutdown.

```
gdbus call --session --dest=org.freedesktop.Notifications \
    --object-path=/org/freedesktop/Notifications \
    --method=org.freedesktop.Notifications.Notify \
    "test" 0 "" 'deepin-dde-shell-action' '' \
    '["shutdown", "shutdown"]' \
    '{"deepin-dde-shell-action-shutdown":<"{\"pluginId\":\"org.deepin.ds.dde-shutdown\",\"method\":\"requestShutdown\",\"arguments\":[\"Shutdown\" ]}">}' \
     0
```

pms: TASK-366403
