### PR TITLE
fix: compatibility with Qt 6.9+

### DIFF
--- a/frame/layershell/qwaylandlayershellsurface.cpp
+++ b/frame/layershell/qwaylandlayershellsurface.cpp
@@ -135,8 +135,10 @@ void QWaylandLayerShellSurface::zwlr_layer_surface_v1_configure(uint32_t serial,
         window()->resizeFromApplyConfigure(m_pendingSize);
 #if QT_VERSION < QT_VERSION_CHECK(6, 7, 0)
         window()->handleExpose(QRect(QPoint(), m_pendingSize));
-#else
+#elif QT_VERSION < QT_VERSION_CHECK(6, 9, 0)
         window()->sendRecursiveExposeEvent();
+#else
+        window()->updateExposure();
 #endif
 
     } else {


### PR DESCRIPTION
QtWayland removed the method at
https://github.com/qt/qtwayland/commit/333bb8024214799e818854295b13e7a0b9c79d31

This change follows layer-shell-qt's fix at
https://github.com/KDE/layer-shell-qt/commit/368cf2dd374ce104cbbe1fa356991db2e238c640

## Summary by Sourcery

Update Qt compatibility for layer shell surface configuration to support Qt 6.9 and newer versions

Bug Fixes:
- Fix compatibility issue with Qt 6.9+ by replacing sendRecursiveExposeEvent() with updateExposure() method

Enhancements:
- Add version-specific handling for window exposure events across different Qt versions