### PR TITLE
fix: Fixed the issue that qCDebug does not output

### DIFF
--- a/panels/dock/taskmanager/taskmanager.cpp
+++ b/panels/dock/taskmanager/taskmanager.cpp
@@ -27,7 +27,7 @@
 #include "x11windowmonitor.h"
 #endif
 
-Q_LOGGING_CATEGORY(taskManagerLog, "dde.shell.dock.taskmanager", QtInfoMsg)
+Q_LOGGING_CATEGORY(taskManagerLog, "dde.shell.dock.taskmanager", QtDebugMsg)
 
 #define Settings TaskManagerSettings::instance()
 


### PR DESCRIPTION
as title.

## Summary by Sourcery

Bug Fixes:
- Fixed qCDebug not outputting for the task manager logging category by changing the default logging level from QtInfoMsg to QtDebugMsg