### PR TITLE
fix: item size not updated when taskbar item count was changed

### DIFF
--- a/example/bridge-example/package/appletitem.qml
+++ b/example/bridge-example/package/appletitem.qml
@@ -16,7 +16,7 @@ import org.deepin.ds.dock 1.0
 AppletItem {
     id: debuggerApplet
     property bool useColumnLayout: Panel.position % 2
-    property int dockOrder: 12
+    property int dockOrder: 21
     // 1:4 the distance between app : dock height; get width/height≈0.8
     implicitWidth: useColumnLayout ? Panel.rootObject.dockSize : Panel.rootObject.dockItemMaxSize * 0.8
     implicitHeight: useColumnLayout ? Panel.rootObject.dockItemMaxSize * 0.8 : Panel.rootObject.dockSize


### PR DESCRIPTION
修复任务栏图标数量过多时,新增图标后,图标大小仍未更新的问题.

PMS: BUG-289225
Log: