### PR TITLE
fix: elements not aligned correctly when dock resize

### DIFF
--- a/panels/dock/package/main.qml
+++ b/panels/dock/package/main.qml
@@ -235,8 +235,8 @@ Window {
 
     Item {
         id: dockContainer
-        width: dock.useColumnLayout ? Panel.dockSize : parent.width
-        height: dock.useColumnLayout ? parent.height : Panel.dockSize
+        width: dock.useColumnLayout ? dock.dockSize : parent.width
+        height: dock.useColumnLayout ? parent.height : dock.dockSize
         anchors {
             left: parent.left
             top: parent.top

--- a/panels/dock/tray/package/tray.qml
+++ b/panels/dock/tray/package/tray.qml
@@ -102,7 +102,7 @@ AppletItem {
         isHorizontal: !tray.useColumnLayout
         model: DDT.TraySortOrderModel
         collapsed: DDT.TraySortOrderModel.collapsed
-        trayHeight: isHorizontal ? tray.implicitHeight : tray.implicitWidth
+        trayHeight: Panel.rootObject.dockSize
         surfaceAcceptor: isTrayPluginPopup
         color: "transparent"
         Component.onCompleted: {


### PR DESCRIPTION
修复用户拖拽 dock 调整高度时,dock内元素未居中的问题.

PMS: BUG-312831
Log: