### PR TITLE
fix: bluetooth still entered notificationcenter

### DIFF
--- a/panels/notification/common/dataaccessorproxy.h
+++ b/panels/notification/common/dataaccessorproxy.h
@@ -40,6 +40,7 @@ public:
 
 private:
     bool routerToSource(qint64 id, int processedType) const;
+    bool filterToSource(const NotifyEntity &entity) const;
 
 private:
     DataAccessor *m_source = nullptr;

--- a/panels/notification/server/notificationmanager.cpp
+++ b/panels/notification/server/notificationmanager.cpp
@@ -472,9 +472,7 @@ void NotificationManager::updateEntityProcessed(const NotifyEntity &entity)
     if (entity.hints().contains("x-deepin-ShowInNotifyCenter")) {
         showInCenter = entity.hints()["x-deepin-ShowInNotifyCenter"].toBool();
     }
-    // "cancel"表示正在发送蓝牙文件,不需要发送到通知中心
-    const auto bluetooth = entity.body().contains("%") && entity.actions().contains("cancel");
-    if (removed || !showInCenter || bluetooth) {
+    if (removed || !showInCenter) {
         // remove it from memory
         m_persistence->removeEntity(id);
     } else {


### PR DESCRIPTION
Filting bluetooth notification in DataAccessorProxy.

pms: BUG-311617

## Summary by Sourcery

Improve handling of Bluetooth file transfer notifications to prevent them from appearing in the notification center

Bug Fixes:
- Fix Bluetooth file transfer notifications incorrectly entering the notification center by adding a filter mechanism

Enhancements:
- Introduce a new filterToSource method in DataAccessorProxy to detect and filter out Bluetooth file transfer notifications