### PR TITLE
pref: using map-reduce to fetch window preview for x11

### DIFF
--- a/panels/dock/taskmanager/CMakeLists.txt
+++ b/panels/dock/taskmanager/CMakeLists.txt
@@ -83,6 +83,7 @@ qt_generate_wayland_protocol_client_sources(dock-taskmanager
 target_link_libraries(dock-taskmanager PRIVATE
     dde-shell-frame
     Qt${QT_VERSION_MAJOR}::WaylandClientPrivate
+    Qt${QT_VERSION_MAJOR}::Concurrent
     yaml-cpp
     PkgConfig::WaylandClient
 )


### PR DESCRIPTION
Avoid lagging during multi window preview.

## Summary by Sourcery

Optimize window preview fetching for X11 using map-reduce concurrency to improve performance and reduce lag during multi-window preview

Enhancements:
- Implement concurrent window preview fetching using QtConcurrent::blockingMapped to parallelize preview generation

Build:
- Add Qt Concurrent library as a link dependency in CMakeLists.txt