### PR TITLE
fix: incorrect windowText for osd

### DIFF
--- a/panels/notification/osd/package/main.qml
+++ b/panels/notification/osd/package/main.qml
@@ -33,22 +33,30 @@ Window {
     property Item osdView
     property bool isSingleView: false
 
-    Repeater {
-        model: Applet.appletItems
-        delegate: Loader {
-            active: modelData.update(Applet.osdType)
-            onActiveChanged: {
-                if (active) {
-                    root.isSingleView = modelData.singleView
-                    root.osdView = this
-                }
-            }
+    Control {
+        property D.Palette textColor: D.Palette {
+            normal: Qt.rgba(0, 0, 0, 1)
+            normalDark: Qt.rgba(1, 1, 1, 1)
+        }
+        palette.windowText:  D.ColorSelector.textColor
 
-            sourceComponent: Control {
-                contentItem: model.data
-                background: D.FloatingPanel {
-                    implicitWidth:  100
-                    implicitHeight: 40
+        Repeater {
+            model: Applet.appletItems
+            delegate: Loader {
+                active: modelData.update(Applet.osdType)
+                onActiveChanged: {
+                    if (active) {
+                        root.isSingleView = modelData.singleView
+                        root.osdView = this
+                    }
+                }
+
+                sourceComponent: Control {
+                    contentItem: model.data
+                    background: D.FloatingPanel {
+                        implicitWidth:  100
+                        implicitHeight: 40
+                    }
                 }
             }
         }

--- a/panels/notification/osd/windoweffect/package/main.qml
+++ b/panels/notification/osd/windoweffect/package/main.qml
@@ -138,6 +138,7 @@ AppletItem {
                     D.Label {
                         text: itemView.description
                         font: D.DTK.fontManager.t6
+                        palette.windowText: D.DTK.palette.windowText
                         Layout.fillWidth: true
                         horizontalAlignment: Text.AlignLeft
                         Layout.maximumWidth: 298


### PR DESCRIPTION
windowText is not opacity for most Control, so we change the
windowText of root Control.

pms: BUG-311111

## Summary by Sourcery

Fix incorrect window text color for OSD (On-Screen Display) controls

Bug Fixes:
- Corrected the window text color for OSD controls to ensure proper text visibility across different themes and color palettes

Enhancements:
- Added a custom text color palette to improve text readability in OSD components