### PR TITLE
fix: remove DSG_APP_ID from notification action

### DIFF
--- a/panels/notification/server/notificationmanager.cpp
+++ b/panels/notification/server/notificationmanager.cpp
@@ -509,7 +509,14 @@ void NotificationManager::doActionInvoked(const NotifyEntity &entity, const QStr
             QStringList args = i.value().toString().split(",");
             if (!args.isEmpty()) {
                 QString cmd = args.takeFirst(); // 命令
-                QProcess::startDetached(cmd, args); //执行相关命令
+
+                QProcess pro;
+                pro.setProgram(cmd);
+                pro.setArguments(args);
+                QProcessEnvironment proEnv = QProcessEnvironment::systemEnvironment();
+                proEnv.remove("DSG_APP_ID");
+                pro.setProcessEnvironment(proEnv);
+                pro.startDetached();
             }
         } else if (i.key() == "deepin-dde-shell-action-" + actionId) {
             const QString data(i.value().toString());


### PR DESCRIPTION
When starting a child process, do not inherit the DSG_APP-ID environment variable to prevent direct modification of dde shell configuration by the child process

pms: BUG-315007

## Summary by Sourcery

Bug Fixes:
- Prevent direct modification of DDE shell configuration by child processes by removing DSG_APP_ID environment variable