### PR TITLE
fix: initialize dock color theme with default value

### DIFF
--- a/panels/dock/pluginmanagerextension_p.h
+++ b/panels/dock/pluginmanagerextension_p.h
@@ -108,8 +108,8 @@ private:
 private:
     QList<PluginSurface*> m_pluginSurfaces;
 
-    uint32_t m_dockPosition;
-    uint32_t m_dockColorTheme;
+    uint32_t m_dockPosition = 0;
+    uint32_t m_dockColorTheme = 0;
     QSize m_dockSize;
     int m_popupMinHeight = 0;
 };


### PR DESCRIPTION
1. Changed m_dockColorTheme initialization from uninitialized to -1
2. Prevents potential undefined behavior when accessing uninitialized
variable
3. Ensures consistent behavior when dock color theme is not set

fix: 初始化 dock 颜色主题默认值

1. 将 m_dockColorTheme 从未初始化状态改为初始化为 -1
2. 防止访问未初始化变量时出现未定义行为
3. 确保当 dock 颜色主题未设置时行为一致

pms: BUG-314263

## Summary by Sourcery

Bug Fixes:
- Initialize `m_dockPosition` and `m_dockColorTheme` to 0 in `PluginManagerExtension`.