### PR TITLE
fix: Change the translation language of the application in dock #1100

### DIFF
--- a/panels/dock/taskmanager/desktopfileamparser.cpp
+++ b/panels/dock/taskmanager/desktopfileamparser.cpp
@@ -240,18 +240,32 @@ void DesktopFileAMParser::updateActions()
     auto actionNames = m_applicationInterface->actionName();
 
     for (auto action : actions) {
-        auto localeName = actionNames.value(action).value(currentLanguageCode);
+        auto localeName = getLocaleName(currentLanguageCode, actionNames.value(action));
         auto fallbackDefaultName = actionNames.value(action).value(DEFAULT_KEY);
         m_actions.append({action, localeName.isEmpty() ? fallbackDefaultName : localeName});
     }
+}
+
+QString DesktopFileAMParser::getLocaleName(const QString& currentLanguageCode, const QStringMap& names)
+{
+    auto localeName = names.value(currentLanguageCode);
+    if (currentLanguageCode.contains('_') && !(names.contains(currentLanguageCode)))
+    {
+        auto prefix = currentLanguageCode.split('_')[0];
+        if (names.contains(prefix)) {
+            localeName = names.value(prefix);
+        }
+    }
+    return localeName;
 }
 
 void DesktopFileAMParser::updateLocalName()
 {
     QString currentLanguageCode = QLocale::system().name();
     auto names = m_applicationInterface->name();
-    auto localeName = names.value(currentLanguageCode);
+    auto localeName = getLocaleName(currentLanguageCode, names);
     auto fallbackName = names.value(DEFAULT_KEY);
+
     m_name = localeName.isEmpty() ? fallbackName : localeName;
 }
 
@@ -264,8 +278,9 @@ void DesktopFileAMParser::updateLocalGenericName()
 {
     QString currentLanguageCode = QLocale::system().name();
     auto genericNames = m_applicationInterface->genericName();
-    auto localeGenericName = genericNames.value(currentLanguageCode);
+    auto localeGenericName = getLocaleName(currentLanguageCode, genericNames);
     auto fallBackGenericName = genericNames.value(DEFAULT_KEY);
+
     m_genericName = localeGenericName.isEmpty() ? fallBackGenericName : localeGenericName;
 }
 

--- a/panels/dock/taskmanager/desktopfileamparser.h
+++ b/panels/dock/taskmanager/desktopfileamparser.h
@@ -47,6 +47,7 @@ private:
     QString id2dbusPath(const QString& id);
     void connectToAmDBusSignal(const QString& propertyName, const char* slot);
     void launchByAMTool(const QString &action = QString());
+    QString getLocaleName(const QString& currentLanguageCode, const QStringMap& names);
 
 private Q_SLOTS:
     void updateActions();


### PR DESCRIPTION
Configure name retrieval in three levels

fix-Bug-translation

## Summary by Sourcery

Improve language code handling for application translations by adding a more flexible method to retrieve localized names

Bug Fixes:
- Fix translation retrieval by supporting fallback to language code prefix when exact language code is not found

Enhancements:
- Add a new method to handle language code variations when retrieving localized names
- Improve localization name resolution for actions, names, and generic names