### PR TITLE
fix: Change the translation language of the application in dock

### DIFF
--- a/panels/dock/taskmanager/desktopfileamparser.cpp
+++ b/panels/dock/taskmanager/desktopfileamparser.cpp
@@ -249,7 +249,7 @@ void DesktopFileAMParser::updateActions()
 QString DesktopFileAMParser::getLocaleName(const QString& currentLanguageCode, const QStringMap& names)
 {
     auto localeName = names.value(currentLanguageCode);
-    if( currentLanguageCode.contains('_') && !(names.contains(currentLanguageCode)))
+    if (currentLanguageCode.contains('_') && !(names.contains(currentLanguageCode)))
     {
         auto prefix = currentLanguageCode.split('_')[0];
         if (names.contains(prefix)) {

--- a/panels/dock/taskmanager/desktopfileamparser.cpp
+++ b/panels/dock/taskmanager/desktopfileamparser.cpp
@@ -240,18 +240,32 @@ void DesktopFileAMParser::updateActions()
     auto actionNames = m_applicationInterface->actionName();
 
     for (auto action : actions) {
-        auto localeName = actionNames.value(action).value(currentLanguageCode);
+        auto localeName = getLocaleName(currentLanguageCode, actionNames.value(action));
         auto fallbackDefaultName = actionNames.value(action).value(DEFAULT_KEY);
         m_actions.append({action, localeName.isEmpty() ? fallbackDefaultName : localeName});
     }
+}
+
+QString DesktopFileAMParser::getLocaleName(const QString& currentLanguageCode, const QStringMap& names)
+{
+    auto localeName = names.value(currentLanguageCode);
+    if( currentLanguageCode.contains('_') && !(names.contains(currentLanguageCode)))
+    {
+        auto prefix = currentLanguageCode.split('_')[0];
+        if (names.contains(prefix)) {
+            localeName = names.value(prefix);
+        }
+    }
+    return localeName;
 }
 
 void DesktopFileAMParser::updateLocalName()
 {
     QString currentLanguageCode = QLocale::system().name();
     auto names = m_applicationInterface->name();
-    auto localeName = names.value(currentLanguageCode);
+    auto localeName = getLocaleName(currentLanguageCode, names);
     auto fallbackName = names.value(DEFAULT_KEY);
+
     m_name = localeName.isEmpty() ? fallbackName : localeName;
 }
 
@@ -264,8 +278,9 @@ void DesktopFileAMParser::updateLocalGenericName()
 {
     QString currentLanguageCode = QLocale::system().name();
     auto genericNames = m_applicationInterface->genericName();
-    auto localeGenericName = genericNames.value(currentLanguageCode);
+    auto localeGenericName = getLocaleName(currentLanguageCode, genericNames);
     auto fallBackGenericName = genericNames.value(DEFAULT_KEY);
+
     m_genericName = localeGenericName.isEmpty() ? fallBackGenericName : localeGenericName;
 }
 

--- a/panels/dock/taskmanager/desktopfileamparser.h
+++ b/panels/dock/taskmanager/desktopfileamparser.h
@@ -47,6 +47,7 @@ private:
     QString id2dbusPath(const QString& id);
     void connectToAmDBusSignal(const QString& propertyName, const char* slot);
     void launchByAMTool(const QString &action = QString());
+    QString getLocaleName(const QString& currentLanguageCode, const QStringMap& names);
 
 private Q_SLOTS:
     void updateActions();


### PR DESCRIPTION
Configure name retrieval in three levels

fix-Bug-translation

## Summary by Sourcery

Improve language translation handling for desktop file parsing by adding a more flexible language code matching mechanism

Bug Fixes:
- Enhance language translation retrieval to handle language codes with region specifiers (e.g., en_US) by falling back to base language code (en) if an exact match is not found

Enhancements:
- Introduce a new method `getLocaleName()` to provide more robust language code matching for application names, actions, and generic names