### PR TITLE
fix: task area might have incorrect height after resize in some cases

### DIFF
--- a/panels/dock/dockpanel.cpp
+++ b/panels/dock/dockpanel.cpp
@@ -74,7 +74,7 @@ bool DockPanel::init()
                 if (m_dockScreen != window()->screen() && qApp->screens().contains( m_dockScreen)) {
                     qWarning() << "m_dockScreen" << m_dockScreen << m_dockScreen->name() << "window()->screen()" << window()->screen() << window()->screen()->name();
                     QTimer::singleShot(10, this, [this](){
-                        window()->setScreen(m_dockScreen); 
+                        window()->setScreen(m_dockScreen);
                         onWindowGeometryChanged();
                     });
                 } else {
@@ -335,11 +335,16 @@ void DockPanel::launcherVisibleChanged(bool visible)
 {
     if (visible == m_launcherShown) return;
 
+    const HideState oldHideState = hideState();
     m_launcherShown = visible;
-    Q_EMIT hideStateChanged(hideState());
+    const HideState newHideState = hideState();
+
+    if (newHideState != oldHideState) {
+        Q_EMIT hideStateChanged(newHideState);
+    }
 }
 
-void DockPanel::updateDockScreen() 
+void DockPanel::updateDockScreen()
 {
     auto win = window();
     if (!win)


### PR DESCRIPTION
在启动器为显示状态时,直接拖拽dock边缘迅速调整dock高度会导致dock高度变回拖拽前的高度,表现行为即dock显示不完整或dock内组件使用的高度与dock自身高度不符.

根音是启动器的隐藏会触发dock隐藏状态属性变化的信号(无论是否真的变化了),此属性绑定了调整dock窗口高度的动画,动画中修改了窗口的实际高度.

由于当前仅以最保守的形式进行bug修复,此处仅添加了属性是否实际变化的检查,并仅在真的变化时才发变化的信号.此部分对应的写法应当后续改掉.

PMS: BUG-303541, BUG-303155