### PR TITLE
feat: support to register dbus service for dde-shell

### DIFF
--- a/panels/osd/osdpanel.cpp
+++ b/panels/osd/osdpanel.cpp
@@ -24,9 +24,6 @@ bool OsdPanel::load()
 #ifndef QT_DEBUG
     return false;
 #else
-    QDBusConnection bus = QDBusConnection::sessionBus();
-    // TODO
-    bus.registerService("org.deepin.dde.Shell");
 
     return DPanel::load();
 #endif
@@ -35,10 +32,7 @@ bool OsdPanel::load()
 bool OsdPanel::init()
 {
     auto bus = QDBusConnection::sessionBus();
-    if (!bus.registerObject(QStringLiteral("/org/deepin/osdService"),
-                       QStringLiteral("org.deepin.osdService"),
-                       this,
-                           QDBusConnection::ExportAllSlots)) {
+    if (!bus.registerObject(QStringLiteral("/org/deepin/dde/shell/osd"), QStringLiteral("org.deepin.dde.shell.osd"), this, QDBusConnection::ExportAllSlots)) {
         return false;
     }
 

--- a/shell/CMakeLists.txt
+++ b/shell/CMakeLists.txt
@@ -29,6 +29,7 @@ target_link_libraries(dde-shell PRIVATE
     Qt${QT_VERSION_MAJOR}::Gui
     Qt${QT_VERSION_MAJOR}::Widgets
     Dtk${DTK_VERSION_MAJOR}::Gui
+    Qt${QT_VERSION_MAJOR}::DBus
 )
 
 configure_file(${CMAKE_SOURCE_DIR}/misc/dde-shell-plugin@.service.in

--- a/shell/main.cpp
+++ b/shell/main.cpp
@@ -121,6 +121,11 @@ int main(int argc, char *argv[])
     parser.addOption(listOption);
     QCommandLineOption sceneviewOption("sceneview", "View applets in scene, it only works without Window.", QString());
     parser.addOption(sceneviewOption);
+    QCommandLineOption dbusServiceNameOption("serviceName",
+                                             "Registed DBus service for the serviceName, if it's not empty.",
+                                             "serviceName",
+                                             QString("org.deepin.dde.shell"));
+    parser.addOption(dbusServiceNameOption);
 
     parser.process(a);
 
@@ -144,6 +149,24 @@ int main(int argc, char *argv[])
     Dtk::Core::DLogManager::registerFileAppender();
     Dtk::Core::DLogManager::registerJournalAppender();
     qCInfo(dsLog) << "Log path is:" << Dtk::Core::DLogManager::getlogFilePath();
+
+    Shell shell;
+    QString serviceName(parser.value(dbusServiceNameOption));
+    if (!parser.isSet(dbusServiceNameOption)) {
+        const QString prefix(serviceName);
+        if (parser.isSet(categoryOption)) {
+            QString subfix(parser.value(categoryOption));
+            serviceName = QString("%1.%2").arg(prefix).arg(subfix);
+        } else {
+            QString subfix(QString::number(QGuiApplication::applicationPid()));
+            serviceName = QString("%1.random%2").arg(prefix).arg(subfix);
+        }
+    }
+    if (!shell.registerDBusService(serviceName)) {
+        qCFatal(dsLog).noquote() << QString("Can't start an instance for the dbus serviceName: \"%1\".").arg(serviceName);
+        return -1;
+    }
+    qCInfo(dsLog).noquote() << QStringLiteral("Register dbus service for the serviceName: \"%1\"").arg(serviceName);
 
     QList<QString> pluginIds;
     if (parser.isSet(testOption)) {
@@ -174,7 +197,6 @@ int main(int argc, char *argv[])
         });
     }
 
-    Shell shell;
     shell.dconfigsMigrate();
     // TODO disable qml's cache avoid to parsing error for ExecutionEngine.
     shell.disableQmlCache();

--- a/shell/shell.cpp
+++ b/shell/shell.cpp
@@ -4,10 +4,12 @@
 
 #include "shell.h"
 
-#include <memory>
 #include <DConfig>
+#include <QDBusConnection>
+#include <QDBusError>
 #include <QLoggingCategory>
 #include <QQmlAbstractUrlInterceptor>
+#include <memory>
 #include <qmlengine.h>
 
 DS_BEGIN_NAMESPACE
@@ -94,6 +96,16 @@ void Shell::dconfigsMigrate()
     }
 
     dconfig->setValue(QStringLiteral("migratedDConfigs"), migratedDconfigs);
+}
+
+bool Shell::registerDBusService(const QString &serviceName)
+{
+    auto bus = QDBusConnection::sessionBus();
+    if (!bus.registerService(serviceName)) {
+        qCWarning(dsLoaderLog).noquote() << QStringLiteral("Failed to register the dbus service: \"%1\".").arg(serviceName) << bus.lastError().message();
+        return false;
+    }
+    return true;
 }
 
 bool Shell::dconfigMigrate(const QString &newConf, const QString &oldConf)

--- a/shell/shell.h
+++ b/shell/shell.h
@@ -19,6 +19,7 @@ public:
     void disableQmlCache();
     void setFlickableWheelDeceleration(const int &value);
     void dconfigsMigrate();
+    bool registerDBusService(const QString &serviceName);
 
 private:
     bool dconfigMigrate(const QString &newConf, const QString &oldConf);


### PR DESCRIPTION
dde-shell register the dbus service, and it's applet only registers object path.