### PR TITLE
fix: need update exclusion zone when screen was added or removed

### DIFF
--- a/frame/layershell/x11dlayershellemulation.cpp
+++ b/frame/layershell/x11dlayershellemulation.cpp
@@ -55,12 +55,15 @@ LayerShellEmulation::LayerShellEmulation(QWindow* window, QObject *parent)
     connect(qApp, &QGuiApplication::screenAdded, this, [this] (const QScreen *newScreen) {
         connect(newScreen, &QScreen::geometryChanged, this, &LayerShellEmulation::onPositionChanged);
         connect(newScreen, &QScreen::geometryChanged, &m_exclusionZoneChangedTimer, static_cast<void (QTimer::*)()>(&QTimer::start));
+        m_exclusionZoneChangedTimer.start();
     });
     connect(qApp, &QGuiApplication::primaryScreenChanged, &m_exclusionZoneChangedTimer, static_cast<void (QTimer::*)()>(&QTimer::start));
     connect(m_window, &QWindow::screenChanged, this, [this](QScreen *nowScreen){
         onPositionChanged();
         m_exclusionZoneChangedTimer.start();
     });
+
+    connect(qApp, &QGuiApplication::screenRemoved, &m_exclusionZoneChangedTimer, static_cast<void (QTimer::*)()>(&QTimer::start));
 
     // connect(m_dlayerShellWindow, &DS_NAMESPACE::DLayerShellWindow::keyboardInteractivityChanged, this, &LayerShellEmulation::onKeyboardInteractivityChanged);
 }
@@ -188,7 +191,7 @@ void LayerShellEmulation::onExclusionZoneChanged()
             if (boundary < screen->geometry().bottom())
                 boundary = screen->geometry().bottom();
         }
-        strut_partial.bottom =  + boundary - rect.bottom() + (m_dlayerShellWindow->exclusionZone()) * scaleFactor;
+        strut_partial.bottom = boundary - rect.bottom() + (m_dlayerShellWindow->exclusionZone()) * scaleFactor;
         strut_partial.bottom_start_x = rect.x();
         strut_partial.bottom_end_x = rect.x() + m_window->width();
     }


### PR DESCRIPTION
as title

Log: as title
Pms: BUG-306339

## Summary by Sourcery

Update exclusion zone handling to trigger recalculation when screens are added or removed

Bug Fixes:
- Ensure exclusion zone is updated correctly when screen configuration changes, including screen addition and removal

Enhancements:
- Improve screen change event handling by starting exclusion zone timer for screen addition, removal, and screen changes