### PR TITLE
fix: incorrect exclusionZone in x11

### DIFF
--- a/frame/layershell/x11dlayershellemulation.cpp
+++ b/frame/layershell/x11dlayershellemulation.cpp
@@ -150,6 +150,9 @@ void LayerShellEmulation::onPositionChanged()
   */
 void LayerShellEmulation::onExclusionZoneChanged()
 {
+    // dde-shell issues:379
+    if (m_dlayerShellWindow->exclusionZone() <= 0)
+        return;
     auto scaleFactor = qGuiApp->devicePixelRatio();
     auto *x11Application = qGuiApp->nativeInterface<QNativeInterface::QX11Application>();
     xcb_ewmh_connection_t ewmh_connection;


### PR DESCRIPTION
It caused other screen's maxed window hide when show the window,
and it's only a flag when exclusion zone is less zero in x11.

pms: TASK-365879
