### PR TITLE
fix: Error with SmartHidden and KeepHidden modes of dock

### DIFF
--- a/frame/layershell/x11dlayershellemulation.cpp
+++ b/frame/layershell/x11dlayershellemulation.cpp
@@ -151,7 +151,7 @@ void LayerShellEmulation::onPositionChanged()
 void LayerShellEmulation::onExclusionZoneChanged()
 {
     // dde-shell issues:379
-    if (m_dlayerShellWindow->exclusionZone() <= 0)
+    if (m_dlayerShellWindow->exclusionZone() < 0)
         return;
     auto scaleFactor = qGuiApp->devicePixelRatio();
     auto *x11Application = qGuiApp->nativeInterface<QNativeInterface::QX11Application>();

--- a/panels/dock/dockhelper.h
+++ b/panels/dock/dockhelper.h
@@ -49,6 +49,7 @@ private:
 private:
     QHash<QScreen *, DockWakeUpArea *> m_areas;
     QHash<QWindow *, bool> m_enters;
+    QHash<QWindow *, bool> m_transientChildShows;
     QTimer *m_hideTimer;
     QTimer *m_showTimer;
 };


### PR DESCRIPTION
1. SmartHide mode does not automatically hide
2. KeepHidden mode should not be hidden when a subwindow show

Log: pms-302819