### PR TITLE
fix: dnd does not disable to play sound for notification

### DIFF
--- a/panels/notification/server/notificationmanager.cpp
+++ b/panels/notification/server/notificationmanager.cpp
@@ -421,8 +421,6 @@ void NotificationManager::tryPlayNotificationSound(const NotifyEntity &entity, c
         } else {
             playSoundTip = true;
         }
-    } else if (systemNotification && dndMode) {
-        playSoundTip = true;
     }
 
     if (playSoundTip) {


### PR DESCRIPTION
it's the action in v23, we handle it according v20.

pms: BUG-310921

## Summary by Sourcery

Bug Fixes:
- Prevent playing system notification sounds when in Do Not Disturb mode