### PR TITLE
refactor: simplify notification action handling

### DIFF
--- a/panels/notification/center/notifyaccessor.cpp
+++ b/panels/notification/center/notifyaccessor.cpp
@@ -196,22 +196,10 @@ void NotifyAccessor::invokeAction(const NotifyEntity &entity, const QString &act
 {
     qDebug(notifyLog) << "Invoke action for the notify" << entity.id() << actionId;
 
-    QMap<QString, QVariant> hints = entity.hints();
-    if (hints.isEmpty())
+    if (!m_dataUpdater)
         return;
-    QMap<QString, QVariant>::const_iterator i = hints.constBegin();
-    while (i != hints.constEnd()) {
-        QStringList args = i.value().toString().split(",");
-        if (!args.isEmpty()) {
-            QString cmd = args.first();
-            args.removeFirst();
-            if (i.key() == "x-deepin-action-" + actionId) {
-                qDebug(notifyLog) << "Invoke action" << cmd;
-                QProcess::startDetached(cmd, args);
-            }
-        }
-        ++i;
-    }
+    const auto id = entity.id();
+    QMetaObject::invokeMethod(m_dataUpdater, "actionInvoked", Qt::DirectConnection, Q_ARG(qint64, id), Q_ARG(const QString &, actionId));
 }
 
 void NotifyAccessor::pinApplication(const QString &appId, bool pin)

--- a/panels/notification/server/notificationmanager.cpp
+++ b/panels/notification/server/notificationmanager.cpp
@@ -113,9 +113,9 @@ uint NotificationManager::recordCount() const
     return m_persistence->fetchEntityCount(DataAccessor::AllApp(), NotifyEntity::Processed);
 }
 
-void NotificationManager::actionInvoked(qint64 id, uint bubbleId, const QString &actionKey)
+void NotificationManager::actionInvoked(qint64 id, const QString &actionKey)
 {
-    qInfo(notifyLog) << "Action invoked, bubbleId:" << bubbleId << ", id:" << id << ", actionKey" << actionKey;
+    qInfo(notifyLog) << "Action invoked, id:" << id << ", actionKey" << actionKey;
     auto entity = m_persistence->fetchEntity(id);
     if (entity.isValid()) {
         doActionInvoked(entity, actionKey);
@@ -123,6 +123,12 @@ void NotificationManager::actionInvoked(qint64 id, uint bubbleId, const QString 
         entity.setProcessedType(NotifyEntity::Removed);
         updateEntityProcessed(entity);
     }
+}
+
+void NotificationManager::actionInvoked(qint64 id, uint bubbleId, const QString &actionKey)
+{
+    qInfo(notifyLog) << "Action invoked, bubbleId:" << bubbleId << ", id:" << id << ", actionKey" << actionKey;
+    actionInvoked(id, actionKey);
 
     Q_EMIT ActionInvoked(bubbleId, actionKey);
     Q_EMIT NotificationClosed(bubbleId, NotifyEntity::Closed);

--- a/panels/notification/server/notificationmanager.h
+++ b/panels/notification/server/notificationmanager.h
@@ -26,6 +26,7 @@ public:
     bool registerDbusService();
 
     uint recordCount() const;
+    Q_INVOKABLE void actionInvoked(qint64 id, const QString &actionKey);
     Q_INVOKABLE void actionInvoked(qint64 id, uint bubbleId, const QString &actionKey);
     Q_INVOKABLE void notificationClosed(qint64 id, uint bubbleId, uint reason);
     Q_INVOKABLE void notificationReplaced(qint64 id);

--- a/panels/notification/server/notifyserverapplet.cpp
+++ b/panels/notification/server/notifyserverapplet.cpp
@@ -67,6 +67,11 @@ void NotifyServerApplet::actionInvoked(qint64 id, uint bubbleId, const QString &
     QMetaObject::invokeMethod(m_manager, "actionInvoked", Qt::DirectConnection, Q_ARG(qint64, id), Q_ARG(uint, bubbleId), Q_ARG(QString, actionKey));
 }
 
+void NotifyServerApplet::actionInvoked(qint64 id, const QString &actionKey)
+{
+    QMetaObject::invokeMethod(m_manager, "actionInvoked", Qt::DirectConnection, Q_ARG(qint64, id), Q_ARG(QString, actionKey));
+}
+
 void NotifyServerApplet::notificationClosed(qint64 id, uint bubbleId, uint reason)
 {
     QMetaObject::invokeMethod(m_manager, "notificationClosed", Qt::DirectConnection, Q_ARG(qint64, id), Q_ARG(uint, bubbleId), Q_ARG(uint, reason));

--- a/panels/notification/server/notifyserverapplet.h
+++ b/panels/notification/server/notifyserverapplet.h
@@ -24,6 +24,7 @@ Q_SIGNALS:
 
 public Q_SLOTS:
     void actionInvoked(qint64 id, uint bubbleId, const QString &actionKey);
+    void actionInvoked(qint64 id, const QString &actionKey);
     void notificationClosed(qint64 id, uint bubbleId, uint reason);
     QVariant appValue(const QString &appId, int configItem);
     void removeNotification(qint64 id);


### PR DESCRIPTION
1. Removed manual action processing in NotifyAccessor and delegated
to DataUpdater
2. Added new actionInvoked method without bubbleId parameter to
NotificationManager
3. Simplified action handling logic by removing direct QProcess
execution
4. Added corresponding methods in NotifyserverApplet to support new
action flow
5. Improved code organization by separating action handling concerns

refactor: 简化通知操作处理逻辑

1. 移除 NotifyAccessor 中的手动操作处理，委托给 DataUpdater
2. 在 NotificationManager 中添加不带 bubbleId 参数的 actionInvoked 方法
3. 通过移除直接 QProcess 执行简化操作处理逻辑
4. 在 NotifyserverApplet 中添加对应方法以支持新的操作流程
5. 通过分离操作处理关注点改进代码组织

## Summary by Sourcery

Refactor notification action handling to simplify and improve code organization by delegating action processing and removing direct process execution

Enhancements:
- Simplified notification action handling logic
- Improved separation of concerns in action processing

Chores:
- Removed direct QProcess execution for action handling
- Updated method signatures to remove unnecessary parameters