### PR TITLE
feat: export visible status for notification

### DIFF
--- a/panels/notification/center/notificationcenterdbusadaptor.h
+++ b/panels/notification/center/notificationcenterdbusadaptor.h
@@ -23,6 +23,9 @@ public Q_SLOTS: // methods
     void Show();
     void Hide();
 
+Q_SIGNALS:
+    void VisibleChanged(bool visible);
+
 private:
     NotificationCenterProxy *impl() const;
 };

--- a/panels/notification/center/notificationcenterproxy.cpp
+++ b/panels/notification/center/notificationcenterproxy.cpp
@@ -16,6 +16,9 @@ namespace notification {
 NotificationCenterProxy::NotificationCenterProxy(QObject *parent)
     : QObject(parent)
 {
+    connect(panel(), &NotificationCenterPanel::visibleChanged, this, [this]() {
+        Q_EMIT VisibleChanged(panel()->visible());
+    });
 }
 
 NotificationCenterProxy::~NotificationCenterProxy()

--- a/panels/notification/center/notificationcenterproxy.h
+++ b/panels/notification/center/notificationcenterproxy.h
@@ -20,6 +20,9 @@ public slots:
     void Show();
     void Hide();
 
+signals:
+    void VisibleChanged(bool visible);
+
 private:
     NotificationCenterPanel *panel() const;
 };


### PR DESCRIPTION
it's useful for dde-tray-loader of notification.

pms: BUG-294163

## Summary by Sourcery

Export the visible status of the notification center as a DBus signal to allow external components to track its visibility state

New Features:
- Add a VisibleChanged signal to expose the notification center's visibility status via DBus

Enhancements:
- Implement a signal connection to propagate the notification center panel's visibility changes