### PR TITLE
fix: [Font-size] The Font size can not change by dde-control-center.

### DIFF
--- a/shell/CMakeLists.txt
+++ b/shell/CMakeLists.txt
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: CC0-1.0
 
+find_package(Dtk${DTK_VERSION_MAJOR} COMPONENTS Widget REQUIRED)
 find_package(Qt${QT_VERSION_MAJOR} ${REQUIRED_QT_VERSION} REQUIRED COMPONENTS Widgets Gui WaylandClient)
 find_package(TreelandProtocols REQUIRED)
 pkg_check_modules(WaylandClient REQUIRED IMPORTED_TARGET wayland-client)
@@ -41,6 +42,7 @@ target_link_libraries(dde-shell PRIVATE
     Qt${QT_VERSION_MAJOR}::Widgets
     Qt${QT_VERSION_MAJOR}::WaylandClient
     Dtk${DTK_VERSION_MAJOR}::Gui
+    Dtk${DTK_VERSION_MAJOR}::Widget
     Qt${QT_VERSION_MAJOR}::DBus
     PkgConfig::WaylandClient
 )

--- a/shell/main.cpp
+++ b/shell/main.cpp
@@ -7,6 +7,7 @@
 #include <QCommandLineParser>
 #include <QStandardPaths>
 
+#include <DApplication>
 #include <DGuiApplicationHelper>
 #include <DLog>
 #include <QQuickWindow>
@@ -24,6 +25,7 @@
 
 DS_USE_NAMESPACE
 DGUI_USE_NAMESPACE
+DWIDGET_USE_NAMESPACE
 
 DS_BEGIN_NAMESPACE
 Q_DECLARE_LOGGING_CATEGORY(dsLog)
@@ -95,7 +97,7 @@ int main(int argc, char *argv[])
 {
     setenv("DSG_APP_ID", "org.deepin.dde.shell", 0);
     DGuiApplicationHelper::setAttribute(DGuiApplicationHelper::UseInactiveColorGroup, false);
-    QApplication a(argc, argv);
+    DApplication a(argc, argv);
     // Don't apply to plugins
     qunsetenv("QT_SCALE_FACTOR");
     // dde-shell contains UI controls based on QML and Widget technologies.


### PR DESCRIPTION
-- Dtk enables the font size of upper-layer applications to change with the control center
   through DApplication.
-- The desktop program has embedded dde-shell, but dde-shell uses QApplication, causing the
   font size of upper-layer applications not to follow changes when the control center's font
   size is adjusted.
-- Modify dde-shell's QApplication to DApplication.

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-285621.html

## Summary by Sourcery

Replace QApplication with DApplication in dde-shell to enable font size synchronization with the control center

Bug Fixes:
- Fix font size change synchronization issue between dde-shell and control center by switching from QApplication to DApplication

Enhancements:
- Update application initialization to use DApplication for better integration with Deepin desktop environment

Build:
- Add Dtk Widget package dependency in CMakeLists.txt
- Update target link libraries to include Dtk Widget library