### PR TITLE
fix: need request back when embed popup hidden

### DIFF
--- a/panels/dock/tray/quickpanel/SubPluginPage.qml
+++ b/panels/dock/tray/quickpanel/SubPluginPage.qml
@@ -87,6 +87,10 @@ Item {
             id: surfaceLayer
             autoClose: true
             Layout.fillWidth: true
+
+            onSurfaceDestroyed: {
+                requestBack()
+            }
         }
 
         Item { Layout.fillHeight: true; Layout.preferredWidth: 1 }


### PR DESCRIPTION
as title

Log: as title
Pms: BUG-285035

## Summary by Sourcery

Bug Fixes:
- Ensure proper navigation when embed popup is hidden by adding a requestBack() call on surface destruction