### PR TITLE
fix: shadow clipped for notification

### DIFF
--- a/panels/notification/bubble/package/main.qml
+++ b/panels/notification/bubble/package/main.qml
@@ -31,7 +31,7 @@ Window {
     }
 
     visible: Applet.visible
-    width: 380
+    width: 390
     height: Math.max(10, bubbleView.height + bubbleView.anchors.topMargin + bubbleView.anchors.bottomMargin)
     DLayerShellWindow.layer: DLayerShellWindow.LayerTop
     DLayerShellWindow.anchors: DLayerShellWindow.AnchorBottom | DLayerShellWindow.AnchorRight
@@ -57,9 +57,11 @@ Window {
         width: 360
         height: contentHeight
         anchors {
-            centerIn: parent
-            margins: 10
-            topMargin: 20
+            right: parent.right
+            bottom: parent.bottom
+            bottomMargin: 10
+            rightMargin: 10
+            margins: 30
         }
 
         spacing: 10

--- a/panels/notification/center/package/main.qml
+++ b/panels/notification/center/package/main.qml
@@ -84,8 +84,7 @@ Window {
         anchors {
             top: parent.top
             left: parent.left
-            margins: 10
-            rightMargin: 20
+            margins: 20
             bottom: parent.bottom
         }
 

--- a/panels/notification/plugin/NotifyItemBackground.qml
+++ b/panels/notification/plugin/NotifyItemBackground.qml
@@ -59,7 +59,7 @@ Control {
             active: control.dropShadowColor
             sourceComponent: BoxShadow {
                 shadowOffsetX: 0
-                shadowOffsetY: 6
+                shadowOffsetY: 8
                 shadowColor: control.ColorSelector.dropShadowColor
                 shadowBlur: 20
                 cornerRadius: backgroundRect.radius

--- a/panels/notification/plugin/NotifyItemContent.qml
+++ b/panels/notification/plugin/NotifyItemContent.qml
@@ -72,10 +72,12 @@ NotifyItem {
                     color1: Palette {
                         normal {
                             common: ("transparent")
-                            crystal: Qt.rgba(240 / 255.0, 240 / 255.0, 240 / 255.0, 0.5)
+                            // TODO crystal: Qt.rgba(240 / 255.0, 240 / 255.0, 240 / 255.0, 0.5)
+                            crystal: Qt.rgba(240 / 255.0, 240 / 255.0, 240 / 255.0, 1.0)
                         }
                         normalDark {
-                            crystal: Qt.rgba(24 / 255.0, 24 / 255.0, 24 / 255.0, 0.5)
+                            // TODO crystal: Qt.rgba(240 / 255.0, 240 / 255.0, 240 / 255.0, 0.5)
+                            crystal: Qt.rgba(24 / 255.0, 24 / 255.0, 24 / 255.0, 1.0)
                         }
                     }
                     color2: color1

--- a/panels/notification/plugin/SettingActionButton.qml
+++ b/panels/notification/plugin/SettingActionButton.qml
@@ -36,10 +36,12 @@ ActionButton {
         color1: Palette {
             normal {
                 common: ("transparent")
-                crystal: Qt.rgba(240 / 255.0, 240 / 255.0, 240 / 255.0, 0.5)
+                // TODO crystal: Qt.rgba(240 / 255.0, 240 / 255.0, 240 / 255.0, 0.5)
+                crystal: Qt.rgba(240 / 255.0, 240 / 255.0, 240 / 255.0, 1.0)
             }
             normalDark {
-                crystal: Qt.rgba(24 / 255.0, 24 / 255.0, 24 / 255.0, 0.5)
+                // TODO crystal: Qt.rgba(240 / 255.0, 240 / 255.0, 240 / 255.0, 0.5)
+                crystal: Qt.rgba(24 / 255.0, 24 / 255.0, 24 / 255.0, 1.0)
             }
         }
 


### PR DESCRIPTION
Increase window's width to prevent shadows from being clipped.

pms: BUG-304379 BUG-300509

## Summary by Sourcery

Improve notification panel visual appearance and prevent shadow clipping by adjusting window dimensions and shadow properties

Bug Fixes:
- Increase notification window width to prevent shadow clipping
- Adjust notification item shadow and positioning to improve visual clarity

Enhancements:
- Modify notification item background and positioning for better visual presentation
- Update color opacity for notification elements