### PR TITLE
chore: temporary disable grand-search icon for wayland

### DIFF
--- a/panels/dock/searchitem/searchitem.h
+++ b/panels/dock/searchitem/searchitem.h
@@ -8,6 +8,8 @@
 #include "applet.h"
 #include "dsglobal.h"
 
+#include <QGuiApplication>
+
 class QDBusMessage;
 namespace dock
 {
@@ -34,6 +36,11 @@ public:
     Q_INVOKABLE bool grandSearchVisible() const
     {
         return m_grandSearchVisible;
+    }
+
+    bool load() override
+    {
+        return QGuiApplication::platformName() != QStringLiteral("wayland");
     }
 
 Q_SIGNALS:


### PR DESCRIPTION
由于全局搜索未适配 layershell，导致全局搜索框的位置可能不正确。在
全局搜索适配前，临时为 treeland 环境禁用任务栏上的全局搜索图标。

Log: