### PR TITLE
fix: invalid cache for opacity

### DIFF
--- a/applets/dde-appearance/appearanceapplet.cpp
+++ b/applets/dde-appearance/appearanceapplet.cpp
@@ -59,7 +59,6 @@ void AppearanceApplet::initDBusProxy()
     }
 
     m_interface->setSync(false);
-    m_interface->setUseCache(true);
     QObject::connect(m_interface.data(), &org::deepin::dde::Appearance1::OpacityChanged, this, &AppearanceApplet::opacityChanged);
 }
 


### PR DESCRIPTION
it's a bug for dtk in DDBusExtendedAbstractInterface, which is
not initialize value when using userCache.

pms:BUG-297195
