### PR TITLE
fix: incorrect window shadow height for osd

### DIFF
--- a/panels/notification/osd/package/main.qml
+++ b/panels/notification/osd/package/main.qml
@@ -15,6 +15,8 @@ Window {
     D.DWindow.windowRadius: isSingleView ? 30 : D.DTK.platformTheme.windowRadius
     D.DWindow.enableBlurWindow: true
     D.DWindow.enabled: true
+    D.DWindow.shadowOffset: Qt.point(0, 8)
+    D.DWindow.shadowColor: D.DTK.themeType === D.ApplicationHelper.DarkType ? Qt.rgba(0, 0, 0, 0.2) : Qt.rgba(0, 0, 0, 0.1)
     color: "transparent"
     DLayerShellWindow.bottomMargin: 180
     DLayerShellWindow.layer: DLayerShellWindow.LayerOverlay


### PR DESCRIPTION
Adjust shadowOffset by UI designer to avoid shadow height is
not enough.

pms: BUG-310841

## Summary by Sourcery

Bug Fixes:
- Correct the shadow offset and color for the OSD window to ensure proper shadow height and visibility across light and dark themes