### PR TITLE
feat: drop to dock task icon to launch with uri

### DIFF
--- a/panels/dock/taskmanager/abstractitem.h
+++ b/panels/dock/taskmanager/abstractitem.h
@@ -56,6 +56,7 @@ public:
     virtual void setDocked(bool docked) =0;
 
     virtual void handleClick(const QString& clickItem) = 0;
+    virtual void handleFileDrop(const QStringList & urls) = 0;
 
     // three type data
     virtual QVariant data() = 0;

--- a/panels/dock/taskmanager/appitem.cpp
+++ b/panels/dock/taskmanager/appitem.cpp
@@ -201,6 +201,13 @@ void AppItem::handleClick(const QString& clickItem)
 
 }
 
+void AppItem::handleFileDrop(const QStringList & urls)
+{
+    if (m_desktopfileParser && !m_desktopfileParser.isNull()) {
+        m_desktopfileParser->launchWithUrls(urls);
+    }
+}
+
 QVariant AppItem::data()
 {
     QStringList ret;

--- a/panels/dock/taskmanager/appitem.h
+++ b/panels/dock/taskmanager/appitem.h
@@ -42,6 +42,7 @@ public:
     void setDocked(bool docked) override;
 
     void handleClick(const QString& clickItem) override;
+    void handleFileDrop(const QStringList & urls) override;
 
     QVariant data() override;
 

--- a/panels/dock/taskmanager/desktopfileabstractparser.cpp
+++ b/panels/dock/taskmanager/desktopfileabstractparser.cpp
@@ -37,6 +37,10 @@ void DesktopfileAbstractParser::launchWithAction(const QString& action)
 
 }
 
+void DesktopfileAbstractParser::launchWithUrls(const QStringList & urls)
+{
+}
+
 void DesktopfileAbstractParser::requestQuit()
 {
 

--- a/panels/dock/taskmanager/desktopfileabstractparser.h
+++ b/panels/dock/taskmanager/desktopfileabstractparser.h
@@ -39,11 +39,12 @@ public:
     virtual QString genericName();
     virtual QString desktopIcon();
     virtual QString xDeepinVendor();
-    
+
     virtual std::pair<bool, QString> isValied();
 
     virtual void launch();
     virtual void launchWithAction(const QString& action);
+    virtual void launchWithUrls(const QStringList & urls);
     virtual void requestQuit();
     virtual QString type();
 

--- a/panels/dock/taskmanager/desktopfileamparser.cpp
+++ b/panels/dock/taskmanager/desktopfileamparser.cpp
@@ -39,7 +39,7 @@ DesktopFileAMParser::DesktopFileAMParser(QString id, QObject* parent)
 {
     if (!m_amIsAvaliable) m_amIsAvaliable = QDBusConnection::sessionBus().
         interface()->isServiceRegistered(AM_DBUS_PATH);
-    
+
     connect(&desktopobjectManager, &ObjectManager::InterfacesRemoved, this, [this] (const QDBusObjectPath& path, const QStringList& interfaces) {
         if (m_applicationInterface->path() == path.path()) {
             getAppItem()->setDocked(false);
@@ -189,6 +189,11 @@ void DesktopFileAMParser::launch()
 void DesktopFileAMParser::launchWithAction(const QString& action)
 {
     return launchByAMTool(action);
+}
+
+void DesktopFileAMParser::launchWithUrls(const QStringList & urls)
+{
+    m_applicationInterface->Launch(QString(), urls, QVariantMap());
 }
 
 void DesktopFileAMParser::requestQuit()

--- a/panels/dock/taskmanager/desktopfileamparser.h
+++ b/panels/dock/taskmanager/desktopfileamparser.h
@@ -22,6 +22,7 @@ public:
 
     virtual void launch() override;
     virtual void launchWithAction(const QString& action) override;
+    virtual void launchWithUrls(const QStringList & urls) override;
     virtual void requestQuit() override;
 
     virtual QString id() override;

--- a/panels/dock/taskmanager/package/AppItem.qml
+++ b/panels/dock/taskmanager/package/AppItem.qml
@@ -24,6 +24,7 @@ Item {
     required property int visualIndex
 
     signal clickItem(itemId: string, menuId: string)
+    signal dropFilesOnItem(itemId: string, files: list<string>)
     signal dragFinished()
 
     Drag.active: mouseArea.drag.active
@@ -245,7 +246,7 @@ Item {
                             NumberAnimation { target: rect; property: "width"; from: originSize * (index + 1); to: originSize * (index + 2); duration: 1200 }
                             ColorAnimation { target: rect; property: "color"; from: Qt.rgba(1, 1, 1, 0.4); to: Qt.rgba(1, 1, 1, 0.1); duration: 1200 }
                         }
-                    } 
+                    }
 
                     // TODO Remove it because of consuming performance.
                     // D.BoxShadow {
@@ -381,6 +382,15 @@ Item {
             } else {
                 taskmanager.Applet.hideItemPreview()
             }
+        }
+    }
+
+    DropArea {
+        anchors.fill: parent
+        keys: ["dfm_app_type_for_drag"]
+
+        onDropped: function (drop){
+            root.dropFilesOnItem(root.itemId, drop.urls)
         }
     }
 

--- a/panels/dock/taskmanager/package/TaskManager.qml
+++ b/panels/dock/taskmanager/package/TaskManager.qml
@@ -104,6 +104,7 @@ ContainmentItem {
                     ListView.delayRemove: Drag.active
                     Component.onCompleted: {
                         clickItem.connect(taskmanager.Applet.clickItem)
+                        dropFilesOnItem.connect(taskmanager.Applet.dropFilesOnItem)
                     }
                     onDragFinished: function() {
                         launcherDndDropArea.resetDndState()

--- a/panels/dock/taskmanager/taskmanager.cpp
+++ b/panels/dock/taskmanager/taskmanager.cpp
@@ -180,6 +180,14 @@ void TaskManager::clickItem(const QString& itemId, const QString& menuId)
     item->handleClick(menuId);
 }
 
+void TaskManager::dropFilesOnItem(const QString& itemId, const QStringList& urls)
+{
+    auto item = ItemModel::instance()->getItemById(itemId);
+    if(!item) return;
+
+    item->handleFileDrop(urls);
+}
+
 void TaskManager::showItemPreview(const QString &itemId, QObject* relativePositionItem, int32_t previewXoffset, int32_t previewYoffset, uint32_t direction)
 {
     auto item = ItemModel::instance()->getItemById(itemId).get();

--- a/panels/dock/taskmanager/taskmanager.h
+++ b/panels/dock/taskmanager/taskmanager.h
@@ -44,6 +44,7 @@ public:
     Q_INVOKABLE bool RequestUndock(QString appID);
 
     Q_INVOKABLE void clickItem(const QString& itemid, const QString& menuId);
+    Q_INVOKABLE void dropFilesOnItem(const QString& itemId, const QStringList& urls);
     Q_INVOKABLE void showItemPreview(const QString& itemId, QObject* relativePositionItem, int32_t previewXoffset, int32_t previewYoffset, uint32_t direction);
     Q_INVOKABLE void hideItemPreview();
 


### PR DESCRIPTION
拖拽文件到图标上以打开新实例并将拖拽的文件作为参数.

注:仅实现了拖拽打开行为.并未进行拖拽到图标上则激活现有窗口的实现.

PMS: BUG-275395

------

另注：若合并关于任务栏组合功能的分支，此功能仍需要重新做。