### PR TITLE
chore: missing some translations for notification

### DIFF
--- a/panels/notification/center/notifyitem.cpp
+++ b/panels/notification/center/notifyitem.cpp
@@ -79,7 +79,12 @@ void AppNotifyItem::updateTime()
         } else if (minute > 0 && minute < 60) {
             ret = tr("%1 minutes ago").arg(minute);
         } else {
-            ret = tr("%1 hours ago").arg(minute / 60);
+            const auto hour = minute / 60;
+            if (hour == 1) {
+                ret = tr("1 hour ago");
+            } else {
+                ret = tr("%1 hours ago").arg(hour);
+            }
         }
     } else if (elapsedDay >= 1 && elapsedDay < 2) {
         ret = tr("Yesterday ") + " " + time.toString("hh:mm");

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter.ts
@@ -4,7 +4,7 @@
 <context>
     <name>GroupNotify</name>
     <message>
-        <location filename="../GroupNotify.qml" line="50"/>
+        <location filename="../GroupNotify.qml" line="51"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12,17 +12,12 @@
 <context>
     <name>NotifyHeader</name>
     <message>
-        <location filename="../NotifyHeader.qml" line="20"/>
-        <source>Notification Setting</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../NotifyHeader.qml" line="56"/>
+        <location filename="../NotifyHeader.qml" line="42"/>
         <source>Notification Center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../NotifyHeader.qml" line="108"/>
+        <location filename="../NotifyHeader.qml" line="90"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -48,22 +43,27 @@
 <context>
     <name>notifycenter::AppNotifyItem</name>
     <message>
-        <location filename="../notifyitem.cpp" line="76"/>
+        <location filename="../notifyitem.cpp" line="78"/>
         <source>Just now</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="78"/>
+        <location filename="../notifyitem.cpp" line="80"/>
         <source>%1 minutes ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="80"/>
+        <location filename="../notifyitem.cpp" line="84"/>
+        <source>1 hour ago</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../notifyitem.cpp" line="86"/>
         <source>%1 hours ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="83"/>
+        <location filename="../notifyitem.cpp" line="90"/>
         <source>Yesterday </source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_az.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_az.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="az">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="az">
 <context>
     <name>GroupNotify</name>
     <message>
-        <location filename="../GroupNotify.qml" line="50"/>
+        <location filename="../GroupNotify.qml" line="51"/>
         <source>Clear All</source>
         <translation>مسح الكل</translation>
     </message>
@@ -10,17 +12,16 @@
 <context>
     <name>NotifyHeader</name>
     <message>
-        <location filename="../NotifyHeader.qml" line="20"/>
         <source>Notification Setting</source>
-        <translation>إعداد الإشعارات</translation>
+        <translation type="vanished">إعداد الإشعارات</translation>
     </message>
     <message>
-        <location filename="../NotifyHeader.qml" line="56"/>
+        <location filename="../NotifyHeader.qml" line="42"/>
         <source>Notification Center</source>
         <translation>مركز الإشعارات</translation>
     </message>
     <message>
-        <location filename="../NotifyHeader.qml" line="108"/>
+        <location filename="../NotifyHeader.qml" line="90"/>
         <source>Clear All</source>
         <translation>مسح الكل</translation>
     </message>
@@ -46,22 +47,27 @@
 <context>
     <name>notifycenter::AppNotifyItem</name>
     <message>
-        <location filename="../notifyitem.cpp" line="76"/>
+        <location filename="../notifyitem.cpp" line="78"/>
         <source>Just now</source>
         <translation>الآن</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="78"/>
+        <location filename="../notifyitem.cpp" line="80"/>
         <source>%1 minutes ago</source>
         <translation>%1 دقيقة مضت</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="80"/>
+        <location filename="../notifyitem.cpp" line="84"/>
+        <source>1 hour ago</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../notifyitem.cpp" line="86"/>
         <source>%1 hours ago</source>
         <translation>%1 ساعة مضت</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="83"/>
+        <location filename="../notifyitem.cpp" line="90"/>
         <source>Yesterday </source>
         <translation>أمس </translation>
     </message>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_bo.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_bo.ts
@@ -4,7 +4,7 @@
 <context>
     <name>GroupNotify</name>
     <message>
-        <location filename="../GroupNotify.qml" line="50"/>
+        <location filename="../GroupNotify.qml" line="51"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12,17 +12,12 @@
 <context>
     <name>NotifyHeader</name>
     <message>
-        <location filename="../NotifyHeader.qml" line="20"/>
-        <source>Notification Setting</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../NotifyHeader.qml" line="56"/>
+        <location filename="../NotifyHeader.qml" line="42"/>
         <source>Notification Center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../NotifyHeader.qml" line="108"/>
+        <location filename="../NotifyHeader.qml" line="90"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -48,22 +43,27 @@
 <context>
     <name>notifycenter::AppNotifyItem</name>
     <message>
-        <location filename="../notifyitem.cpp" line="76"/>
+        <location filename="../notifyitem.cpp" line="78"/>
         <source>Just now</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="78"/>
+        <location filename="../notifyitem.cpp" line="80"/>
         <source>%1 minutes ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="80"/>
+        <location filename="../notifyitem.cpp" line="84"/>
+        <source>1 hour ago</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../notifyitem.cpp" line="86"/>
         <source>%1 hours ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="83"/>
+        <location filename="../notifyitem.cpp" line="90"/>
         <source>Yesterday </source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_ca.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_ca.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ca">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ca">
 <context>
     <name>GroupNotify</name>
     <message>
-        <location filename="../GroupNotify.qml" line="50"/>
+        <location filename="../GroupNotify.qml" line="51"/>
         <source>Clear All</source>
         <translation>Neteja-ho tot</translation>
     </message>
@@ -10,17 +12,16 @@
 <context>
     <name>NotifyHeader</name>
     <message>
-        <location filename="../NotifyHeader.qml" line="20"/>
         <source>Notification Setting</source>
-        <translation>Configuració de les notificacions</translation>
+        <translation type="vanished">Configuració de les notificacions</translation>
     </message>
     <message>
-        <location filename="../NotifyHeader.qml" line="56"/>
+        <location filename="../NotifyHeader.qml" line="42"/>
         <source>Notification Center</source>
         <translation>Centre de notificacions</translation>
     </message>
     <message>
-        <location filename="../NotifyHeader.qml" line="108"/>
+        <location filename="../NotifyHeader.qml" line="90"/>
         <source>Clear All</source>
         <translation>Neteja-ho tot</translation>
     </message>
@@ -46,22 +47,27 @@
 <context>
     <name>notifycenter::AppNotifyItem</name>
     <message>
-        <location filename="../notifyitem.cpp" line="76"/>
+        <location filename="../notifyitem.cpp" line="78"/>
         <source>Just now</source>
         <translation>Ara mateix</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="78"/>
+        <location filename="../notifyitem.cpp" line="80"/>
         <source>%1 minutes ago</source>
         <translation>Fa %1 minuts</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="80"/>
+        <location filename="../notifyitem.cpp" line="84"/>
+        <source>1 hour ago</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../notifyitem.cpp" line="86"/>
         <source>%1 hours ago</source>
         <translation>Fa %1 hores</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="83"/>
+        <location filename="../notifyitem.cpp" line="90"/>
         <source>Yesterday </source>
         <translation>Ahir</translation>
     </message>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_es.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_es.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="es">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="es">
 <context>
     <name>GroupNotify</name>
     <message>
-        <location filename="../GroupNotify.qml" line="50"/>
+        <location filename="../GroupNotify.qml" line="51"/>
         <source>Clear All</source>
         <translation>Limpiar todo</translation>
     </message>
@@ -10,17 +12,16 @@
 <context>
     <name>NotifyHeader</name>
     <message>
-        <location filename="../NotifyHeader.qml" line="20"/>
         <source>Notification Setting</source>
-        <translation>Ajustes de notificaciones</translation>
+        <translation type="vanished">Ajustes de notificaciones</translation>
     </message>
     <message>
-        <location filename="../NotifyHeader.qml" line="56"/>
+        <location filename="../NotifyHeader.qml" line="42"/>
         <source>Notification Center</source>
         <translation>Centro de notificaciones</translation>
     </message>
     <message>
-        <location filename="../NotifyHeader.qml" line="108"/>
+        <location filename="../NotifyHeader.qml" line="90"/>
         <source>Clear All</source>
         <translation>Limpiar todo</translation>
     </message>
@@ -46,22 +47,27 @@
 <context>
     <name>notifycenter::AppNotifyItem</name>
     <message>
-        <location filename="../notifyitem.cpp" line="76"/>
+        <location filename="../notifyitem.cpp" line="78"/>
         <source>Just now</source>
         <translation>Ahora mismo</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="78"/>
+        <location filename="../notifyitem.cpp" line="80"/>
         <source>%1 minutes ago</source>
         <translation>Hace %1 minutos</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="80"/>
+        <location filename="../notifyitem.cpp" line="84"/>
+        <source>1 hour ago</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../notifyitem.cpp" line="86"/>
         <source>%1 hours ago</source>
         <translation>Hace %1 horas</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="83"/>
+        <location filename="../notifyitem.cpp" line="90"/>
         <source>Yesterday </source>
         <translation>Ayer </translation>
     </message>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_fi.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_fi.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="fi">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fi">
 <context>
     <name>GroupNotify</name>
     <message>
-        <location filename="../GroupNotify.qml" line="50"/>
+        <location filename="../GroupNotify.qml" line="51"/>
         <source>Clear All</source>
         <translation>Tyhjennä kaikki</translation>
     </message>
@@ -10,17 +12,16 @@
 <context>
     <name>NotifyHeader</name>
     <message>
-        <location filename="../NotifyHeader.qml" line="20"/>
         <source>Notification Setting</source>
-        <translation>Ilmoitusten asetukset</translation>
+        <translation type="vanished">Ilmoitusten asetukset</translation>
     </message>
     <message>
-        <location filename="../NotifyHeader.qml" line="56"/>
+        <location filename="../NotifyHeader.qml" line="42"/>
         <source>Notification Center</source>
         <translation>Ilmoituskeskus</translation>
     </message>
     <message>
-        <location filename="../NotifyHeader.qml" line="108"/>
+        <location filename="../NotifyHeader.qml" line="90"/>
         <source>Clear All</source>
         <translation>Tyhjennä kaikki</translation>
     </message>
@@ -46,22 +47,27 @@
 <context>
     <name>notifycenter::AppNotifyItem</name>
     <message>
-        <location filename="../notifyitem.cpp" line="76"/>
+        <location filename="../notifyitem.cpp" line="78"/>
         <source>Just now</source>
         <translation>Juuri nyt</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="78"/>
+        <location filename="../notifyitem.cpp" line="80"/>
         <source>%1 minutes ago</source>
         <translation>%1 minuuttia sitten</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="80"/>
+        <location filename="../notifyitem.cpp" line="84"/>
+        <source>1 hour ago</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../notifyitem.cpp" line="86"/>
         <source>%1 hours ago</source>
         <translation>%1 tuntia sitten</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="83"/>
+        <location filename="../notifyitem.cpp" line="90"/>
         <source>Yesterday </source>
         <translation>Eilen</translation>
     </message>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_fr.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_fr.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="fr">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fr">
 <context>
     <name>GroupNotify</name>
     <message>
-        <location filename="../GroupNotify.qml" line="50"/>
+        <location filename="../GroupNotify.qml" line="51"/>
         <source>Clear All</source>
         <translation>Tout effacer</translation>
     </message>
@@ -10,17 +12,16 @@
 <context>
     <name>NotifyHeader</name>
     <message>
-        <location filename="../NotifyHeader.qml" line="20"/>
         <source>Notification Setting</source>
-        <translation>Réglages des notifications</translation>
+        <translation type="vanished">Réglages des notifications</translation>
     </message>
     <message>
-        <location filename="../NotifyHeader.qml" line="56"/>
+        <location filename="../NotifyHeader.qml" line="42"/>
         <source>Notification Center</source>
         <translation>Centre de notification</translation>
     </message>
     <message>
-        <location filename="../NotifyHeader.qml" line="108"/>
+        <location filename="../NotifyHeader.qml" line="90"/>
         <source>Clear All</source>
         <translation>Tout effacer</translation>
     </message>
@@ -46,22 +47,27 @@
 <context>
     <name>notifycenter::AppNotifyItem</name>
     <message>
-        <location filename="../notifyitem.cpp" line="76"/>
+        <location filename="../notifyitem.cpp" line="78"/>
         <source>Just now</source>
         <translation>À l&apos;instant</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="78"/>
+        <location filename="../notifyitem.cpp" line="80"/>
         <source>%1 minutes ago</source>
         <translation>Il y a %1 minutes</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="80"/>
+        <location filename="../notifyitem.cpp" line="84"/>
+        <source>1 hour ago</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../notifyitem.cpp" line="86"/>
         <source>%1 hours ago</source>
         <translation>Il y a %1 heures</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="83"/>
+        <location filename="../notifyitem.cpp" line="90"/>
         <source>Yesterday </source>
         <translation>Hier</translation>
     </message>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_hu.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_hu.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="hu">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="hu">
 <context>
     <name>GroupNotify</name>
     <message>
-        <location filename="../GroupNotify.qml" line="50"/>
+        <location filename="../GroupNotify.qml" line="51"/>
         <source>Clear All</source>
         <translation>Összes törlése</translation>
     </message>
@@ -10,17 +12,16 @@
 <context>
     <name>NotifyHeader</name>
     <message>
-        <location filename="../NotifyHeader.qml" line="20"/>
         <source>Notification Setting</source>
-        <translation>Értesítési Beállítások</translation>
+        <translation type="vanished">Értesítési Beállítások</translation>
     </message>
     <message>
-        <location filename="../NotifyHeader.qml" line="56"/>
+        <location filename="../NotifyHeader.qml" line="42"/>
         <source>Notification Center</source>
         <translation>Értesítési Központ</translation>
     </message>
     <message>
-        <location filename="../NotifyHeader.qml" line="108"/>
+        <location filename="../NotifyHeader.qml" line="90"/>
         <source>Clear All</source>
         <translation>Összes törlése</translation>
     </message>
@@ -46,22 +47,27 @@
 <context>
     <name>notifycenter::AppNotifyItem</name>
     <message>
-        <location filename="../notifyitem.cpp" line="76"/>
+        <location filename="../notifyitem.cpp" line="78"/>
         <source>Just now</source>
         <translation>Csak most</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="78"/>
+        <location filename="../notifyitem.cpp" line="80"/>
         <source>%1 minutes ago</source>
         <translation>%1 perccel ezelőtt</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="80"/>
+        <location filename="../notifyitem.cpp" line="84"/>
+        <source>1 hour ago</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../notifyitem.cpp" line="86"/>
         <source>%1 hours ago</source>
         <translation>%1 órával ezelőtt</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="83"/>
+        <location filename="../notifyitem.cpp" line="90"/>
         <source>Yesterday </source>
         <translation>Tegnap</translation>
     </message>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_it.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_it.ts
@@ -4,7 +4,7 @@
 <context>
     <name>GroupNotify</name>
     <message>
-        <location filename="../GroupNotify.qml" line="50"/>
+        <location filename="../GroupNotify.qml" line="51"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12,17 +12,12 @@
 <context>
     <name>NotifyHeader</name>
     <message>
-        <location filename="../NotifyHeader.qml" line="20"/>
-        <source>Notification Setting</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../NotifyHeader.qml" line="56"/>
+        <location filename="../NotifyHeader.qml" line="42"/>
         <source>Notification Center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../NotifyHeader.qml" line="108"/>
+        <location filename="../NotifyHeader.qml" line="90"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -48,22 +43,27 @@
 <context>
     <name>notifycenter::AppNotifyItem</name>
     <message>
-        <location filename="../notifyitem.cpp" line="76"/>
+        <location filename="../notifyitem.cpp" line="78"/>
         <source>Just now</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="78"/>
+        <location filename="../notifyitem.cpp" line="80"/>
         <source>%1 minutes ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="80"/>
+        <location filename="../notifyitem.cpp" line="84"/>
+        <source>1 hour ago</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../notifyitem.cpp" line="86"/>
         <source>%1 hours ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="83"/>
+        <location filename="../notifyitem.cpp" line="90"/>
         <source>Yesterday </source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_ja.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_ja.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ja">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ja">
 <context>
     <name>GroupNotify</name>
     <message>
-        <location filename="../GroupNotify.qml" line="50"/>
+        <location filename="../GroupNotify.qml" line="51"/>
         <source>Clear All</source>
         <translation>すべて消去</translation>
     </message>
@@ -10,17 +12,16 @@
 <context>
     <name>NotifyHeader</name>
     <message>
-        <location filename="../NotifyHeader.qml" line="20"/>
         <source>Notification Setting</source>
-        <translation>通知の設定</translation>
+        <translation type="vanished">通知の設定</translation>
     </message>
     <message>
-        <location filename="../NotifyHeader.qml" line="56"/>
+        <location filename="../NotifyHeader.qml" line="42"/>
         <source>Notification Center</source>
         <translation>通知センター</translation>
     </message>
     <message>
-        <location filename="../NotifyHeader.qml" line="108"/>
+        <location filename="../NotifyHeader.qml" line="90"/>
         <source>Clear All</source>
         <translation>すべて消去</translation>
     </message>
@@ -46,22 +47,27 @@
 <context>
     <name>notifycenter::AppNotifyItem</name>
     <message>
-        <location filename="../notifyitem.cpp" line="76"/>
+        <location filename="../notifyitem.cpp" line="78"/>
         <source>Just now</source>
         <translation>たった今</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="78"/>
+        <location filename="../notifyitem.cpp" line="80"/>
         <source>%1 minutes ago</source>
         <translation>%1分前</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="80"/>
+        <location filename="../notifyitem.cpp" line="84"/>
+        <source>1 hour ago</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../notifyitem.cpp" line="86"/>
         <source>%1 hours ago</source>
         <translation>%1時間前</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="83"/>
+        <location filename="../notifyitem.cpp" line="90"/>
         <source>Yesterday </source>
         <translation>昨日</translation>
     </message>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_ko.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_ko.ts
@@ -4,7 +4,7 @@
 <context>
     <name>GroupNotify</name>
     <message>
-        <location filename="../GroupNotify.qml" line="50"/>
+        <location filename="../GroupNotify.qml" line="51"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12,17 +12,12 @@
 <context>
     <name>NotifyHeader</name>
     <message>
-        <location filename="../NotifyHeader.qml" line="20"/>
-        <source>Notification Setting</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../NotifyHeader.qml" line="56"/>
+        <location filename="../NotifyHeader.qml" line="42"/>
         <source>Notification Center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../NotifyHeader.qml" line="108"/>
+        <location filename="../NotifyHeader.qml" line="90"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -48,22 +43,27 @@
 <context>
     <name>notifycenter::AppNotifyItem</name>
     <message>
-        <location filename="../notifyitem.cpp" line="76"/>
+        <location filename="../notifyitem.cpp" line="78"/>
         <source>Just now</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="78"/>
+        <location filename="../notifyitem.cpp" line="80"/>
         <source>%1 minutes ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="80"/>
+        <location filename="../notifyitem.cpp" line="84"/>
+        <source>1 hour ago</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../notifyitem.cpp" line="86"/>
         <source>%1 hours ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="83"/>
+        <location filename="../notifyitem.cpp" line="90"/>
         <source>Yesterday </source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_nb_NO.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_nb_NO.ts
@@ -4,7 +4,7 @@
 <context>
     <name>GroupNotify</name>
     <message>
-        <location filename="../GroupNotify.qml" line="50"/>
+        <location filename="../GroupNotify.qml" line="51"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12,17 +12,12 @@
 <context>
     <name>NotifyHeader</name>
     <message>
-        <location filename="../NotifyHeader.qml" line="20"/>
-        <source>Notification Setting</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../NotifyHeader.qml" line="56"/>
+        <location filename="../NotifyHeader.qml" line="42"/>
         <source>Notification Center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../NotifyHeader.qml" line="108"/>
+        <location filename="../NotifyHeader.qml" line="90"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -48,22 +43,27 @@
 <context>
     <name>notifycenter::AppNotifyItem</name>
     <message>
-        <location filename="../notifyitem.cpp" line="76"/>
+        <location filename="../notifyitem.cpp" line="78"/>
         <source>Just now</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="78"/>
+        <location filename="../notifyitem.cpp" line="80"/>
         <source>%1 minutes ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="80"/>
+        <location filename="../notifyitem.cpp" line="84"/>
+        <source>1 hour ago</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../notifyitem.cpp" line="86"/>
         <source>%1 hours ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="83"/>
+        <location filename="../notifyitem.cpp" line="90"/>
         <source>Yesterday </source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_pl.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_pl.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pl">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pl">
 <context>
     <name>GroupNotify</name>
     <message>
-        <location filename="../GroupNotify.qml" line="50"/>
+        <location filename="../GroupNotify.qml" line="51"/>
         <source>Clear All</source>
         <translation>Wyczyść wszystko</translation>
     </message>
@@ -10,17 +12,16 @@
 <context>
     <name>NotifyHeader</name>
     <message>
-        <location filename="../NotifyHeader.qml" line="20"/>
         <source>Notification Setting</source>
-        <translation>Ustawienia powiadomień</translation>
+        <translation type="vanished">Ustawienia powiadomień</translation>
     </message>
     <message>
-        <location filename="../NotifyHeader.qml" line="56"/>
+        <location filename="../NotifyHeader.qml" line="42"/>
         <source>Notification Center</source>
         <translation>Centrum powiadomień</translation>
     </message>
     <message>
-        <location filename="../NotifyHeader.qml" line="108"/>
+        <location filename="../NotifyHeader.qml" line="90"/>
         <source>Clear All</source>
         <translation>Wyczyść wszystko</translation>
     </message>
@@ -46,22 +47,27 @@
 <context>
     <name>notifycenter::AppNotifyItem</name>
     <message>
-        <location filename="../notifyitem.cpp" line="76"/>
+        <location filename="../notifyitem.cpp" line="78"/>
         <source>Just now</source>
         <translation>Właśnie teraz</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="78"/>
+        <location filename="../notifyitem.cpp" line="80"/>
         <source>%1 minutes ago</source>
         <translation>%1 minut temu</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="80"/>
+        <location filename="../notifyitem.cpp" line="84"/>
+        <source>1 hour ago</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../notifyitem.cpp" line="86"/>
         <source>%1 hours ago</source>
         <translation>%1 godzin temu</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="83"/>
+        <location filename="../notifyitem.cpp" line="90"/>
         <source>Yesterday </source>
         <translation>Wczoraj </translation>
     </message>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_pt_BR.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_pt_BR.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pt_BR">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pt_BR">
 <context>
     <name>GroupNotify</name>
     <message>
-        <location filename="../GroupNotify.qml" line="50"/>
+        <location filename="../GroupNotify.qml" line="51"/>
         <source>Clear All</source>
         <translation>Limpar tudo</translation>
     </message>
@@ -10,17 +12,16 @@
 <context>
     <name>NotifyHeader</name>
     <message>
-        <location filename="../NotifyHeader.qml" line="20"/>
         <source>Notification Setting</source>
-        <translation>Configurações de Notificações</translation>
+        <translation type="vanished">Configurações de Notificações</translation>
     </message>
     <message>
-        <location filename="../NotifyHeader.qml" line="56"/>
+        <location filename="../NotifyHeader.qml" line="42"/>
         <source>Notification Center</source>
         <translation>Central de Notificações</translation>
     </message>
     <message>
-        <location filename="../NotifyHeader.qml" line="108"/>
+        <location filename="../NotifyHeader.qml" line="90"/>
         <source>Clear All</source>
         <translation>Limpar tudo</translation>
     </message>
@@ -46,22 +47,27 @@
 <context>
     <name>notifycenter::AppNotifyItem</name>
     <message>
-        <location filename="../notifyitem.cpp" line="76"/>
+        <location filename="../notifyitem.cpp" line="78"/>
         <source>Just now</source>
         <translation>Há pouco</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="78"/>
+        <location filename="../notifyitem.cpp" line="80"/>
         <source>%1 minutes ago</source>
         <translation>%1 minutos atrás</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="80"/>
+        <location filename="../notifyitem.cpp" line="84"/>
+        <source>1 hour ago</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../notifyitem.cpp" line="86"/>
         <source>%1 hours ago</source>
         <translation>%1 horas atrás</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="83"/>
+        <location filename="../notifyitem.cpp" line="90"/>
         <source>Yesterday </source>
         <translation>Ontem</translation>
     </message>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_ru.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_ru.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ru">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ru">
 <context>
     <name>GroupNotify</name>
     <message>
-        <location filename="../GroupNotify.qml" line="50"/>
+        <location filename="../GroupNotify.qml" line="51"/>
         <source>Clear All</source>
         <translation>Очистить всё</translation>
     </message>
@@ -10,17 +12,16 @@
 <context>
     <name>NotifyHeader</name>
     <message>
-        <location filename="../NotifyHeader.qml" line="20"/>
         <source>Notification Setting</source>
-        <translation>Настройки уведомлений</translation>
+        <translation type="vanished">Настройки уведомлений</translation>
     </message>
     <message>
-        <location filename="../NotifyHeader.qml" line="56"/>
+        <location filename="../NotifyHeader.qml" line="42"/>
         <source>Notification Center</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../NotifyHeader.qml" line="108"/>
+        <location filename="../NotifyHeader.qml" line="90"/>
         <source>Clear All</source>
         <translation>Очистить всё</translation>
     </message>
@@ -30,7 +31,7 @@
     <message>
         <location filename="../NotifySetting.qml" line="18"/>
         <source>Unpin</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../NotifySetting.qml" line="18"/>
@@ -40,28 +41,33 @@
     <message>
         <location filename="../NotifySetting.qml" line="26"/>
         <source>Notification Setting</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Настройки уведомлений</translation>
     </message>
 </context>
 <context>
     <name>notifycenter::AppNotifyItem</name>
     <message>
-        <location filename="../notifyitem.cpp" line="76"/>
+        <location filename="../notifyitem.cpp" line="78"/>
         <source>Just now</source>
         <translation>Сейчас</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="78"/>
+        <location filename="../notifyitem.cpp" line="80"/>
         <source>%1 minutes ago</source>
         <translation>%1 минут назад</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="80"/>
+        <location filename="../notifyitem.cpp" line="84"/>
+        <source>1 hour ago</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../notifyitem.cpp" line="86"/>
         <source>%1 hours ago</source>
         <translation>1% часов назад</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="83"/>
+        <location filename="../notifyitem.cpp" line="90"/>
         <source>Yesterday </source>
         <translation>Вчера</translation>
     </message>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_uk.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_uk.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="uk">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="uk">
 <context>
     <name>GroupNotify</name>
     <message>
-        <location filename="../GroupNotify.qml" line="50"/>
+        <location filename="../GroupNotify.qml" line="51"/>
         <source>Clear All</source>
         <translation>Вилучити все</translation>
     </message>
@@ -10,17 +12,16 @@
 <context>
     <name>NotifyHeader</name>
     <message>
-        <location filename="../NotifyHeader.qml" line="20"/>
         <source>Notification Setting</source>
-        <translation>Параметри сповіщень</translation>
+        <translation type="vanished">Параметри сповіщень</translation>
     </message>
     <message>
-        <location filename="../NotifyHeader.qml" line="56"/>
+        <location filename="../NotifyHeader.qml" line="42"/>
         <source>Notification Center</source>
         <translation>Центр сповіщень</translation>
     </message>
     <message>
-        <location filename="../NotifyHeader.qml" line="108"/>
+        <location filename="../NotifyHeader.qml" line="90"/>
         <source>Clear All</source>
         <translation>Вилучити все</translation>
     </message>
@@ -46,22 +47,27 @@
 <context>
     <name>notifycenter::AppNotifyItem</name>
     <message>
-        <location filename="../notifyitem.cpp" line="76"/>
+        <location filename="../notifyitem.cpp" line="78"/>
         <source>Just now</source>
         <translation>Щойно</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="78"/>
+        <location filename="../notifyitem.cpp" line="80"/>
         <source>%1 minutes ago</source>
         <translation>%1 хвилин тому</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="80"/>
+        <location filename="../notifyitem.cpp" line="84"/>
+        <source>1 hour ago</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../notifyitem.cpp" line="86"/>
         <source>%1 hours ago</source>
         <translation>%1 годин тому</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="83"/>
+        <location filename="../notifyitem.cpp" line="90"/>
         <source>Yesterday </source>
         <translation>Вчора</translation>
     </message>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_zh_CN.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_zh_CN.ts
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1">
+<TS version="2.1" language="zh_CN">
 <context>
     <name>GroupNotify</name>
     <message>
-        <location filename="../GroupNotify.qml" line="50"/>
+        <location filename="../GroupNotify.qml" line="51"/>
         <source>Clear All</source>
         <translation type="unfinished">全部清除</translation>
     </message>
@@ -12,17 +12,16 @@
 <context>
     <name>NotifyHeader</name>
     <message>
-        <location filename="../NotifyHeader.qml" line="20"/>
         <source>Notification Setting</source>
-        <translation type="unfinished">通知设置</translation>
+        <translation type="obsolete">通知设置</translation>
     </message>
     <message>
-        <location filename="../NotifyHeader.qml" line="56"/>
+        <location filename="../NotifyHeader.qml" line="42"/>
         <source>Notification Center</source>
         <translation type="unfinished">通知中心</translation>
     </message>
     <message>
-        <location filename="../NotifyHeader.qml" line="108"/>
+        <location filename="../NotifyHeader.qml" line="90"/>
         <source>Clear All</source>
         <translation type="unfinished">全部清除</translation>
     </message>
@@ -48,22 +47,27 @@
 <context>
     <name>notifycenter::AppNotifyItem</name>
     <message>
-        <location filename="../notifyitem.cpp" line="76"/>
+        <location filename="../notifyitem.cpp" line="78"/>
         <source>Just now</source>
         <translation type="unfinished">刚刚</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="78"/>
+        <location filename="../notifyitem.cpp" line="80"/>
         <source>%1 minutes ago</source>
         <translation type="unfinished">%1分钟前</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="80"/>
+        <location filename="../notifyitem.cpp" line="84"/>
+        <source>1 hour ago</source>
+        <translation type="unfinished">1小时前</translation>
+    </message>
+    <message>
+        <location filename="../notifyitem.cpp" line="86"/>
         <source>%1 hours ago</source>
         <translation type="unfinished">%1小时前</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="83"/>
+        <location filename="../notifyitem.cpp" line="90"/>
         <source>Yesterday </source>
         <translation type="unfinished">昨天</translation>
     </message>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_zh_HK.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_zh_HK.ts
@@ -4,7 +4,7 @@
 <context>
     <name>GroupNotify</name>
     <message>
-        <location filename="../GroupNotify.qml" line="50"/>
+        <location filename="../GroupNotify.qml" line="51"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12,17 +12,12 @@
 <context>
     <name>NotifyHeader</name>
     <message>
-        <location filename="../NotifyHeader.qml" line="20"/>
-        <source>Notification Setting</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../NotifyHeader.qml" line="56"/>
+        <location filename="../NotifyHeader.qml" line="42"/>
         <source>Notification Center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../NotifyHeader.qml" line="108"/>
+        <location filename="../NotifyHeader.qml" line="90"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -48,22 +43,27 @@
 <context>
     <name>notifycenter::AppNotifyItem</name>
     <message>
-        <location filename="../notifyitem.cpp" line="76"/>
+        <location filename="../notifyitem.cpp" line="78"/>
         <source>Just now</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="78"/>
+        <location filename="../notifyitem.cpp" line="80"/>
         <source>%1 minutes ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="80"/>
+        <location filename="../notifyitem.cpp" line="84"/>
+        <source>1 hour ago</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../notifyitem.cpp" line="86"/>
         <source>%1 hours ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="83"/>
+        <location filename="../notifyitem.cpp" line="90"/>
         <source>Yesterday </source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_zh_TW.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_zh_TW.ts
@@ -4,7 +4,7 @@
 <context>
     <name>GroupNotify</name>
     <message>
-        <location filename="../GroupNotify.qml" line="50"/>
+        <location filename="../GroupNotify.qml" line="51"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12,17 +12,12 @@
 <context>
     <name>NotifyHeader</name>
     <message>
-        <location filename="../NotifyHeader.qml" line="20"/>
-        <source>Notification Setting</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../NotifyHeader.qml" line="56"/>
+        <location filename="../NotifyHeader.qml" line="42"/>
         <source>Notification Center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../NotifyHeader.qml" line="108"/>
+        <location filename="../NotifyHeader.qml" line="90"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -48,22 +43,27 @@
 <context>
     <name>notifycenter::AppNotifyItem</name>
     <message>
-        <location filename="../notifyitem.cpp" line="76"/>
+        <location filename="../notifyitem.cpp" line="78"/>
         <source>Just now</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="78"/>
+        <location filename="../notifyitem.cpp" line="80"/>
         <source>%1 minutes ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="80"/>
+        <location filename="../notifyitem.cpp" line="84"/>
+        <source>1 hour ago</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../notifyitem.cpp" line="86"/>
         <source>%1 hours ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="83"/>
+        <location filename="../notifyitem.cpp" line="90"/>
         <source>Yesterday </source>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
as title.

pms: BUG-289337

## Summary by Sourcery

Update translations for notification center with missing translations and time-related improvements

Enhancements:
- Add specific translation for '1 hour ago' to improve time display accuracy

Chores:
- Update XML encoding and DOCTYPE for translation files
- Remove deprecated 'Notification Setting' translations