### PR TITLE
fix: access wild pointer for notificationcenter

### DIFF
--- a/panels/notification/server/notificationmanager.cpp
+++ b/panels/notification/server/notificationmanager.cpp
@@ -78,10 +78,6 @@ NotificationManager::NotificationManager(QObject *parent)
 
 NotificationManager::~NotificationManager()
 {
-    if (m_persistence) {
-        delete m_persistence;
-        m_persistence = nullptr;
-    }
 }
 
 bool NotificationManager::registerDbusService()


### PR DESCRIPTION
DataAccessorProxy::instance() is an static object, and we should release
it in server applet.

pms: BUG-366403
