### PR TITLE
chore: update copywriting of dock modes

### DIFF
--- a/cmake/DDEShellPackageMacros.cmake
+++ b/cmake/DDEShellPackageMacros.cmake
@@ -89,6 +89,7 @@ function(ds_handle_package_translation)
         TS_FILES ${TRANSLATION_FILES}
         SOURCES ${_config_QML_FILES} ${_config_SOURCE_FILES}
         QM_FILES_OUTPUT_VARIABLE TRANSLATED_FILES
+        LUPDATE_OPTIONS -no-obsolete -no-ui-lines -locations none
         IMMEDIATE_CALL
     )
 

--- a/panels/dock/multitaskview/translations/org.deepin.ds.dock.multitaskview.ts
+++ b/panels/dock/multitaskview/translations/org.deepin.ds.dock.multitaskview.ts
@@ -4,7 +4,6 @@
 <context>
     <name>dock::MultiTaskView</name>
     <message>
-        <location filename="../multitaskview.cpp" line="65"/>
         <source>Multitasking View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12,7 +11,6 @@
 <context>
     <name>multitaskview</name>
     <message>
-        <location filename="../package/multitaskview.qml" line="23"/>
         <source>Multitasking View</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/multitaskview/translations/org.deepin.ds.dock.multitaskview_az.ts
+++ b/panels/dock/multitaskview/translations/org.deepin.ds.dock.multitaskview_az.ts
@@ -4,7 +4,6 @@
 <context>
     <name>dock::MultiTaskView</name>
     <message>
-        <location filename="../multitaskview.cpp" line="65"/>
         <source>Multitasking View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12,7 +11,6 @@
 <context>
     <name>multitaskview</name>
     <message>
-        <location filename="../package/multitaskview.qml" line="23"/>
         <source>Multitasking View</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/multitaskview/translations/org.deepin.ds.dock.multitaskview_bo.ts
+++ b/panels/dock/multitaskview/translations/org.deepin.ds.dock.multitaskview_bo.ts
@@ -4,7 +4,6 @@
 <context>
     <name>dock::MultiTaskView</name>
     <message>
-        <location filename="../multitaskview.cpp" line="65"/>
         <source>Multitasking View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12,7 +11,6 @@
 <context>
     <name>multitaskview</name>
     <message>
-        <location filename="../package/multitaskview.qml" line="23"/>
         <source>Multitasking View</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/multitaskview/translations/org.deepin.ds.dock.multitaskview_ca.ts
+++ b/panels/dock/multitaskview/translations/org.deepin.ds.dock.multitaskview_ca.ts
@@ -4,7 +4,6 @@
 <context>
     <name>dock::MultiTaskView</name>
     <message>
-        <location filename="../multitaskview.cpp" line="65"/>
         <source>Multitasking View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12,7 +11,6 @@
 <context>
     <name>multitaskview</name>
     <message>
-        <location filename="../package/multitaskview.qml" line="23"/>
         <source>Multitasking View</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/multitaskview/translations/org.deepin.ds.dock.multitaskview_es.ts
+++ b/panels/dock/multitaskview/translations/org.deepin.ds.dock.multitaskview_es.ts
@@ -4,7 +4,6 @@
 <context>
     <name>dock::MultiTaskView</name>
     <message>
-        <location filename="../multitaskview.cpp" line="65"/>
         <source>Multitasking View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12,7 +11,6 @@
 <context>
     <name>multitaskview</name>
     <message>
-        <location filename="../package/multitaskview.qml" line="23"/>
         <source>Multitasking View</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/multitaskview/translations/org.deepin.ds.dock.multitaskview_fi.ts
+++ b/panels/dock/multitaskview/translations/org.deepin.ds.dock.multitaskview_fi.ts
@@ -4,7 +4,6 @@
 <context>
     <name>dock::MultiTaskView</name>
     <message>
-        <location filename="../multitaskview.cpp" line="65"/>
         <source>Multitasking View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12,7 +11,6 @@
 <context>
     <name>multitaskview</name>
     <message>
-        <location filename="../package/multitaskview.qml" line="23"/>
         <source>Multitasking View</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/multitaskview/translations/org.deepin.ds.dock.multitaskview_fr.ts
+++ b/panels/dock/multitaskview/translations/org.deepin.ds.dock.multitaskview_fr.ts
@@ -4,7 +4,6 @@
 <context>
     <name>dock::MultiTaskView</name>
     <message>
-        <location filename="../multitaskview.cpp" line="65"/>
         <source>Multitasking View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12,7 +11,6 @@
 <context>
     <name>multitaskview</name>
     <message>
-        <location filename="../package/multitaskview.qml" line="23"/>
         <source>Multitasking View</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/multitaskview/translations/org.deepin.ds.dock.multitaskview_hu.ts
+++ b/panels/dock/multitaskview/translations/org.deepin.ds.dock.multitaskview_hu.ts
@@ -4,7 +4,6 @@
 <context>
     <name>dock::MultiTaskView</name>
     <message>
-        <location filename="../multitaskview.cpp" line="65"/>
         <source>Multitasking View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12,7 +11,6 @@
 <context>
     <name>multitaskview</name>
     <message>
-        <location filename="../package/multitaskview.qml" line="23"/>
         <source>Multitasking View</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/multitaskview/translations/org.deepin.ds.dock.multitaskview_it.ts
+++ b/panels/dock/multitaskview/translations/org.deepin.ds.dock.multitaskview_it.ts
@@ -4,7 +4,6 @@
 <context>
     <name>dock::MultiTaskView</name>
     <message>
-        <location filename="../multitaskview.cpp" line="65"/>
         <source>Multitasking View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12,7 +11,6 @@
 <context>
     <name>multitaskview</name>
     <message>
-        <location filename="../package/multitaskview.qml" line="23"/>
         <source>Multitasking View</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/multitaskview/translations/org.deepin.ds.dock.multitaskview_ja.ts
+++ b/panels/dock/multitaskview/translations/org.deepin.ds.dock.multitaskview_ja.ts
@@ -4,7 +4,6 @@
 <context>
     <name>dock::MultiTaskView</name>
     <message>
-        <location filename="../multitaskview.cpp" line="65"/>
         <source>Multitasking View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12,7 +11,6 @@
 <context>
     <name>multitaskview</name>
     <message>
-        <location filename="../package/multitaskview.qml" line="23"/>
         <source>Multitasking View</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/multitaskview/translations/org.deepin.ds.dock.multitaskview_ko.ts
+++ b/panels/dock/multitaskview/translations/org.deepin.ds.dock.multitaskview_ko.ts
@@ -4,7 +4,6 @@
 <context>
     <name>dock::MultiTaskView</name>
     <message>
-        <location filename="../multitaskview.cpp" line="65"/>
         <source>Multitasking View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12,7 +11,6 @@
 <context>
     <name>multitaskview</name>
     <message>
-        <location filename="../package/multitaskview.qml" line="23"/>
         <source>Multitasking View</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/multitaskview/translations/org.deepin.ds.dock.multitaskview_nb_NO.ts
+++ b/panels/dock/multitaskview/translations/org.deepin.ds.dock.multitaskview_nb_NO.ts
@@ -4,7 +4,6 @@
 <context>
     <name>dock::MultiTaskView</name>
     <message>
-        <location filename="../multitaskview.cpp" line="65"/>
         <source>Multitasking View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12,7 +11,6 @@
 <context>
     <name>multitaskview</name>
     <message>
-        <location filename="../package/multitaskview.qml" line="23"/>
         <source>Multitasking View</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/multitaskview/translations/org.deepin.ds.dock.multitaskview_pl.ts
+++ b/panels/dock/multitaskview/translations/org.deepin.ds.dock.multitaskview_pl.ts
@@ -4,7 +4,6 @@
 <context>
     <name>dock::MultiTaskView</name>
     <message>
-        <location filename="../multitaskview.cpp" line="65"/>
         <source>Multitasking View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12,7 +11,6 @@
 <context>
     <name>multitaskview</name>
     <message>
-        <location filename="../package/multitaskview.qml" line="23"/>
         <source>Multitasking View</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/multitaskview/translations/org.deepin.ds.dock.multitaskview_pt_BR.ts
+++ b/panels/dock/multitaskview/translations/org.deepin.ds.dock.multitaskview_pt_BR.ts
@@ -4,7 +4,6 @@
 <context>
     <name>dock::MultiTaskView</name>
     <message>
-        <location filename="../multitaskview.cpp" line="65"/>
         <source>Multitasking View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12,7 +11,6 @@
 <context>
     <name>multitaskview</name>
     <message>
-        <location filename="../package/multitaskview.qml" line="23"/>
         <source>Multitasking View</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/multitaskview/translations/org.deepin.ds.dock.multitaskview_ru.ts
+++ b/panels/dock/multitaskview/translations/org.deepin.ds.dock.multitaskview_ru.ts
@@ -4,7 +4,6 @@
 <context>
     <name>dock::MultiTaskView</name>
     <message>
-        <location filename="../multitaskview.cpp" line="65"/>
         <source>Multitasking View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12,7 +11,6 @@
 <context>
     <name>multitaskview</name>
     <message>
-        <location filename="../package/multitaskview.qml" line="23"/>
         <source>Multitasking View</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/multitaskview/translations/org.deepin.ds.dock.multitaskview_uk.ts
+++ b/panels/dock/multitaskview/translations/org.deepin.ds.dock.multitaskview_uk.ts
@@ -4,7 +4,6 @@
 <context>
     <name>dock::MultiTaskView</name>
     <message>
-        <location filename="../multitaskview.cpp" line="65"/>
         <source>Multitasking View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12,7 +11,6 @@
 <context>
     <name>multitaskview</name>
     <message>
-        <location filename="../package/multitaskview.qml" line="23"/>
         <source>Multitasking View</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/multitaskview/translations/org.deepin.ds.dock.multitaskview_zh_HK.ts
+++ b/panels/dock/multitaskview/translations/org.deepin.ds.dock.multitaskview_zh_HK.ts
@@ -4,7 +4,6 @@
 <context>
     <name>dock::MultiTaskView</name>
     <message>
-        <location filename="../multitaskview.cpp" line="65"/>
         <source>Multitasking View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12,7 +11,6 @@
 <context>
     <name>multitaskview</name>
     <message>
-        <location filename="../package/multitaskview.qml" line="23"/>
         <source>Multitasking View</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/multitaskview/translations/org.deepin.ds.dock.multitaskview_zh_TW.ts
+++ b/panels/dock/multitaskview/translations/org.deepin.ds.dock.multitaskview_zh_TW.ts
@@ -4,7 +4,6 @@
 <context>
     <name>dock::MultiTaskView</name>
     <message>
-        <location filename="../multitaskview.cpp" line="65"/>
         <source>Multitasking View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12,7 +11,6 @@
 <context>
     <name>multitaskview</name>
     <message>
-        <location filename="../package/multitaskview.qml" line="23"/>
         <source>Multitasking View</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/package/main.qml
+++ b/panels/dock/package/main.qml
@@ -166,18 +166,12 @@ Window {
             MutuallyExclusiveMenu {
                 title: qsTr("Mode")
                 EnumPropertyMenuItem {
-                    name: {
-                        if (Panel.position === Dock.Top || Panel.position === Dock.Bottom) {
-                            return qsTr("Align Left")
-                        } else {
-                            return qsTr("Align Top")
-                        }
-                    }
+                    name: qsTr("Classic Mode")
                     prop: "itemAlignment"
                     value: Dock.LeftAlignment
                 }
                 EnumPropertyMenuItem {
-                    name: qsTr("Align Center")
+                    name: qsTr("Centered Mode")
                     prop: "itemAlignment"
                     value: Dock.CenterAlignment
                 }

--- a/panels/dock/showdesktop/translations/org.deepin.ds.dock.showdesktop.ts
+++ b/panels/dock/showdesktop/translations/org.deepin.ds.dock.showdesktop.ts
@@ -4,7 +4,6 @@
 <context>
     <name>showdesktop</name>
     <message>
-        <location filename="../package/showdesktop.qml" line="45"/>
         <source>show desktop</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/showdesktop/translations/org.deepin.ds.dock.showdesktop_az.ts
+++ b/panels/dock/showdesktop/translations/org.deepin.ds.dock.showdesktop_az.ts
@@ -4,7 +4,6 @@
 <context>
     <name>showdesktop</name>
     <message>
-        <location filename="../package/showdesktop.qml" line="45"/>
         <source>show desktop</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/showdesktop/translations/org.deepin.ds.dock.showdesktop_bo.ts
+++ b/panels/dock/showdesktop/translations/org.deepin.ds.dock.showdesktop_bo.ts
@@ -4,7 +4,6 @@
 <context>
     <name>showdesktop</name>
     <message>
-        <location filename="../package/showdesktop.qml" line="45"/>
         <source>show desktop</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/showdesktop/translations/org.deepin.ds.dock.showdesktop_ca.ts
+++ b/panels/dock/showdesktop/translations/org.deepin.ds.dock.showdesktop_ca.ts
@@ -4,7 +4,6 @@
 <context>
     <name>showdesktop</name>
     <message>
-        <location filename="../package/showdesktop.qml" line="45"/>
         <source>show desktop</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/showdesktop/translations/org.deepin.ds.dock.showdesktop_es.ts
+++ b/panels/dock/showdesktop/translations/org.deepin.ds.dock.showdesktop_es.ts
@@ -4,7 +4,6 @@
 <context>
     <name>showdesktop</name>
     <message>
-        <location filename="../package/showdesktop.qml" line="45"/>
         <source>show desktop</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/showdesktop/translations/org.deepin.ds.dock.showdesktop_fi.ts
+++ b/panels/dock/showdesktop/translations/org.deepin.ds.dock.showdesktop_fi.ts
@@ -4,7 +4,6 @@
 <context>
     <name>showdesktop</name>
     <message>
-        <location filename="../package/showdesktop.qml" line="45"/>
         <source>show desktop</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/showdesktop/translations/org.deepin.ds.dock.showdesktop_fr.ts
+++ b/panels/dock/showdesktop/translations/org.deepin.ds.dock.showdesktop_fr.ts
@@ -4,7 +4,6 @@
 <context>
     <name>showdesktop</name>
     <message>
-        <location filename="../package/showdesktop.qml" line="45"/>
         <source>show desktop</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/showdesktop/translations/org.deepin.ds.dock.showdesktop_hu.ts
+++ b/panels/dock/showdesktop/translations/org.deepin.ds.dock.showdesktop_hu.ts
@@ -4,7 +4,6 @@
 <context>
     <name>showdesktop</name>
     <message>
-        <location filename="../package/showdesktop.qml" line="45"/>
         <source>show desktop</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/showdesktop/translations/org.deepin.ds.dock.showdesktop_it.ts
+++ b/panels/dock/showdesktop/translations/org.deepin.ds.dock.showdesktop_it.ts
@@ -4,7 +4,6 @@
 <context>
     <name>showdesktop</name>
     <message>
-        <location filename="../package/showdesktop.qml" line="45"/>
         <source>show desktop</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/showdesktop/translations/org.deepin.ds.dock.showdesktop_ja.ts
+++ b/panels/dock/showdesktop/translations/org.deepin.ds.dock.showdesktop_ja.ts
@@ -4,7 +4,6 @@
 <context>
     <name>showdesktop</name>
     <message>
-        <location filename="../package/showdesktop.qml" line="45"/>
         <source>show desktop</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/showdesktop/translations/org.deepin.ds.dock.showdesktop_ko.ts
+++ b/panels/dock/showdesktop/translations/org.deepin.ds.dock.showdesktop_ko.ts
@@ -4,7 +4,6 @@
 <context>
     <name>showdesktop</name>
     <message>
-        <location filename="../package/showdesktop.qml" line="45"/>
         <source>show desktop</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/showdesktop/translations/org.deepin.ds.dock.showdesktop_nb_NO.ts
+++ b/panels/dock/showdesktop/translations/org.deepin.ds.dock.showdesktop_nb_NO.ts
@@ -4,7 +4,6 @@
 <context>
     <name>showdesktop</name>
     <message>
-        <location filename="../package/showdesktop.qml" line="45"/>
         <source>show desktop</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/showdesktop/translations/org.deepin.ds.dock.showdesktop_pl.ts
+++ b/panels/dock/showdesktop/translations/org.deepin.ds.dock.showdesktop_pl.ts
@@ -4,7 +4,6 @@
 <context>
     <name>showdesktop</name>
     <message>
-        <location filename="../package/showdesktop.qml" line="45"/>
         <source>show desktop</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/showdesktop/translations/org.deepin.ds.dock.showdesktop_pt_BR.ts
+++ b/panels/dock/showdesktop/translations/org.deepin.ds.dock.showdesktop_pt_BR.ts
@@ -4,7 +4,6 @@
 <context>
     <name>showdesktop</name>
     <message>
-        <location filename="../package/showdesktop.qml" line="45"/>
         <source>show desktop</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/showdesktop/translations/org.deepin.ds.dock.showdesktop_ru.ts
+++ b/panels/dock/showdesktop/translations/org.deepin.ds.dock.showdesktop_ru.ts
@@ -4,7 +4,6 @@
 <context>
     <name>showdesktop</name>
     <message>
-        <location filename="../package/showdesktop.qml" line="45"/>
         <source>show desktop</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/showdesktop/translations/org.deepin.ds.dock.showdesktop_uk.ts
+++ b/panels/dock/showdesktop/translations/org.deepin.ds.dock.showdesktop_uk.ts
@@ -4,7 +4,6 @@
 <context>
     <name>showdesktop</name>
     <message>
-        <location filename="../package/showdesktop.qml" line="45"/>
         <source>show desktop</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager.ts
+++ b/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager.ts
@@ -4,32 +4,22 @@
 <context>
     <name>dock::AppItem</name>
     <message>
-        <location filename="../appitem.cpp" line="83"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="99"/>
-        <source>All Windows</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../appitem.cpp" line="105"/>
         <source>Undock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="105"/>
         <source>Dock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="111"/>
         <source>Force Quit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="118"/>
         <source>Close All</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_az.ts
+++ b/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_az.ts
@@ -4,32 +4,22 @@
 <context>
     <name>dock::AppItem</name>
     <message>
-        <location filename="../appitem.cpp" line="83"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="99"/>
-        <source>All Windows</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../appitem.cpp" line="105"/>
         <source>Undock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="105"/>
         <source>Dock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="111"/>
         <source>Force Quit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="118"/>
         <source>Close All</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_bo.ts
+++ b/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_bo.ts
@@ -4,32 +4,22 @@
 <context>
     <name>dock::AppItem</name>
     <message>
-        <location filename="../appitem.cpp" line="83"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="99"/>
-        <source>All Windows</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../appitem.cpp" line="105"/>
         <source>Undock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="105"/>
         <source>Dock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="111"/>
         <source>Force Quit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="118"/>
         <source>Close All</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_ca.ts
+++ b/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_ca.ts
@@ -4,32 +4,22 @@
 <context>
     <name>dock::AppItem</name>
     <message>
-        <location filename="../appitem.cpp" line="83"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="99"/>
-        <source>All Windows</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../appitem.cpp" line="105"/>
         <source>Undock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="105"/>
         <source>Dock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="111"/>
         <source>Force Quit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="118"/>
         <source>Close All</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_es.ts
+++ b/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_es.ts
@@ -4,32 +4,22 @@
 <context>
     <name>dock::AppItem</name>
     <message>
-        <location filename="../appitem.cpp" line="83"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="99"/>
-        <source>All Windows</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../appitem.cpp" line="105"/>
         <source>Undock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="105"/>
         <source>Dock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="111"/>
         <source>Force Quit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="118"/>
         <source>Close All</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_fi.ts
+++ b/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_fi.ts
@@ -4,32 +4,22 @@
 <context>
     <name>dock::AppItem</name>
     <message>
-        <location filename="../appitem.cpp" line="83"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="99"/>
-        <source>All Windows</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../appitem.cpp" line="105"/>
         <source>Undock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="105"/>
         <source>Dock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="111"/>
         <source>Force Quit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="118"/>
         <source>Close All</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_fr.ts
+++ b/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_fr.ts
@@ -4,32 +4,22 @@
 <context>
     <name>dock::AppItem</name>
     <message>
-        <location filename="../appitem.cpp" line="83"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="99"/>
-        <source>All Windows</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../appitem.cpp" line="105"/>
         <source>Undock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="105"/>
         <source>Dock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="111"/>
         <source>Force Quit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="118"/>
         <source>Close All</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_hu.ts
+++ b/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_hu.ts
@@ -4,32 +4,22 @@
 <context>
     <name>dock::AppItem</name>
     <message>
-        <location filename="../appitem.cpp" line="83"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="99"/>
-        <source>All Windows</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../appitem.cpp" line="105"/>
         <source>Undock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="105"/>
         <source>Dock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="111"/>
         <source>Force Quit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="118"/>
         <source>Close All</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_it.ts
+++ b/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_it.ts
@@ -4,32 +4,22 @@
 <context>
     <name>dock::AppItem</name>
     <message>
-        <location filename="../appitem.cpp" line="83"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="99"/>
-        <source>All Windows</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../appitem.cpp" line="105"/>
         <source>Undock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="105"/>
         <source>Dock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="111"/>
         <source>Force Quit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="118"/>
         <source>Close All</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_ja.ts
+++ b/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_ja.ts
@@ -4,32 +4,22 @@
 <context>
     <name>dock::AppItem</name>
     <message>
-        <location filename="../appitem.cpp" line="83"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="99"/>
-        <source>All Windows</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../appitem.cpp" line="105"/>
         <source>Undock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="105"/>
         <source>Dock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="111"/>
         <source>Force Quit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="118"/>
         <source>Close All</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_ko.ts
+++ b/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_ko.ts
@@ -4,32 +4,22 @@
 <context>
     <name>dock::AppItem</name>
     <message>
-        <location filename="../appitem.cpp" line="83"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="99"/>
-        <source>All Windows</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../appitem.cpp" line="105"/>
         <source>Undock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="105"/>
         <source>Dock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="111"/>
         <source>Force Quit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="118"/>
         <source>Close All</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_nb_NO.ts
+++ b/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_nb_NO.ts
@@ -4,32 +4,22 @@
 <context>
     <name>dock::AppItem</name>
     <message>
-        <location filename="../appitem.cpp" line="83"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="99"/>
-        <source>All Windows</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../appitem.cpp" line="105"/>
         <source>Undock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="105"/>
         <source>Dock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="111"/>
         <source>Force Quit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="118"/>
         <source>Close All</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_pl.ts
+++ b/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_pl.ts
@@ -4,32 +4,22 @@
 <context>
     <name>dock::AppItem</name>
     <message>
-        <location filename="../appitem.cpp" line="83"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="99"/>
-        <source>All Windows</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../appitem.cpp" line="105"/>
         <source>Undock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="105"/>
         <source>Dock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="111"/>
         <source>Force Quit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="118"/>
         <source>Close All</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_pt_BR.ts
+++ b/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_pt_BR.ts
@@ -4,32 +4,22 @@
 <context>
     <name>dock::AppItem</name>
     <message>
-        <location filename="../appitem.cpp" line="83"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="99"/>
-        <source>All Windows</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../appitem.cpp" line="105"/>
         <source>Undock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="105"/>
         <source>Dock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="111"/>
         <source>Force Quit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="118"/>
         <source>Close All</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_ru.ts
+++ b/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_ru.ts
@@ -4,32 +4,22 @@
 <context>
     <name>dock::AppItem</name>
     <message>
-        <location filename="../appitem.cpp" line="83"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="99"/>
-        <source>All Windows</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../appitem.cpp" line="105"/>
         <source>Undock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="105"/>
         <source>Dock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="111"/>
         <source>Force Quit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="118"/>
         <source>Close All</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_uk.ts
+++ b/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_uk.ts
@@ -4,32 +4,22 @@
 <context>
     <name>dock::AppItem</name>
     <message>
-        <location filename="../appitem.cpp" line="83"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="99"/>
-        <source>All Windows</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../appitem.cpp" line="105"/>
         <source>Undock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="105"/>
         <source>Dock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="111"/>
         <source>Force Quit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="118"/>
         <source>Close All</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_zh_CN.ts
+++ b/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_zh_CN.ts
@@ -4,32 +4,22 @@
 <context>
     <name>dock::AppItem</name>
     <message>
-        <location filename="../appitem.cpp" line="83"/>
         <source>Open</source>
         <translation>打开</translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="99"/>
-        <source>All Windows</source>
-        <translation>所有窗口</translation>
-    </message>
-    <message>
-        <location filename="../appitem.cpp" line="105"/>
         <source>Undock</source>
         <translation>移除驻留</translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="105"/>
         <source>Dock</source>
         <translation>驻留</translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="111"/>
         <source>Force Quit</source>
         <translation>强制退出</translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="118"/>
         <source>Close All</source>
         <translation>关闭所有</translation>
     </message>

--- a/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_zh_HK.ts
+++ b/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_zh_HK.ts
@@ -4,32 +4,22 @@
 <context>
     <name>dock::AppItem</name>
     <message>
-        <location filename="../appitem.cpp" line="83"/>
         <source>Open</source>
         <translation>打開</translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="99"/>
-        <source>All Windows</source>
-        <translation>所有窗口</translation>
-    </message>
-    <message>
-        <location filename="../appitem.cpp" line="105"/>
         <source>Undock</source>
         <translation>移除駐留</translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="105"/>
         <source>Dock</source>
         <translation>駐留</translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="111"/>
         <source>Force Quit</source>
         <translation>強制退出</translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="118"/>
         <source>Close All</source>
         <translation>關閉所有</translation>
     </message>

--- a/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_zh_TW.ts
+++ b/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_zh_TW.ts
@@ -4,32 +4,22 @@
 <context>
     <name>dock::AppItem</name>
     <message>
-        <location filename="../appitem.cpp" line="83"/>
         <source>Open</source>
         <translation>打開</translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="99"/>
-        <source>All Windows</source>
-        <translation>所有窗口</translation>
-    </message>
-    <message>
-        <location filename="../appitem.cpp" line="105"/>
         <source>Undock</source>
         <translation>移除駐留</translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="105"/>
         <source>Dock</source>
         <translation>駐留</translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="111"/>
         <source>Force Quit</source>
         <translation>強制退出</translation>
     </message>
     <message>
-        <location filename="../appitem.cpp" line="118"/>
         <source>Close All</source>
         <translation>關閉所有</translation>
     </message>

--- a/panels/dock/translations/org.deepin.ds.dock.ts
+++ b/panels/dock/translations/org.deepin.ds.dock.ts
@@ -4,87 +4,66 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="159"/>
         <source>Indicator Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="161"/>
         <source>Fashion Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="166"/>
         <source>Efficient Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="203"/>
+        <source>Classic Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Centered Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="191"/>
         <source>Position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="172"/>
         <source>Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="176"/>
-        <source>Align Left</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../package/main.qml" line="178"/>
-        <source>Align Top</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../package/main.qml" line="185"/>
-        <source>Align Center</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../package/main.qml" line="193"/>
         <source>Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="198"/>
         <source>Bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="208"/>
         <source>Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="214"/>
         <source>Status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="216"/>
         <source>Keep Shown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="221"/>
         <source>Keep Hidden</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="226"/>
         <source>Smart Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="233"/>
         <source>Dock Settings</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/translations/org.deepin.ds.dock_az.ts
+++ b/panels/dock/translations/org.deepin.ds.dock_az.ts
@@ -1,88 +1,69 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="az">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="az">
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="159"/>
         <source>Indicator Style</source>
         <translation>نوع المؤشر</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="161"/>
         <source>Fashion Mode</source>
         <translation>الMode الموضوي</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="166"/>
         <source>Efficient Mode</source>
         <translation>الMode الفعال</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="203"/>
+        <source>Classic Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Centered Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Left</source>
         <translation>يسار</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="191"/>
         <source>Position</source>
         <translation>الposição</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="172"/>
         <source>Mode</source>
         <translation>الMode</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="176"/>
-        <source>Align Left</source>
-        <translation>محاذاة اليسار</translation>
-    </message>
-    <message>
-        <location filename="../package/main.qml" line="178"/>
-        <source>Align Top</source>
-        <translation>محاذاة الأعلى</translation>
-    </message>
-    <message>
-        <location filename="../package/main.qml" line="185"/>
-        <source>Align Center</source>
-        <translation>محاذاة المنتصف</translation>
-    </message>
-    <message>
-        <location filename="../package/main.qml" line="193"/>
         <source>Top</source>
         <translation>أعلى</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="198"/>
         <source>Bottom</source>
         <translation>أسفل</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="208"/>
         <source>Right</source>
         <translation>يمين</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="214"/>
         <source>Status</source>
         <translation>الحالة</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="216"/>
         <source>Keep Shown</source>
         <translation>احفظ العرض</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="221"/>
         <source>Keep Hidden</source>
         <translation>احفظ الخفاء</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="226"/>
         <source>Smart Hide</source>
         <translation>إخفاء ذكي</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="233"/>
         <source>Dock Settings</source>
         <translation>إعدادات الرف</translation>
     </message>

--- a/panels/dock/translations/org.deepin.ds.dock_bo.ts
+++ b/panels/dock/translations/org.deepin.ds.dock_bo.ts
@@ -4,87 +4,66 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="159"/>
         <source>Indicator Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="161"/>
         <source>Fashion Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="166"/>
         <source>Efficient Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="203"/>
+        <source>Classic Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Centered Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="191"/>
         <source>Position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="172"/>
         <source>Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="176"/>
-        <source>Align Left</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../package/main.qml" line="178"/>
-        <source>Align Top</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../package/main.qml" line="185"/>
-        <source>Align Center</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../package/main.qml" line="193"/>
         <source>Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="198"/>
         <source>Bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="208"/>
         <source>Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="214"/>
         <source>Status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="216"/>
         <source>Keep Shown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="221"/>
         <source>Keep Hidden</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="226"/>
         <source>Smart Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="233"/>
         <source>Dock Settings</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/translations/org.deepin.ds.dock_ca.ts
+++ b/panels/dock/translations/org.deepin.ds.dock_ca.ts
@@ -1,88 +1,69 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ca">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ca">
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="159"/>
         <source>Indicator Style</source>
         <translation>Estil de l&apos;indicador</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="161"/>
         <source>Fashion Mode</source>
         <translation>Mode de moda</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="166"/>
         <source>Efficient Mode</source>
         <translation>Mode eficient</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="203"/>
+        <source>Classic Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Centered Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Left</source>
         <translation>A l&apos;esquerra</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="191"/>
         <source>Position</source>
         <translation>Posició</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="172"/>
         <source>Mode</source>
         <translation>Mode</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="176"/>
-        <source>Align Left</source>
-        <translation>Alinea a l&apos;esquerra</translation>
-    </message>
-    <message>
-        <location filename="../package/main.qml" line="178"/>
-        <source>Align Top</source>
-        <translation>Alinea a dalt</translation>
-    </message>
-    <message>
-        <location filename="../package/main.qml" line="185"/>
-        <source>Align Center</source>
-        <translation>Alinea el centre</translation>
-    </message>
-    <message>
-        <location filename="../package/main.qml" line="193"/>
         <source>Top</source>
         <translation>A dalt</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="198"/>
         <source>Bottom</source>
         <translation>A baix</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="208"/>
         <source>Right</source>
         <translation>A la dreta</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="214"/>
         <source>Status</source>
         <translation>Estat</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="216"/>
         <source>Keep Shown</source>
         <translation>Mantén-ho visible</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="221"/>
         <source>Keep Hidden</source>
         <translation>Mantén-ho amagat</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="226"/>
         <source>Smart Hide</source>
         <translation>Ocultació intel·ligent</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="233"/>
         <source>Dock Settings</source>
         <translation>Paràmetres de l&apos;acoblador</translation>
     </message>

--- a/panels/dock/translations/org.deepin.ds.dock_es.ts
+++ b/panels/dock/translations/org.deepin.ds.dock_es.ts
@@ -1,88 +1,69 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="es">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="es">
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="159"/>
         <source>Indicator Style</source>
         <translation>Estilo de indicador</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="161"/>
         <source>Fashion Mode</source>
         <translation>Modo elegante</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="166"/>
         <source>Efficient Mode</source>
         <translation>Modo eficiente</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="203"/>
+        <source>Classic Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Centered Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Left</source>
         <translation>Izquierda</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="191"/>
         <source>Position</source>
         <translation>Posición</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="172"/>
         <source>Mode</source>
         <translation>Modo</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="176"/>
-        <source>Align Left</source>
-        <translation>Alinear a la izquierda</translation>
-    </message>
-    <message>
-        <location filename="../package/main.qml" line="178"/>
-        <source>Align Top</source>
-        <translation>Alinear hacia arriba</translation>
-    </message>
-    <message>
-        <location filename="../package/main.qml" line="185"/>
-        <source>Align Center</source>
-        <translation>Alinear al centro</translation>
-    </message>
-    <message>
-        <location filename="../package/main.qml" line="193"/>
         <source>Top</source>
         <translation>parte superior</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="198"/>
         <source>Bottom</source>
         <translation>parte inferior</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="208"/>
         <source>Right</source>
         <translation>Derecha</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="214"/>
         <source>Status</source>
         <translation>Estado</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="216"/>
         <source>Keep Shown</source>
         <translation>Mantener visible</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="221"/>
         <source>Keep Hidden</source>
         <translation>Mantener oculto</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="226"/>
         <source>Smart Hide</source>
         <translation>Ocultado inteligente</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="233"/>
         <source>Dock Settings</source>
         <translation>Ajustes del muelle</translation>
     </message>

--- a/panels/dock/translations/org.deepin.ds.dock_fi.ts
+++ b/panels/dock/translations/org.deepin.ds.dock_fi.ts
@@ -1,88 +1,69 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="fi">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fi">
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="159"/>
         <source>Indicator Style</source>
         <translation>Ilmaisimen tyyli</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="161"/>
         <source>Fashion Mode</source>
         <translation>Keskitetty</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="166"/>
         <source>Efficient Mode</source>
         <translation>Alavalikko</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="203"/>
+        <source>Classic Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Centered Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Left</source>
         <translation>Vasen</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="191"/>
         <source>Position</source>
         <translation>Asema</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="172"/>
         <source>Mode</source>
         <translation>Tila</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="176"/>
-        <source>Align Left</source>
-        <translation>Vasemmalle</translation>
-    </message>
-    <message>
-        <location filename="../package/main.qml" line="178"/>
-        <source>Align Top</source>
-        <translation>Tasaa ylös</translation>
-    </message>
-    <message>
-        <location filename="../package/main.qml" line="185"/>
-        <source>Align Center</source>
-        <translation>Tasaa keskelle</translation>
-    </message>
-    <message>
-        <location filename="../package/main.qml" line="193"/>
         <source>Top</source>
         <translation>Ylös</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="198"/>
         <source>Bottom</source>
         <translation>Alas</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="208"/>
         <source>Right</source>
         <translation>Oikea</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="214"/>
         <source>Status</source>
         <translation>Tila</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="216"/>
         <source>Keep Shown</source>
         <translation>Näytä aina</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="221"/>
         <source>Keep Hidden</source>
         <translation>Piilotta paneeli</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="226"/>
         <source>Smart Hide</source>
         <translation>Älykäs piilotus</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="233"/>
         <source>Dock Settings</source>
         <translation>Paneeli asetukset</translation>
     </message>

--- a/panels/dock/translations/org.deepin.ds.dock_fr.ts
+++ b/panels/dock/translations/org.deepin.ds.dock_fr.ts
@@ -1,88 +1,69 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="fr">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fr">
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="159"/>
         <source>Indicator Style</source>
         <translation>Style d&apos;indicateur</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="161"/>
         <source>Fashion Mode</source>
         <translation>Mode fashion</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="166"/>
         <source>Efficient Mode</source>
         <translation>Mode productif</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="203"/>
+        <source>Classic Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Centered Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Left</source>
         <translation>Gauche</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="191"/>
         <source>Position</source>
         <translation>Position</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="172"/>
         <source>Mode</source>
         <translation>Mode</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="176"/>
-        <source>Align Left</source>
-        <translation>Aligner à gauche</translation>
-    </message>
-    <message>
-        <location filename="../package/main.qml" line="178"/>
-        <source>Align Top</source>
-        <translation>Aligner en haut</translation>
-    </message>
-    <message>
-        <location filename="../package/main.qml" line="185"/>
-        <source>Align Center</source>
-        <translation>Aligner au centre</translation>
-    </message>
-    <message>
-        <location filename="../package/main.qml" line="193"/>
         <source>Top</source>
         <translation>Haut</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="198"/>
         <source>Bottom</source>
         <translation>Bas</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="208"/>
         <source>Right</source>
         <translation>Droite</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="214"/>
         <source>Status</source>
         <translation>Statut</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="216"/>
         <source>Keep Shown</source>
         <translation>Toujours affiché</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="221"/>
         <source>Keep Hidden</source>
         <translation>Toujours caché</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="226"/>
         <source>Smart Hide</source>
         <translation>Masquage intelligemment</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="233"/>
         <source>Dock Settings</source>
         <translation>Réglages du dock</translation>
     </message>

--- a/panels/dock/translations/org.deepin.ds.dock_hu.ts
+++ b/panels/dock/translations/org.deepin.ds.dock_hu.ts
@@ -1,88 +1,69 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="hu">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="hu">
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="159"/>
         <source>Indicator Style</source>
         <translation>Jelölő stíéusa</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="161"/>
         <source>Fashion Mode</source>
         <translation>Stílusos mód</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="166"/>
         <source>Efficient Mode</source>
         <translation>Hatékony mód</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="203"/>
+        <source>Classic Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Centered Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Left</source>
         <translation>Bal</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="191"/>
         <source>Position</source>
         <translation>Pozíció</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="172"/>
         <source>Mode</source>
         <translation>Mód</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="176"/>
-        <source>Align Left</source>
-        <translation>Igazítás Balra</translation>
-    </message>
-    <message>
-        <location filename="../package/main.qml" line="178"/>
-        <source>Align Top</source>
-        <translation>Igazítás Fentre</translation>
-    </message>
-    <message>
-        <location filename="../package/main.qml" line="185"/>
-        <source>Align Center</source>
-        <translation>Igazítás Középre</translation>
-    </message>
-    <message>
-        <location filename="../package/main.qml" line="193"/>
         <source>Top</source>
         <translation>Fent</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="198"/>
         <source>Bottom</source>
         <translation>Lent</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="208"/>
         <source>Right</source>
         <translation>Jobb</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="214"/>
         <source>Status</source>
         <translation>Állapot</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="216"/>
         <source>Keep Shown</source>
         <translation>Folyamatosan látható</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="221"/>
         <source>Keep Hidden</source>
         <translation>Maradjon rejtve</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="226"/>
         <source>Smart Hide</source>
         <translation>Intelligens elrejtés</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="233"/>
         <source>Dock Settings</source>
         <translation>Dokkoló beállításai</translation>
     </message>

--- a/panels/dock/translations/org.deepin.ds.dock_it.ts
+++ b/panels/dock/translations/org.deepin.ds.dock_it.ts
@@ -4,87 +4,66 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="159"/>
         <source>Indicator Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="161"/>
         <source>Fashion Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="166"/>
         <source>Efficient Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="203"/>
+        <source>Classic Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Centered Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="191"/>
         <source>Position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="172"/>
         <source>Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="176"/>
-        <source>Align Left</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../package/main.qml" line="178"/>
-        <source>Align Top</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../package/main.qml" line="185"/>
-        <source>Align Center</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../package/main.qml" line="193"/>
         <source>Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="198"/>
         <source>Bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="208"/>
         <source>Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="214"/>
         <source>Status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="216"/>
         <source>Keep Shown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="221"/>
         <source>Keep Hidden</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="226"/>
         <source>Smart Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="233"/>
         <source>Dock Settings</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/translations/org.deepin.ds.dock_ja.ts
+++ b/panels/dock/translations/org.deepin.ds.dock_ja.ts
@@ -4,87 +4,66 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="159"/>
         <source>Indicator Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="161"/>
         <source>Fashion Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="166"/>
         <source>Efficient Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="203"/>
+        <source>Classic Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Centered Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="191"/>
         <source>Position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="172"/>
         <source>Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="176"/>
-        <source>Align Left</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../package/main.qml" line="178"/>
-        <source>Align Top</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../package/main.qml" line="185"/>
-        <source>Align Center</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../package/main.qml" line="193"/>
         <source>Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="198"/>
         <source>Bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="208"/>
         <source>Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="214"/>
         <source>Status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="216"/>
         <source>Keep Shown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="221"/>
         <source>Keep Hidden</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="226"/>
         <source>Smart Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="233"/>
         <source>Dock Settings</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/translations/org.deepin.ds.dock_ko.ts
+++ b/panels/dock/translations/org.deepin.ds.dock_ko.ts
@@ -4,87 +4,66 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="159"/>
         <source>Indicator Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="161"/>
         <source>Fashion Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="166"/>
         <source>Efficient Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="203"/>
+        <source>Classic Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Centered Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="191"/>
         <source>Position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="172"/>
         <source>Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="176"/>
-        <source>Align Left</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../package/main.qml" line="178"/>
-        <source>Align Top</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../package/main.qml" line="185"/>
-        <source>Align Center</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../package/main.qml" line="193"/>
         <source>Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="198"/>
         <source>Bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="208"/>
         <source>Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="214"/>
         <source>Status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="216"/>
         <source>Keep Shown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="221"/>
         <source>Keep Hidden</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="226"/>
         <source>Smart Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="233"/>
         <source>Dock Settings</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/translations/org.deepin.ds.dock_nb_NO.ts
+++ b/panels/dock/translations/org.deepin.ds.dock_nb_NO.ts
@@ -4,87 +4,66 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="159"/>
         <source>Indicator Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="161"/>
         <source>Fashion Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="166"/>
         <source>Efficient Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="203"/>
+        <source>Classic Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Centered Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="191"/>
         <source>Position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="172"/>
         <source>Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="176"/>
-        <source>Align Left</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../package/main.qml" line="178"/>
-        <source>Align Top</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../package/main.qml" line="185"/>
-        <source>Align Center</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../package/main.qml" line="193"/>
         <source>Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="198"/>
         <source>Bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="208"/>
         <source>Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="214"/>
         <source>Status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="216"/>
         <source>Keep Shown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="221"/>
         <source>Keep Hidden</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="226"/>
         <source>Smart Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="233"/>
         <source>Dock Settings</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/translations/org.deepin.ds.dock_pl.ts
+++ b/panels/dock/translations/org.deepin.ds.dock_pl.ts
@@ -1,88 +1,69 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pl">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pl">
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="159"/>
         <source>Indicator Style</source>
         <translation>Styl wskaźnika</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="161"/>
         <source>Fashion Mode</source>
         <translation>Tryb modny</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="166"/>
         <source>Efficient Mode</source>
         <translation>Tryb wydajny</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="203"/>
+        <source>Classic Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Centered Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Left</source>
         <translation>Lewo</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="191"/>
         <source>Position</source>
         <translation>Pozycja</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="172"/>
         <source>Mode</source>
         <translation>Tryb</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="176"/>
-        <source>Align Left</source>
-        <translation>Wyrównaj do lewej</translation>
-    </message>
-    <message>
-        <location filename="../package/main.qml" line="178"/>
-        <source>Align Top</source>
-        <translation>Wyrównaj do góry</translation>
-    </message>
-    <message>
-        <location filename="../package/main.qml" line="185"/>
-        <source>Align Center</source>
-        <translation>Wyrównaj do środka</translation>
-    </message>
-    <message>
-        <location filename="../package/main.qml" line="193"/>
         <source>Top</source>
         <translation>Góra</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="198"/>
         <source>Bottom</source>
         <translation>Dół</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="208"/>
         <source>Right</source>
         <translation>Prawo</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="214"/>
         <source>Status</source>
         <translation>Status</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="216"/>
         <source>Keep Shown</source>
         <translation>Zawsze wyświetlaj</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="221"/>
         <source>Keep Hidden</source>
         <translation>Zawsze ukrywaj</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="226"/>
         <source>Smart Hide</source>
         <translation>Inteligentne ukrywanie</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="233"/>
         <source>Dock Settings</source>
         <translation>Ustawienia doku</translation>
     </message>

--- a/panels/dock/translations/org.deepin.ds.dock_pt_BR.ts
+++ b/panels/dock/translations/org.deepin.ds.dock_pt_BR.ts
@@ -1,88 +1,69 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pt_BR">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pt_BR">
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="159"/>
         <source>Indicator Style</source>
         <translation>Estilo do indicador</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="161"/>
         <source>Fashion Mode</source>
         <translation>Fashion</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="166"/>
         <source>Efficient Mode</source>
         <translation>Eficiente</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="203"/>
+        <source>Classic Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Centered Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Left</source>
         <translation>Esquerda</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="191"/>
         <source>Position</source>
         <translation>Posição</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="172"/>
         <source>Mode</source>
         <translation>Modo</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="176"/>
-        <source>Align Left</source>
-        <translation>Esquerda</translation>
-    </message>
-    <message>
-        <location filename="../package/main.qml" line="178"/>
-        <source>Align Top</source>
-        <translation>Superior</translation>
-    </message>
-    <message>
-        <location filename="../package/main.qml" line="185"/>
-        <source>Align Center</source>
-        <translation>Centralizado</translation>
-    </message>
-    <message>
-        <location filename="../package/main.qml" line="193"/>
         <source>Top</source>
         <translation>Superior</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="198"/>
         <source>Bottom</source>
         <translation>Inferior</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="208"/>
         <source>Right</source>
         <translation>Direita</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="214"/>
         <source>Status</source>
         <translation>Exibição</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="216"/>
         <source>Keep Shown</source>
         <translation>Sempre exibir</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="221"/>
         <source>Keep Hidden</source>
         <translation>Sempre ocultar</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="226"/>
         <source>Smart Hide</source>
         <translation>Ocultar automaticamente</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="233"/>
         <source>Dock Settings</source>
         <translation>Configurações do dock</translation>
     </message>

--- a/panels/dock/translations/org.deepin.ds.dock_ru.ts
+++ b/panels/dock/translations/org.deepin.ds.dock_ru.ts
@@ -1,88 +1,69 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ru">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ru">
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="159"/>
         <source>Indicator Style</source>
         <translation>Стиль индикатора</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="161"/>
         <source>Fashion Mode</source>
         <translation>Современный Режим</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="166"/>
         <source>Efficient Mode</source>
         <translation>Эффективный Режим</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="203"/>
+        <source>Classic Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Centered Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Left</source>
         <translation>Слева</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="191"/>
         <source>Position</source>
         <translation>Положение</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="172"/>
         <source>Mode</source>
         <translation>Режим</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="176"/>
-        <source>Align Left</source>
-        <translation>Выровнять по левому краю</translation>
-    </message>
-    <message>
-        <location filename="../package/main.qml" line="178"/>
-        <source>Align Top</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../package/main.qml" line="185"/>
-        <source>Align Center</source>
-        <translation>Выровнять по центру</translation>
-    </message>
-    <message>
-        <location filename="../package/main.qml" line="193"/>
         <source>Top</source>
         <translation>Сверху</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="198"/>
         <source>Bottom</source>
         <translation>Снизу</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="208"/>
         <source>Right</source>
         <translation>Справа</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="214"/>
         <source>Status</source>
         <translation>Состояние</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="216"/>
         <source>Keep Shown</source>
         <translation>Отображать Всегда</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="221"/>
         <source>Keep Hidden</source>
         <translation>Держать Скрытым</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="226"/>
         <source>Smart Hide</source>
         <translation>Умное Скрытие</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="233"/>
         <source>Dock Settings</source>
         <translation>Настройки Dock</translation>
     </message>

--- a/panels/dock/translations/org.deepin.ds.dock_uk.ts
+++ b/panels/dock/translations/org.deepin.ds.dock_uk.ts
@@ -1,88 +1,69 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="uk">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="uk">
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="159"/>
         <source>Indicator Style</source>
         <translation>Стиль індикатора</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="161"/>
         <source>Fashion Mode</source>
         <translation>Модний режим</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="166"/>
         <source>Efficient Mode</source>
         <translation>Практичний режим</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="203"/>
+        <source>Classic Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Centered Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Left</source>
         <translation>Ліворуч</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="191"/>
         <source>Position</source>
         <translation>Розташування</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="172"/>
         <source>Mode</source>
         <translation>Режим</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="176"/>
-        <source>Align Left</source>
-        <translation>Вирівняти ліворуч</translation>
-    </message>
-    <message>
-        <location filename="../package/main.qml" line="178"/>
-        <source>Align Top</source>
-        <translation>Вирівняти вгору</translation>
-    </message>
-    <message>
-        <location filename="../package/main.qml" line="185"/>
-        <source>Align Center</source>
-        <translation>Вирівняти за центром</translation>
-    </message>
-    <message>
-        <location filename="../package/main.qml" line="193"/>
         <source>Top</source>
         <translation>Вгорі</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="198"/>
         <source>Bottom</source>
         <translation>Внизу</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="208"/>
         <source>Right</source>
         <translation>Праворуч</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="214"/>
         <source>Status</source>
         <translation>Стан</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="216"/>
         <source>Keep Shown</source>
         <translation>Показувати постійно</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="221"/>
         <source>Keep Hidden</source>
         <translation>Приховувати</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="226"/>
         <source>Smart Hide</source>
         <translation>Розумне приховування</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="233"/>
         <source>Dock Settings</source>
         <translation>Параметри бічної панелі</translation>
     </message>

--- a/panels/dock/translations/org.deepin.ds.dock_zh_CN.ts
+++ b/panels/dock/translations/org.deepin.ds.dock_zh_CN.ts
@@ -1,88 +1,69 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_CN">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_CN">
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="159"/>
         <source>Indicator Style</source>
         <translation>指示器样式</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="161"/>
         <source>Fashion Mode</source>
         <translation>时尚模式</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="166"/>
         <source>Efficient Mode</source>
         <translation>高效模式</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="203"/>
+        <source>Classic Mode</source>
+        <translation>经典模式</translation>
+    </message>
+    <message>
+        <source>Centered Mode</source>
+        <translation>居中模式</translation>
+    </message>
+    <message>
         <source>Left</source>
         <translation>左</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="191"/>
         <source>Position</source>
         <translation>位置</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="172"/>
         <source>Mode</source>
         <translation>模式</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="176"/>
-        <source>Align Left</source>
-        <translation>经典</translation>
-    </message>
-    <message>
-        <location filename="../package/main.qml" line="178"/>
-        <source>Align Top</source>
-        <translation>经典</translation>
-    </message>
-    <message>
-        <location filename="../package/main.qml" line="185"/>
-        <source>Align Center</source>
-        <translation>居中</translation>
-    </message>
-    <message>
-        <location filename="../package/main.qml" line="193"/>
         <source>Top</source>
         <translation>上</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="198"/>
         <source>Bottom</source>
         <translation>下</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="208"/>
         <source>Right</source>
         <translation>右</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="214"/>
         <source>Status</source>
         <translation>状态</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="216"/>
         <source>Keep Shown</source>
         <translation>一直显示</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="221"/>
         <source>Keep Hidden</source>
         <translation>一直隐藏</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="226"/>
         <source>Smart Hide</source>
         <translation>智能隐藏</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="233"/>
         <source>Dock Settings</source>
         <translation>任务栏设置</translation>
     </message>

--- a/panels/dock/translations/org.deepin.ds.dock_zh_HK.ts
+++ b/panels/dock/translations/org.deepin.ds.dock_zh_HK.ts
@@ -1,88 +1,69 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_HK">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_HK">
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="159"/>
         <source>Indicator Style</source>
         <translation>指示器樣式</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="161"/>
         <source>Fashion Mode</source>
         <translation>時尚模式</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="166"/>
         <source>Efficient Mode</source>
         <translation>高效模式</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="203"/>
+        <source>Classic Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Centered Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Left</source>
         <translation>左</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="191"/>
         <source>Position</source>
         <translation>位置</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="172"/>
         <source>Mode</source>
         <translation>模式</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="176"/>
-        <source>Align Left</source>
-        <translation>經典</translation>
-    </message>
-    <message>
-        <location filename="../package/main.qml" line="178"/>
-        <source>Align Top</source>
-        <translation>經典</translation>
-    </message>
-    <message>
-        <location filename="../package/main.qml" line="185"/>
-        <source>Align Center</source>
-        <translation>居中</translation>
-    </message>
-    <message>
-        <location filename="../package/main.qml" line="193"/>
         <source>Top</source>
         <translation>上</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="198"/>
         <source>Bottom</source>
         <translation>下</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="208"/>
         <source>Right</source>
         <translation>右</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="214"/>
         <source>Status</source>
         <translation>狀態</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="216"/>
         <source>Keep Shown</source>
         <translation>壹直顯示</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="221"/>
         <source>Keep Hidden</source>
         <translation>壹直隱藏</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="226"/>
         <source>Smart Hide</source>
         <translation>智能隱藏</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="233"/>
         <source>Dock Settings</source>
         <translation>任務欄設置</translation>
     </message>

--- a/panels/dock/translations/org.deepin.ds.dock_zh_TW.ts
+++ b/panels/dock/translations/org.deepin.ds.dock_zh_TW.ts
@@ -1,88 +1,69 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_TW">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_TW">
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="159"/>
         <source>Indicator Style</source>
         <translation>指示器樣式</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="161"/>
         <source>Fashion Mode</source>
         <translation>時尚模式</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="166"/>
         <source>Efficient Mode</source>
         <translation>高效模式</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="203"/>
+        <source>Classic Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Centered Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Left</source>
         <translation>左</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="191"/>
         <source>Position</source>
         <translation>位置</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="172"/>
         <source>Mode</source>
         <translation>模式</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="176"/>
-        <source>Align Left</source>
-        <translation>經典</translation>
-    </message>
-    <message>
-        <location filename="../package/main.qml" line="178"/>
-        <source>Align Top</source>
-        <translation>經典</translation>
-    </message>
-    <message>
-        <location filename="../package/main.qml" line="185"/>
-        <source>Align Center</source>
-        <translation>居中</translation>
-    </message>
-    <message>
-        <location filename="../package/main.qml" line="193"/>
         <source>Top</source>
         <translation>上</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="198"/>
         <source>Bottom</source>
         <translation>下</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="208"/>
         <source>Right</source>
         <translation>右</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="214"/>
         <source>Status</source>
         <translation>狀態</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="216"/>
         <source>Keep Shown</source>
         <translation>壹直顯示</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="221"/>
         <source>Keep Hidden</source>
         <translation>壹直隱藏</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="226"/>
         <source>Smart Hide</source>
         <translation>智能隱藏</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="233"/>
         <source>Dock Settings</source>
         <translation>任務欄設置</translation>
     </message>

--- a/panels/dock/tray/translations/org.deepin.ds.dock.tray.ts
+++ b/panels/dock/tray/translations/org.deepin.ds.dock.tray.ts
@@ -4,7 +4,6 @@
 <context>
     <name>ActionShowStashDelegate</name>
     <message>
-        <location filename="../package/ActionShowStashDelegate.qml" line="95"/>
         <source>Application tray</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12,7 +11,6 @@
 <context>
     <name>ActionToggleCollapseDelegate</name>
     <message>
-        <location filename="../package/ActionToggleCollapseDelegate.qml" line="30"/>
         <source>Collapse tray</source>
         <translation type="unfinished"></translation>
     </message>
@@ -20,7 +18,6 @@
 <context>
     <name>PanelTrayItem</name>
     <message>
-        <location filename="../quickpanel/PanelTrayItem.qml" line="30"/>
         <source>Quick actions</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/tray/translations/org.deepin.ds.dock.tray_az.ts
+++ b/panels/dock/tray/translations/org.deepin.ds.dock.tray_az.ts
@@ -4,7 +4,6 @@
 <context>
     <name>ActionShowStashDelegate</name>
     <message>
-        <location filename="../package/ActionShowStashDelegate.qml" line="95"/>
         <source>Application tray</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12,7 +11,6 @@
 <context>
     <name>ActionToggleCollapseDelegate</name>
     <message>
-        <location filename="../package/ActionToggleCollapseDelegate.qml" line="30"/>
         <source>Collapse tray</source>
         <translation type="unfinished"></translation>
     </message>
@@ -20,7 +18,6 @@
 <context>
     <name>PanelTrayItem</name>
     <message>
-        <location filename="../quickpanel/PanelTrayItem.qml" line="30"/>
         <source>Quick actions</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/tray/translations/org.deepin.ds.dock.tray_bo.ts
+++ b/panels/dock/tray/translations/org.deepin.ds.dock.tray_bo.ts
@@ -4,7 +4,6 @@
 <context>
     <name>ActionShowStashDelegate</name>
     <message>
-        <location filename="../package/ActionShowStashDelegate.qml" line="95"/>
         <source>Application tray</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12,7 +11,6 @@
 <context>
     <name>ActionToggleCollapseDelegate</name>
     <message>
-        <location filename="../package/ActionToggleCollapseDelegate.qml" line="30"/>
         <source>Collapse tray</source>
         <translation type="unfinished"></translation>
     </message>
@@ -20,7 +18,6 @@
 <context>
     <name>PanelTrayItem</name>
     <message>
-        <location filename="../quickpanel/PanelTrayItem.qml" line="30"/>
         <source>Quick actions</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/tray/translations/org.deepin.ds.dock.tray_ca.ts
+++ b/panels/dock/tray/translations/org.deepin.ds.dock.tray_ca.ts
@@ -4,7 +4,6 @@
 <context>
     <name>ActionShowStashDelegate</name>
     <message>
-        <location filename="../package/ActionShowStashDelegate.qml" line="95"/>
         <source>Application tray</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12,7 +11,6 @@
 <context>
     <name>ActionToggleCollapseDelegate</name>
     <message>
-        <location filename="../package/ActionToggleCollapseDelegate.qml" line="30"/>
         <source>Collapse tray</source>
         <translation type="unfinished"></translation>
     </message>
@@ -20,7 +18,6 @@
 <context>
     <name>PanelTrayItem</name>
     <message>
-        <location filename="../quickpanel/PanelTrayItem.qml" line="30"/>
         <source>Quick actions</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/tray/translations/org.deepin.ds.dock.tray_es.ts
+++ b/panels/dock/tray/translations/org.deepin.ds.dock.tray_es.ts
@@ -4,7 +4,6 @@
 <context>
     <name>ActionShowStashDelegate</name>
     <message>
-        <location filename="../package/ActionShowStashDelegate.qml" line="95"/>
         <source>Application tray</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12,7 +11,6 @@
 <context>
     <name>ActionToggleCollapseDelegate</name>
     <message>
-        <location filename="../package/ActionToggleCollapseDelegate.qml" line="30"/>
         <source>Collapse tray</source>
         <translation type="unfinished"></translation>
     </message>
@@ -20,7 +18,6 @@
 <context>
     <name>PanelTrayItem</name>
     <message>
-        <location filename="../quickpanel/PanelTrayItem.qml" line="30"/>
         <source>Quick actions</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/tray/translations/org.deepin.ds.dock.tray_fi.ts
+++ b/panels/dock/tray/translations/org.deepin.ds.dock.tray_fi.ts
@@ -4,7 +4,6 @@
 <context>
     <name>ActionShowStashDelegate</name>
     <message>
-        <location filename="../package/ActionShowStashDelegate.qml" line="95"/>
         <source>Application tray</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12,7 +11,6 @@
 <context>
     <name>ActionToggleCollapseDelegate</name>
     <message>
-        <location filename="../package/ActionToggleCollapseDelegate.qml" line="30"/>
         <source>Collapse tray</source>
         <translation type="unfinished"></translation>
     </message>
@@ -20,7 +18,6 @@
 <context>
     <name>PanelTrayItem</name>
     <message>
-        <location filename="../quickpanel/PanelTrayItem.qml" line="30"/>
         <source>Quick actions</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/tray/translations/org.deepin.ds.dock.tray_fr.ts
+++ b/panels/dock/tray/translations/org.deepin.ds.dock.tray_fr.ts
@@ -4,7 +4,6 @@
 <context>
     <name>ActionShowStashDelegate</name>
     <message>
-        <location filename="../package/ActionShowStashDelegate.qml" line="95"/>
         <source>Application tray</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12,7 +11,6 @@
 <context>
     <name>ActionToggleCollapseDelegate</name>
     <message>
-        <location filename="../package/ActionToggleCollapseDelegate.qml" line="30"/>
         <source>Collapse tray</source>
         <translation type="unfinished"></translation>
     </message>
@@ -20,7 +18,6 @@
 <context>
     <name>PanelTrayItem</name>
     <message>
-        <location filename="../quickpanel/PanelTrayItem.qml" line="30"/>
         <source>Quick actions</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/tray/translations/org.deepin.ds.dock.tray_hu.ts
+++ b/panels/dock/tray/translations/org.deepin.ds.dock.tray_hu.ts
@@ -4,7 +4,6 @@
 <context>
     <name>ActionShowStashDelegate</name>
     <message>
-        <location filename="../package/ActionShowStashDelegate.qml" line="95"/>
         <source>Application tray</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12,7 +11,6 @@
 <context>
     <name>ActionToggleCollapseDelegate</name>
     <message>
-        <location filename="../package/ActionToggleCollapseDelegate.qml" line="30"/>
         <source>Collapse tray</source>
         <translation type="unfinished"></translation>
     </message>
@@ -20,7 +18,6 @@
 <context>
     <name>PanelTrayItem</name>
     <message>
-        <location filename="../quickpanel/PanelTrayItem.qml" line="30"/>
         <source>Quick actions</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/tray/translations/org.deepin.ds.dock.tray_it.ts
+++ b/panels/dock/tray/translations/org.deepin.ds.dock.tray_it.ts
@@ -4,7 +4,6 @@
 <context>
     <name>ActionShowStashDelegate</name>
     <message>
-        <location filename="../package/ActionShowStashDelegate.qml" line="95"/>
         <source>Application tray</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12,7 +11,6 @@
 <context>
     <name>ActionToggleCollapseDelegate</name>
     <message>
-        <location filename="../package/ActionToggleCollapseDelegate.qml" line="30"/>
         <source>Collapse tray</source>
         <translation type="unfinished"></translation>
     </message>
@@ -20,7 +18,6 @@
 <context>
     <name>PanelTrayItem</name>
     <message>
-        <location filename="../quickpanel/PanelTrayItem.qml" line="30"/>
         <source>Quick actions</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/tray/translations/org.deepin.ds.dock.tray_ja.ts
+++ b/panels/dock/tray/translations/org.deepin.ds.dock.tray_ja.ts
@@ -4,7 +4,6 @@
 <context>
     <name>ActionShowStashDelegate</name>
     <message>
-        <location filename="../package/ActionShowStashDelegate.qml" line="95"/>
         <source>Application tray</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12,7 +11,6 @@
 <context>
     <name>ActionToggleCollapseDelegate</name>
     <message>
-        <location filename="../package/ActionToggleCollapseDelegate.qml" line="30"/>
         <source>Collapse tray</source>
         <translation type="unfinished"></translation>
     </message>
@@ -20,7 +18,6 @@
 <context>
     <name>PanelTrayItem</name>
     <message>
-        <location filename="../quickpanel/PanelTrayItem.qml" line="30"/>
         <source>Quick actions</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/tray/translations/org.deepin.ds.dock.tray_ko.ts
+++ b/panels/dock/tray/translations/org.deepin.ds.dock.tray_ko.ts
@@ -4,7 +4,6 @@
 <context>
     <name>ActionShowStashDelegate</name>
     <message>
-        <location filename="../package/ActionShowStashDelegate.qml" line="95"/>
         <source>Application tray</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12,7 +11,6 @@
 <context>
     <name>ActionToggleCollapseDelegate</name>
     <message>
-        <location filename="../package/ActionToggleCollapseDelegate.qml" line="30"/>
         <source>Collapse tray</source>
         <translation type="unfinished"></translation>
     </message>
@@ -20,7 +18,6 @@
 <context>
     <name>PanelTrayItem</name>
     <message>
-        <location filename="../quickpanel/PanelTrayItem.qml" line="30"/>
         <source>Quick actions</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/tray/translations/org.deepin.ds.dock.tray_nb_NO.ts
+++ b/panels/dock/tray/translations/org.deepin.ds.dock.tray_nb_NO.ts
@@ -4,7 +4,6 @@
 <context>
     <name>ActionShowStashDelegate</name>
     <message>
-        <location filename="../package/ActionShowStashDelegate.qml" line="95"/>
         <source>Application tray</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12,7 +11,6 @@
 <context>
     <name>ActionToggleCollapseDelegate</name>
     <message>
-        <location filename="../package/ActionToggleCollapseDelegate.qml" line="30"/>
         <source>Collapse tray</source>
         <translation type="unfinished"></translation>
     </message>
@@ -20,7 +18,6 @@
 <context>
     <name>PanelTrayItem</name>
     <message>
-        <location filename="../quickpanel/PanelTrayItem.qml" line="30"/>
         <source>Quick actions</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/tray/translations/org.deepin.ds.dock.tray_pl.ts
+++ b/panels/dock/tray/translations/org.deepin.ds.dock.tray_pl.ts
@@ -4,7 +4,6 @@
 <context>
     <name>ActionShowStashDelegate</name>
     <message>
-        <location filename="../package/ActionShowStashDelegate.qml" line="95"/>
         <source>Application tray</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12,7 +11,6 @@
 <context>
     <name>ActionToggleCollapseDelegate</name>
     <message>
-        <location filename="../package/ActionToggleCollapseDelegate.qml" line="30"/>
         <source>Collapse tray</source>
         <translation type="unfinished"></translation>
     </message>
@@ -20,7 +18,6 @@
 <context>
     <name>PanelTrayItem</name>
     <message>
-        <location filename="../quickpanel/PanelTrayItem.qml" line="30"/>
         <source>Quick actions</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/tray/translations/org.deepin.ds.dock.tray_pt_BR.ts
+++ b/panels/dock/tray/translations/org.deepin.ds.dock.tray_pt_BR.ts
@@ -4,7 +4,6 @@
 <context>
     <name>ActionShowStashDelegate</name>
     <message>
-        <location filename="../package/ActionShowStashDelegate.qml" line="95"/>
         <source>Application tray</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12,7 +11,6 @@
 <context>
     <name>ActionToggleCollapseDelegate</name>
     <message>
-        <location filename="../package/ActionToggleCollapseDelegate.qml" line="30"/>
         <source>Collapse tray</source>
         <translation type="unfinished"></translation>
     </message>
@@ -20,7 +18,6 @@
 <context>
     <name>PanelTrayItem</name>
     <message>
-        <location filename="../quickpanel/PanelTrayItem.qml" line="30"/>
         <source>Quick actions</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/tray/translations/org.deepin.ds.dock.tray_ru.ts
+++ b/panels/dock/tray/translations/org.deepin.ds.dock.tray_ru.ts
@@ -4,7 +4,6 @@
 <context>
     <name>ActionShowStashDelegate</name>
     <message>
-        <location filename="../package/ActionShowStashDelegate.qml" line="95"/>
         <source>Application tray</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12,7 +11,6 @@
 <context>
     <name>ActionToggleCollapseDelegate</name>
     <message>
-        <location filename="../package/ActionToggleCollapseDelegate.qml" line="30"/>
         <source>Collapse tray</source>
         <translation type="unfinished"></translation>
     </message>
@@ -20,7 +18,6 @@
 <context>
     <name>PanelTrayItem</name>
     <message>
-        <location filename="../quickpanel/PanelTrayItem.qml" line="30"/>
         <source>Quick actions</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/tray/translations/org.deepin.ds.dock.tray_uk.ts
+++ b/panels/dock/tray/translations/org.deepin.ds.dock.tray_uk.ts
@@ -4,7 +4,6 @@
 <context>
     <name>ActionShowStashDelegate</name>
     <message>
-        <location filename="../package/ActionShowStashDelegate.qml" line="95"/>
         <source>Application tray</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12,7 +11,6 @@
 <context>
     <name>ActionToggleCollapseDelegate</name>
     <message>
-        <location filename="../package/ActionToggleCollapseDelegate.qml" line="30"/>
         <source>Collapse tray</source>
         <translation type="unfinished"></translation>
     </message>
@@ -20,7 +18,6 @@
 <context>
     <name>PanelTrayItem</name>
     <message>
-        <location filename="../quickpanel/PanelTrayItem.qml" line="30"/>
         <source>Quick actions</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/dock/tray/translations/org.deepin.ds.dock.tray_zh_CN.ts
+++ b/panels/dock/tray/translations/org.deepin.ds.dock.tray_zh_CN.ts
@@ -4,7 +4,6 @@
 <context>
     <name>ActionShowStashDelegate</name>
     <message>
-        <location filename="../package/ActionShowStashDelegate.qml" line="95"/>
         <source>Application tray</source>
         <translation>应用托盘</translation>
     </message>
@@ -12,7 +11,6 @@
 <context>
     <name>ActionToggleCollapseDelegate</name>
     <message>
-        <location filename="../package/ActionToggleCollapseDelegate.qml" line="30"/>
         <source>Collapse tray</source>
         <translation>折叠托盘</translation>
     </message>
@@ -20,7 +18,6 @@
 <context>
     <name>PanelTrayItem</name>
     <message>
-        <location filename="../quickpanel/PanelTrayItem.qml" line="30"/>
         <source>Quick actions</source>
         <translation>快捷设置</translation>
     </message>

--- a/panels/notification/bubble/translations/org.deepin.ds.notificationbubble.ts
+++ b/panels/notification/bubble/translations/org.deepin.ds.notificationbubble.ts
@@ -4,13 +4,10 @@
 <context>
     <name>notification::BubbleItem</name>
     <message>
-        <location filename="../bubbleitem.cpp" line="158"/>
-        <location filename="../bubbleitem.cpp" line="165"/>
         <source>just now</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bubbleitem.cpp" line="363"/>
         <source>1 new message</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18,7 +15,6 @@
 <context>
     <name>notification::BubbleModel</name>
     <message>
-        <location filename="../bubblemodel.cpp" line="263"/>
         <source>%1 minutes ago</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/notification/bubble/translations/org.deepin.ds.notificationbubble_az.ts
+++ b/panels/notification/bubble/translations/org.deepin.ds.notificationbubble_az.ts
@@ -1,14 +1,13 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="az">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="az">
 <context>
     <name>notification::BubbleItem</name>
     <message>
-        <location filename="../bubbleitem.cpp" line="158"/>
-        <location filename="../bubbleitem.cpp" line="165"/>
         <source>just now</source>
         <translation> justo ahora</translation>
     </message>
     <message>
-        <location filename="../bubbleitem.cpp" line="363"/>
         <source>1 new message</source>
         <translation>1 رسالة جديدة</translation>
     </message>
@@ -16,7 +15,6 @@
 <context>
     <name>notification::BubbleModel</name>
     <message>
-        <location filename="../bubblemodel.cpp" line="263"/>
         <source>%1 minutes ago</source>
         <translation>%1 دقيقة مضت</translation>
     </message>

--- a/panels/notification/bubble/translations/org.deepin.ds.notificationbubble_bo.ts
+++ b/panels/notification/bubble/translations/org.deepin.ds.notificationbubble_bo.ts
@@ -4,13 +4,10 @@
 <context>
     <name>notification::BubbleItem</name>
     <message>
-        <location filename="../bubbleitem.cpp" line="158"/>
-        <location filename="../bubbleitem.cpp" line="165"/>
         <source>just now</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bubbleitem.cpp" line="363"/>
         <source>1 new message</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18,7 +15,6 @@
 <context>
     <name>notification::BubbleModel</name>
     <message>
-        <location filename="../bubblemodel.cpp" line="263"/>
         <source>%1 minutes ago</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/notification/bubble/translations/org.deepin.ds.notificationbubble_ca.ts
+++ b/panels/notification/bubble/translations/org.deepin.ds.notificationbubble_ca.ts
@@ -1,14 +1,13 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ca">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ca">
 <context>
     <name>notification::BubbleItem</name>
     <message>
-        <location filename="../bubbleitem.cpp" line="158"/>
-        <location filename="../bubbleitem.cpp" line="165"/>
         <source>just now</source>
         <translation>ara mateix</translation>
     </message>
     <message>
-        <location filename="../bubbleitem.cpp" line="363"/>
         <source>1 new message</source>
         <translation>1 missatge nou</translation>
     </message>
@@ -16,7 +15,6 @@
 <context>
     <name>notification::BubbleModel</name>
     <message>
-        <location filename="../bubblemodel.cpp" line="263"/>
         <source>%1 minutes ago</source>
         <translation>fa %1 minuts</translation>
     </message>

--- a/panels/notification/bubble/translations/org.deepin.ds.notificationbubble_es.ts
+++ b/panels/notification/bubble/translations/org.deepin.ds.notificationbubble_es.ts
@@ -1,14 +1,13 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="es">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="es">
 <context>
     <name>notification::BubbleItem</name>
     <message>
-        <location filename="../bubbleitem.cpp" line="158"/>
-        <location filename="../bubbleitem.cpp" line="165"/>
         <source>just now</source>
         <translation>Ahora mismo</translation>
     </message>
     <message>
-        <location filename="../bubbleitem.cpp" line="363"/>
         <source>1 new message</source>
         <translation>1 mensaje nuevo</translation>
     </message>
@@ -16,7 +15,6 @@
 <context>
     <name>notification::BubbleModel</name>
     <message>
-        <location filename="../bubblemodel.cpp" line="263"/>
         <source>%1 minutes ago</source>
         <translation>Hace %1 minutos</translation>
     </message>

--- a/panels/notification/bubble/translations/org.deepin.ds.notificationbubble_fi.ts
+++ b/panels/notification/bubble/translations/org.deepin.ds.notificationbubble_fi.ts
@@ -1,14 +1,13 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="fi">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fi">
 <context>
     <name>notification::BubbleItem</name>
     <message>
-        <location filename="../bubbleitem.cpp" line="158"/>
-        <location filename="../bubbleitem.cpp" line="165"/>
         <source>just now</source>
         <translation>juuri nyt</translation>
     </message>
     <message>
-        <location filename="../bubbleitem.cpp" line="363"/>
         <source>1 new message</source>
         <translation>1 uusi viesti</translation>
     </message>
@@ -16,7 +15,6 @@
 <context>
     <name>notification::BubbleModel</name>
     <message>
-        <location filename="../bubblemodel.cpp" line="263"/>
         <source>%1 minutes ago</source>
         <translation>%1 minuuttia sitten</translation>
     </message>

--- a/panels/notification/bubble/translations/org.deepin.ds.notificationbubble_fr.ts
+++ b/panels/notification/bubble/translations/org.deepin.ds.notificationbubble_fr.ts
@@ -1,14 +1,13 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="fr">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fr">
 <context>
     <name>notification::BubbleItem</name>
     <message>
-        <location filename="../bubbleitem.cpp" line="158"/>
-        <location filename="../bubbleitem.cpp" line="165"/>
         <source>just now</source>
         <translation>À l&apos;instant</translation>
     </message>
     <message>
-        <location filename="../bubbleitem.cpp" line="363"/>
         <source>1 new message</source>
         <translation>1 nouveau message</translation>
     </message>
@@ -16,7 +15,6 @@
 <context>
     <name>notification::BubbleModel</name>
     <message>
-        <location filename="../bubblemodel.cpp" line="263"/>
         <source>%1 minutes ago</source>
         <translation>Il y a %1 minutes</translation>
     </message>

--- a/panels/notification/bubble/translations/org.deepin.ds.notificationbubble_hu.ts
+++ b/panels/notification/bubble/translations/org.deepin.ds.notificationbubble_hu.ts
@@ -1,14 +1,13 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="hu">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="hu">
 <context>
     <name>notification::BubbleItem</name>
     <message>
-        <location filename="../bubbleitem.cpp" line="158"/>
-        <location filename="../bubbleitem.cpp" line="165"/>
         <source>just now</source>
         <translation>Csak most</translation>
     </message>
     <message>
-        <location filename="../bubbleitem.cpp" line="363"/>
         <source>1 new message</source>
         <translation>1 új üzenet</translation>
     </message>
@@ -16,7 +15,6 @@
 <context>
     <name>notification::BubbleModel</name>
     <message>
-        <location filename="../bubblemodel.cpp" line="263"/>
         <source>%1 minutes ago</source>
         <translation>%1 perccel ezelőtt</translation>
     </message>

--- a/panels/notification/bubble/translations/org.deepin.ds.notificationbubble_it.ts
+++ b/panels/notification/bubble/translations/org.deepin.ds.notificationbubble_it.ts
@@ -4,13 +4,10 @@
 <context>
     <name>notification::BubbleItem</name>
     <message>
-        <location filename="../bubbleitem.cpp" line="158"/>
-        <location filename="../bubbleitem.cpp" line="165"/>
         <source>just now</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bubbleitem.cpp" line="363"/>
         <source>1 new message</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18,7 +15,6 @@
 <context>
     <name>notification::BubbleModel</name>
     <message>
-        <location filename="../bubblemodel.cpp" line="263"/>
         <source>%1 minutes ago</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/notification/bubble/translations/org.deepin.ds.notificationbubble_ja.ts
+++ b/panels/notification/bubble/translations/org.deepin.ds.notificationbubble_ja.ts
@@ -1,14 +1,13 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ja">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ja">
 <context>
     <name>notification::BubbleItem</name>
     <message>
-        <location filename="../bubbleitem.cpp" line="158"/>
-        <location filename="../bubbleitem.cpp" line="165"/>
         <source>just now</source>
         <translation>たった今</translation>
     </message>
     <message>
-        <location filename="../bubbleitem.cpp" line="363"/>
         <source>1 new message</source>
         <translation>1件の新しいメッセージ</translation>
     </message>
@@ -16,7 +15,6 @@
 <context>
     <name>notification::BubbleModel</name>
     <message>
-        <location filename="../bubblemodel.cpp" line="263"/>
         <source>%1 minutes ago</source>
         <translation>%1分前</translation>
     </message>

--- a/panels/notification/bubble/translations/org.deepin.ds.notificationbubble_ko.ts
+++ b/panels/notification/bubble/translations/org.deepin.ds.notificationbubble_ko.ts
@@ -4,13 +4,10 @@
 <context>
     <name>notification::BubbleItem</name>
     <message>
-        <location filename="../bubbleitem.cpp" line="158"/>
-        <location filename="../bubbleitem.cpp" line="165"/>
         <source>just now</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bubbleitem.cpp" line="363"/>
         <source>1 new message</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18,7 +15,6 @@
 <context>
     <name>notification::BubbleModel</name>
     <message>
-        <location filename="../bubblemodel.cpp" line="263"/>
         <source>%1 minutes ago</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/notification/bubble/translations/org.deepin.ds.notificationbubble_nb_NO.ts
+++ b/panels/notification/bubble/translations/org.deepin.ds.notificationbubble_nb_NO.ts
@@ -4,13 +4,10 @@
 <context>
     <name>notification::BubbleItem</name>
     <message>
-        <location filename="../bubbleitem.cpp" line="158"/>
-        <location filename="../bubbleitem.cpp" line="165"/>
         <source>just now</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bubbleitem.cpp" line="363"/>
         <source>1 new message</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18,7 +15,6 @@
 <context>
     <name>notification::BubbleModel</name>
     <message>
-        <location filename="../bubblemodel.cpp" line="263"/>
         <source>%1 minutes ago</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/notification/bubble/translations/org.deepin.ds.notificationbubble_pl.ts
+++ b/panels/notification/bubble/translations/org.deepin.ds.notificationbubble_pl.ts
@@ -1,14 +1,13 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pl">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pl">
 <context>
     <name>notification::BubbleItem</name>
     <message>
-        <location filename="../bubbleitem.cpp" line="158"/>
-        <location filename="../bubbleitem.cpp" line="165"/>
         <source>just now</source>
         <translation>właśnie teraz</translation>
     </message>
     <message>
-        <location filename="../bubbleitem.cpp" line="363"/>
         <source>1 new message</source>
         <translation>1 nowa wiadomość</translation>
     </message>
@@ -16,7 +15,6 @@
 <context>
     <name>notification::BubbleModel</name>
     <message>
-        <location filename="../bubblemodel.cpp" line="263"/>
         <source>%1 minutes ago</source>
         <translation>%1 minut temu</translation>
     </message>

--- a/panels/notification/bubble/translations/org.deepin.ds.notificationbubble_pt_BR.ts
+++ b/panels/notification/bubble/translations/org.deepin.ds.notificationbubble_pt_BR.ts
@@ -1,14 +1,13 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pt_BR">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pt_BR">
 <context>
     <name>notification::BubbleItem</name>
     <message>
-        <location filename="../bubbleitem.cpp" line="158"/>
-        <location filename="../bubbleitem.cpp" line="165"/>
         <source>just now</source>
         <translation>Há pouco</translation>
     </message>
     <message>
-        <location filename="../bubbleitem.cpp" line="363"/>
         <source>1 new message</source>
         <translation>1 nova mensagem</translation>
     </message>
@@ -16,7 +15,6 @@
 <context>
     <name>notification::BubbleModel</name>
     <message>
-        <location filename="../bubblemodel.cpp" line="263"/>
         <source>%1 minutes ago</source>
         <translation>%1 minutos atrás</translation>
     </message>

--- a/panels/notification/bubble/translations/org.deepin.ds.notificationbubble_ru.ts
+++ b/panels/notification/bubble/translations/org.deepin.ds.notificationbubble_ru.ts
@@ -1,14 +1,13 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ru">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ru">
 <context>
     <name>notification::BubbleItem</name>
     <message>
-        <location filename="../bubbleitem.cpp" line="158"/>
-        <location filename="../bubbleitem.cpp" line="165"/>
         <source>just now</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bubbleitem.cpp" line="363"/>
         <source>1 new message</source>
         <translation>1 новое сообщение</translation>
     </message>
@@ -16,7 +15,6 @@
 <context>
     <name>notification::BubbleModel</name>
     <message>
-        <location filename="../bubblemodel.cpp" line="263"/>
         <source>%1 minutes ago</source>
         <translation>%1 минут назад</translation>
     </message>

--- a/panels/notification/bubble/translations/org.deepin.ds.notificationbubble_uk.ts
+++ b/panels/notification/bubble/translations/org.deepin.ds.notificationbubble_uk.ts
@@ -1,14 +1,13 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="uk">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="uk">
 <context>
     <name>notification::BubbleItem</name>
     <message>
-        <location filename="../bubbleitem.cpp" line="158"/>
-        <location filename="../bubbleitem.cpp" line="165"/>
         <source>just now</source>
         <translation>Щойно</translation>
     </message>
     <message>
-        <location filename="../bubbleitem.cpp" line="363"/>
         <source>1 new message</source>
         <translation>Одне нове повідомлення</translation>
     </message>
@@ -16,7 +15,6 @@
 <context>
     <name>notification::BubbleModel</name>
     <message>
-        <location filename="../bubblemodel.cpp" line="263"/>
         <source>%1 minutes ago</source>
         <translation>%1 хвилин тому</translation>
     </message>

--- a/panels/notification/bubble/translations/org.deepin.ds.notificationbubble_zh_CN.ts
+++ b/panels/notification/bubble/translations/org.deepin.ds.notificationbubble_zh_CN.ts
@@ -1,14 +1,13 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_CN">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_CN">
 <context>
     <name>notification::BubbleItem</name>
     <message>
-        <location filename="../bubbleitem.cpp" line="158"/>
-        <location filename="../bubbleitem.cpp" line="165"/>
         <source>just now</source>
         <translation>刚刚</translation>
     </message>
     <message>
-        <location filename="../bubbleitem.cpp" line="363"/>
         <source>1 new message</source>
         <translation>1条新消息</translation>
     </message>
@@ -16,7 +15,6 @@
 <context>
     <name>notification::BubbleModel</name>
     <message>
-        <location filename="../bubblemodel.cpp" line="263"/>
         <source>%1 minutes ago</source>
         <translation>%1分钟前</translation>
     </message>

--- a/panels/notification/bubble/translations/org.deepin.ds.notificationbubble_zh_HK.ts
+++ b/panels/notification/bubble/translations/org.deepin.ds.notificationbubble_zh_HK.ts
@@ -4,13 +4,10 @@
 <context>
     <name>notification::BubbleItem</name>
     <message>
-        <location filename="../bubbleitem.cpp" line="158"/>
-        <location filename="../bubbleitem.cpp" line="165"/>
         <source>just now</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bubbleitem.cpp" line="363"/>
         <source>1 new message</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18,7 +15,6 @@
 <context>
     <name>notification::BubbleModel</name>
     <message>
-        <location filename="../bubblemodel.cpp" line="263"/>
         <source>%1 minutes ago</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/notification/bubble/translations/org.deepin.ds.notificationbubble_zh_TW.ts
+++ b/panels/notification/bubble/translations/org.deepin.ds.notificationbubble_zh_TW.ts
@@ -4,13 +4,10 @@
 <context>
     <name>notification::BubbleItem</name>
     <message>
-        <location filename="../bubbleitem.cpp" line="158"/>
-        <location filename="../bubbleitem.cpp" line="165"/>
         <source>just now</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bubbleitem.cpp" line="363"/>
         <source>1 new message</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18,7 +15,6 @@
 <context>
     <name>notification::BubbleModel</name>
     <message>
-        <location filename="../bubblemodel.cpp" line="263"/>
         <source>%1 minutes ago</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter.ts
@@ -4,7 +4,6 @@
 <context>
     <name>GroupNotify</name>
     <message>
-        <location filename="../GroupNotify.qml" line="51"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12,12 +11,10 @@
 <context>
     <name>NotifyHeader</name>
     <message>
-        <location filename="../NotifyHeader.qml" line="42"/>
         <source>Notification Center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../NotifyHeader.qml" line="90"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -25,17 +22,14 @@
 <context>
     <name>NotifySetting</name>
     <message>
-        <location filename="../NotifySetting.qml" line="18"/>
         <source>Unpin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../NotifySetting.qml" line="18"/>
         <source>Pin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../NotifySetting.qml" line="26"/>
         <source>Notification Setting</source>
         <translation type="unfinished"></translation>
     </message>
@@ -43,27 +37,22 @@
 <context>
     <name>notifycenter::AppNotifyItem</name>
     <message>
-        <location filename="../notifyitem.cpp" line="78"/>
         <source>Just now</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="80"/>
         <source>%1 minutes ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="84"/>
         <source>1 hour ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="86"/>
         <source>%1 hours ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="90"/>
         <source>Yesterday </source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_az.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_az.ts
@@ -1,8 +1,9 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="az">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="az">
 <context>
     <name>GroupNotify</name>
     <message>
-        <location filename="../GroupNotify.qml" line="51"/>
         <source>Clear All</source>
         <translation>مسح الكل</translation>
     </message>
@@ -10,12 +11,10 @@
 <context>
     <name>NotifyHeader</name>
     <message>
-        <location filename="../NotifyHeader.qml" line="42"/>
         <source>Notification Center</source>
         <translation>مركز الإشعارات</translation>
     </message>
     <message>
-        <location filename="../NotifyHeader.qml" line="90"/>
         <source>Clear All</source>
         <translation>مسح الكل</translation>
     </message>
@@ -23,17 +22,14 @@
 <context>
     <name>NotifySetting</name>
     <message>
-        <location filename="../NotifySetting.qml" line="18"/>
         <source>Unpin</source>
         <translation>إلغاء تثبيت</translation>
     </message>
     <message>
-        <location filename="../NotifySetting.qml" line="18"/>
         <source>Pin</source>
         <translation>تثبيت</translation>
     </message>
     <message>
-        <location filename="../NotifySetting.qml" line="26"/>
         <source>Notification Setting</source>
         <translation>إعداد الإشعارات</translation>
     </message>
@@ -41,27 +37,22 @@
 <context>
     <name>notifycenter::AppNotifyItem</name>
     <message>
-        <location filename="../notifyitem.cpp" line="78"/>
         <source>Just now</source>
         <translation>الآن</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="80"/>
         <source>%1 minutes ago</source>
         <translation>%1 دقيقة مضت</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="84"/>
         <source>1 hour ago</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="86"/>
         <source>%1 hours ago</source>
         <translation>%1 ساعة مضت</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="90"/>
         <source>Yesterday </source>
         <translation>أمس </translation>
     </message>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_bo.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_bo.ts
@@ -4,7 +4,6 @@
 <context>
     <name>GroupNotify</name>
     <message>
-        <location filename="../GroupNotify.qml" line="51"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12,12 +11,10 @@
 <context>
     <name>NotifyHeader</name>
     <message>
-        <location filename="../NotifyHeader.qml" line="42"/>
         <source>Notification Center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../NotifyHeader.qml" line="90"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -25,17 +22,14 @@
 <context>
     <name>NotifySetting</name>
     <message>
-        <location filename="../NotifySetting.qml" line="18"/>
         <source>Unpin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../NotifySetting.qml" line="18"/>
         <source>Pin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../NotifySetting.qml" line="26"/>
         <source>Notification Setting</source>
         <translation type="unfinished"></translation>
     </message>
@@ -43,27 +37,22 @@
 <context>
     <name>notifycenter::AppNotifyItem</name>
     <message>
-        <location filename="../notifyitem.cpp" line="78"/>
         <source>Just now</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="80"/>
         <source>%1 minutes ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="84"/>
         <source>1 hour ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="86"/>
         <source>%1 hours ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="90"/>
         <source>Yesterday </source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_ca.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_ca.ts
@@ -1,8 +1,9 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ca">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ca">
 <context>
     <name>GroupNotify</name>
     <message>
-        <location filename="../GroupNotify.qml" line="51"/>
         <source>Clear All</source>
         <translation>Neteja-ho tot</translation>
     </message>
@@ -10,12 +11,10 @@
 <context>
     <name>NotifyHeader</name>
     <message>
-        <location filename="../NotifyHeader.qml" line="42"/>
         <source>Notification Center</source>
         <translation>Centre de notificacions</translation>
     </message>
     <message>
-        <location filename="../NotifyHeader.qml" line="90"/>
         <source>Clear All</source>
         <translation>Neteja-ho tot</translation>
     </message>
@@ -23,17 +22,14 @@
 <context>
     <name>NotifySetting</name>
     <message>
-        <location filename="../NotifySetting.qml" line="18"/>
         <source>Unpin</source>
         <translation>Desancora</translation>
     </message>
     <message>
-        <location filename="../NotifySetting.qml" line="18"/>
         <source>Pin</source>
         <translation>Ancora</translation>
     </message>
     <message>
-        <location filename="../NotifySetting.qml" line="26"/>
         <source>Notification Setting</source>
         <translation>Configuració de les notificacions</translation>
     </message>
@@ -41,27 +37,22 @@
 <context>
     <name>notifycenter::AppNotifyItem</name>
     <message>
-        <location filename="../notifyitem.cpp" line="78"/>
         <source>Just now</source>
         <translation>Ara mateix</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="80"/>
         <source>%1 minutes ago</source>
         <translation>Fa %1 minuts</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="84"/>
         <source>1 hour ago</source>
         <translation>Fa 1 hora</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="86"/>
         <source>%1 hours ago</source>
         <translation>Fa %1 hores</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="90"/>
         <source>Yesterday </source>
         <translation>Ahir</translation>
     </message>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_es.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_es.ts
@@ -1,8 +1,9 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="es">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="es">
 <context>
     <name>GroupNotify</name>
     <message>
-        <location filename="../GroupNotify.qml" line="51"/>
         <source>Clear All</source>
         <translation>Limpiar todo</translation>
     </message>
@@ -10,12 +11,10 @@
 <context>
     <name>NotifyHeader</name>
     <message>
-        <location filename="../NotifyHeader.qml" line="42"/>
         <source>Notification Center</source>
         <translation>Centro de notificaciones</translation>
     </message>
     <message>
-        <location filename="../NotifyHeader.qml" line="90"/>
         <source>Clear All</source>
         <translation>Limpiar todo</translation>
     </message>
@@ -23,17 +22,14 @@
 <context>
     <name>NotifySetting</name>
     <message>
-        <location filename="../NotifySetting.qml" line="18"/>
         <source>Unpin</source>
         <translation>Desfijar</translation>
     </message>
     <message>
-        <location filename="../NotifySetting.qml" line="18"/>
         <source>Pin</source>
         <translation>Fijar</translation>
     </message>
     <message>
-        <location filename="../NotifySetting.qml" line="26"/>
         <source>Notification Setting</source>
         <translation>Ajustes de notificaciones</translation>
     </message>
@@ -41,27 +37,22 @@
 <context>
     <name>notifycenter::AppNotifyItem</name>
     <message>
-        <location filename="../notifyitem.cpp" line="78"/>
         <source>Just now</source>
         <translation>Ahora mismo</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="80"/>
         <source>%1 minutes ago</source>
         <translation>Hace %1 minutos</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="84"/>
         <source>1 hour ago</source>
         <translation>Hace una hora</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="86"/>
         <source>%1 hours ago</source>
         <translation>Hace %1 horas</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="90"/>
         <source>Yesterday </source>
         <translation>Ayer </translation>
     </message>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_fi.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_fi.ts
@@ -1,8 +1,9 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="fi">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fi">
 <context>
     <name>GroupNotify</name>
     <message>
-        <location filename="../GroupNotify.qml" line="51"/>
         <source>Clear All</source>
         <translation>Tyhjennä kaikki</translation>
     </message>
@@ -10,12 +11,10 @@
 <context>
     <name>NotifyHeader</name>
     <message>
-        <location filename="../NotifyHeader.qml" line="42"/>
         <source>Notification Center</source>
         <translation>Ilmoituskeskus</translation>
     </message>
     <message>
-        <location filename="../NotifyHeader.qml" line="90"/>
         <source>Clear All</source>
         <translation>Tyhjennä kaikki</translation>
     </message>
@@ -23,17 +22,14 @@
 <context>
     <name>NotifySetting</name>
     <message>
-        <location filename="../NotifySetting.qml" line="18"/>
         <source>Unpin</source>
         <translation>Irrota</translation>
     </message>
     <message>
-        <location filename="../NotifySetting.qml" line="18"/>
         <source>Pin</source>
         <translation>Kiinnitä</translation>
     </message>
     <message>
-        <location filename="../NotifySetting.qml" line="26"/>
         <source>Notification Setting</source>
         <translation>Ilmoitusten asetukset</translation>
     </message>
@@ -41,27 +37,22 @@
 <context>
     <name>notifycenter::AppNotifyItem</name>
     <message>
-        <location filename="../notifyitem.cpp" line="78"/>
         <source>Just now</source>
         <translation>Juuri nyt</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="80"/>
         <source>%1 minutes ago</source>
         <translation>%1 min sitten</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="84"/>
         <source>1 hour ago</source>
         <translation>1 h sitten</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="86"/>
         <source>%1 hours ago</source>
         <translation>%1 h sitten</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="90"/>
         <source>Yesterday </source>
         <translation>Eilen</translation>
     </message>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_fr.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_fr.ts
@@ -1,8 +1,9 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="fr">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fr">
 <context>
     <name>GroupNotify</name>
     <message>
-        <location filename="../GroupNotify.qml" line="51"/>
         <source>Clear All</source>
         <translation>Tout effacer</translation>
     </message>
@@ -10,12 +11,10 @@
 <context>
     <name>NotifyHeader</name>
     <message>
-        <location filename="../NotifyHeader.qml" line="42"/>
         <source>Notification Center</source>
         <translation>Centre de notification</translation>
     </message>
     <message>
-        <location filename="../NotifyHeader.qml" line="90"/>
         <source>Clear All</source>
         <translation>Tout effacer</translation>
     </message>
@@ -23,17 +22,14 @@
 <context>
     <name>NotifySetting</name>
     <message>
-        <location filename="../NotifySetting.qml" line="18"/>
         <source>Unpin</source>
         <translation>Retirer</translation>
     </message>
     <message>
-        <location filename="../NotifySetting.qml" line="18"/>
         <source>Pin</source>
         <translation>Épingler</translation>
     </message>
     <message>
-        <location filename="../NotifySetting.qml" line="26"/>
         <source>Notification Setting</source>
         <translation>Réglages des notifications</translation>
     </message>
@@ -41,27 +37,22 @@
 <context>
     <name>notifycenter::AppNotifyItem</name>
     <message>
-        <location filename="../notifyitem.cpp" line="78"/>
         <source>Just now</source>
         <translation>À l&apos;instant</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="80"/>
         <source>%1 minutes ago</source>
         <translation>Il y a %1 minutes</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="84"/>
         <source>1 hour ago</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="86"/>
         <source>%1 hours ago</source>
         <translation>Il y a %1 heures</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="90"/>
         <source>Yesterday </source>
         <translation>Hier</translation>
     </message>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_hu.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_hu.ts
@@ -1,8 +1,9 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="hu">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="hu">
 <context>
     <name>GroupNotify</name>
     <message>
-        <location filename="../GroupNotify.qml" line="51"/>
         <source>Clear All</source>
         <translation>Összes törlése</translation>
     </message>
@@ -10,12 +11,10 @@
 <context>
     <name>NotifyHeader</name>
     <message>
-        <location filename="../NotifyHeader.qml" line="42"/>
         <source>Notification Center</source>
         <translation>Értesítési Központ</translation>
     </message>
     <message>
-        <location filename="../NotifyHeader.qml" line="90"/>
         <source>Clear All</source>
         <translation>Összes törlése</translation>
     </message>
@@ -23,17 +22,14 @@
 <context>
     <name>NotifySetting</name>
     <message>
-        <location filename="../NotifySetting.qml" line="18"/>
         <source>Unpin</source>
         <translation>Feloldás</translation>
     </message>
     <message>
-        <location filename="../NotifySetting.qml" line="18"/>
         <source>Pin</source>
         <translation>Rögzítés</translation>
     </message>
     <message>
-        <location filename="../NotifySetting.qml" line="26"/>
         <source>Notification Setting</source>
         <translation>Értesítési Beállítások</translation>
     </message>
@@ -41,27 +37,22 @@
 <context>
     <name>notifycenter::AppNotifyItem</name>
     <message>
-        <location filename="../notifyitem.cpp" line="78"/>
         <source>Just now</source>
         <translation>Csak most</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="80"/>
         <source>%1 minutes ago</source>
         <translation>%1 perccel ezelőtt</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="84"/>
         <source>1 hour ago</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="86"/>
         <source>%1 hours ago</source>
         <translation>%1 órával ezelőtt</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="90"/>
         <source>Yesterday </source>
         <translation>Tegnap</translation>
     </message>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_it.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_it.ts
@@ -4,7 +4,6 @@
 <context>
     <name>GroupNotify</name>
     <message>
-        <location filename="../GroupNotify.qml" line="51"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12,12 +11,10 @@
 <context>
     <name>NotifyHeader</name>
     <message>
-        <location filename="../NotifyHeader.qml" line="42"/>
         <source>Notification Center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../NotifyHeader.qml" line="90"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -25,17 +22,14 @@
 <context>
     <name>NotifySetting</name>
     <message>
-        <location filename="../NotifySetting.qml" line="18"/>
         <source>Unpin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../NotifySetting.qml" line="18"/>
         <source>Pin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../NotifySetting.qml" line="26"/>
         <source>Notification Setting</source>
         <translation type="unfinished"></translation>
     </message>
@@ -43,27 +37,22 @@
 <context>
     <name>notifycenter::AppNotifyItem</name>
     <message>
-        <location filename="../notifyitem.cpp" line="78"/>
         <source>Just now</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="80"/>
         <source>%1 minutes ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="84"/>
         <source>1 hour ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="86"/>
         <source>%1 hours ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="90"/>
         <source>Yesterday </source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_ja.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_ja.ts
@@ -1,8 +1,9 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ja">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ja">
 <context>
     <name>GroupNotify</name>
     <message>
-        <location filename="../GroupNotify.qml" line="51"/>
         <source>Clear All</source>
         <translation>すべて消去</translation>
     </message>
@@ -10,12 +11,10 @@
 <context>
     <name>NotifyHeader</name>
     <message>
-        <location filename="../NotifyHeader.qml" line="42"/>
         <source>Notification Center</source>
         <translation>通知センター</translation>
     </message>
     <message>
-        <location filename="../NotifyHeader.qml" line="90"/>
         <source>Clear All</source>
         <translation>すべて消去</translation>
     </message>
@@ -23,17 +22,14 @@
 <context>
     <name>NotifySetting</name>
     <message>
-        <location filename="../NotifySetting.qml" line="18"/>
         <source>Unpin</source>
         <translation>固定解除</translation>
     </message>
     <message>
-        <location filename="../NotifySetting.qml" line="18"/>
         <source>Pin</source>
         <translation>固定</translation>
     </message>
     <message>
-        <location filename="../NotifySetting.qml" line="26"/>
         <source>Notification Setting</source>
         <translation>通知の設定</translation>
     </message>
@@ -41,27 +37,22 @@
 <context>
     <name>notifycenter::AppNotifyItem</name>
     <message>
-        <location filename="../notifyitem.cpp" line="78"/>
         <source>Just now</source>
         <translation>たった今</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="80"/>
         <source>%1 minutes ago</source>
         <translation>%1分前</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="84"/>
         <source>1 hour ago</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="86"/>
         <source>%1 hours ago</source>
         <translation>%1時間前</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="90"/>
         <source>Yesterday </source>
         <translation>昨日</translation>
     </message>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_ko.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_ko.ts
@@ -4,7 +4,6 @@
 <context>
     <name>GroupNotify</name>
     <message>
-        <location filename="../GroupNotify.qml" line="51"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12,12 +11,10 @@
 <context>
     <name>NotifyHeader</name>
     <message>
-        <location filename="../NotifyHeader.qml" line="42"/>
         <source>Notification Center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../NotifyHeader.qml" line="90"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -25,17 +22,14 @@
 <context>
     <name>NotifySetting</name>
     <message>
-        <location filename="../NotifySetting.qml" line="18"/>
         <source>Unpin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../NotifySetting.qml" line="18"/>
         <source>Pin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../NotifySetting.qml" line="26"/>
         <source>Notification Setting</source>
         <translation type="unfinished"></translation>
     </message>
@@ -43,27 +37,22 @@
 <context>
     <name>notifycenter::AppNotifyItem</name>
     <message>
-        <location filename="../notifyitem.cpp" line="78"/>
         <source>Just now</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="80"/>
         <source>%1 minutes ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="84"/>
         <source>1 hour ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="86"/>
         <source>%1 hours ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="90"/>
         <source>Yesterday </source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_nb_NO.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_nb_NO.ts
@@ -4,7 +4,6 @@
 <context>
     <name>GroupNotify</name>
     <message>
-        <location filename="../GroupNotify.qml" line="51"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12,12 +11,10 @@
 <context>
     <name>NotifyHeader</name>
     <message>
-        <location filename="../NotifyHeader.qml" line="42"/>
         <source>Notification Center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../NotifyHeader.qml" line="90"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -25,17 +22,14 @@
 <context>
     <name>NotifySetting</name>
     <message>
-        <location filename="../NotifySetting.qml" line="18"/>
         <source>Unpin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../NotifySetting.qml" line="18"/>
         <source>Pin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../NotifySetting.qml" line="26"/>
         <source>Notification Setting</source>
         <translation type="unfinished"></translation>
     </message>
@@ -43,27 +37,22 @@
 <context>
     <name>notifycenter::AppNotifyItem</name>
     <message>
-        <location filename="../notifyitem.cpp" line="78"/>
         <source>Just now</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="80"/>
         <source>%1 minutes ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="84"/>
         <source>1 hour ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="86"/>
         <source>%1 hours ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="90"/>
         <source>Yesterday </source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_pl.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_pl.ts
@@ -1,8 +1,9 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pl">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pl">
 <context>
     <name>GroupNotify</name>
     <message>
-        <location filename="../GroupNotify.qml" line="51"/>
         <source>Clear All</source>
         <translation>Wyczyść wszystko</translation>
     </message>
@@ -10,12 +11,10 @@
 <context>
     <name>NotifyHeader</name>
     <message>
-        <location filename="../NotifyHeader.qml" line="42"/>
         <source>Notification Center</source>
         <translation>Centrum powiadomień</translation>
     </message>
     <message>
-        <location filename="../NotifyHeader.qml" line="90"/>
         <source>Clear All</source>
         <translation>Wyczyść wszystko</translation>
     </message>
@@ -23,17 +22,14 @@
 <context>
     <name>NotifySetting</name>
     <message>
-        <location filename="../NotifySetting.qml" line="18"/>
         <source>Unpin</source>
         <translation>Odepnij</translation>
     </message>
     <message>
-        <location filename="../NotifySetting.qml" line="18"/>
         <source>Pin</source>
         <translation>Przypnij</translation>
     </message>
     <message>
-        <location filename="../NotifySetting.qml" line="26"/>
         <source>Notification Setting</source>
         <translation>Ustawienia powiadomień</translation>
     </message>
@@ -41,27 +37,22 @@
 <context>
     <name>notifycenter::AppNotifyItem</name>
     <message>
-        <location filename="../notifyitem.cpp" line="78"/>
         <source>Just now</source>
         <translation>Właśnie teraz</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="80"/>
         <source>%1 minutes ago</source>
         <translation>%1 minut temu</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="84"/>
         <source>1 hour ago</source>
         <translation>1 godzinę temu</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="86"/>
         <source>%1 hours ago</source>
         <translation>%1 godzin temu</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="90"/>
         <source>Yesterday </source>
         <translation>Wczoraj </translation>
     </message>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_pt_BR.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_pt_BR.ts
@@ -1,8 +1,9 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pt_BR">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pt_BR">
 <context>
     <name>GroupNotify</name>
     <message>
-        <location filename="../GroupNotify.qml" line="51"/>
         <source>Clear All</source>
         <translation>Limpar tudo</translation>
     </message>
@@ -10,12 +11,10 @@
 <context>
     <name>NotifyHeader</name>
     <message>
-        <location filename="../NotifyHeader.qml" line="42"/>
         <source>Notification Center</source>
         <translation>Central de Notificações</translation>
     </message>
     <message>
-        <location filename="../NotifyHeader.qml" line="90"/>
         <source>Clear All</source>
         <translation>Limpar tudo</translation>
     </message>
@@ -23,17 +22,14 @@
 <context>
     <name>NotifySetting</name>
     <message>
-        <location filename="../NotifySetting.qml" line="18"/>
         <source>Unpin</source>
         <translation>Desafixar</translation>
     </message>
     <message>
-        <location filename="../NotifySetting.qml" line="18"/>
         <source>Pin</source>
         <translation>Fixar</translation>
     </message>
     <message>
-        <location filename="../NotifySetting.qml" line="26"/>
         <source>Notification Setting</source>
         <translation>Configurações de Notificações</translation>
     </message>
@@ -41,27 +37,22 @@
 <context>
     <name>notifycenter::AppNotifyItem</name>
     <message>
-        <location filename="../notifyitem.cpp" line="78"/>
         <source>Just now</source>
         <translation>Há pouco</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="80"/>
         <source>%1 minutes ago</source>
         <translation>%1 minutos atrás</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="84"/>
         <source>1 hour ago</source>
         <translation>1 hora atrás</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="86"/>
         <source>%1 hours ago</source>
         <translation>%1 horas atrás</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="90"/>
         <source>Yesterday </source>
         <translation>Ontem</translation>
     </message>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_ru.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_ru.ts
@@ -1,8 +1,9 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ru">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ru">
 <context>
     <name>GroupNotify</name>
     <message>
-        <location filename="../GroupNotify.qml" line="51"/>
         <source>Clear All</source>
         <translation>Очистить всё</translation>
     </message>
@@ -10,12 +11,10 @@
 <context>
     <name>NotifyHeader</name>
     <message>
-        <location filename="../NotifyHeader.qml" line="42"/>
         <source>Notification Center</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../NotifyHeader.qml" line="90"/>
         <source>Clear All</source>
         <translation>Очистить всё</translation>
     </message>
@@ -23,45 +22,37 @@
 <context>
     <name>NotifySetting</name>
     <message>
-        <location filename="../NotifySetting.qml" line="18"/>
         <source>Unpin</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../NotifySetting.qml" line="18"/>
         <source>Pin</source>
         <translation>Прикрепить</translation>
     </message>
     <message>
-        <location filename="../NotifySetting.qml" line="26"/>
         <source>Notification Setting</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>notifycenter::AppNotifyItem</name>
     <message>
-        <location filename="../notifyitem.cpp" line="78"/>
         <source>Just now</source>
         <translation>Сейчас</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="80"/>
         <source>%1 minutes ago</source>
         <translation>%1 минут назад</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="84"/>
         <source>1 hour ago</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="86"/>
         <source>%1 hours ago</source>
         <translation>1% часов назад</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="90"/>
         <source>Yesterday </source>
         <translation>Вчера</translation>
     </message>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_uk.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_uk.ts
@@ -1,8 +1,9 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="uk">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="uk">
 <context>
     <name>GroupNotify</name>
     <message>
-        <location filename="../GroupNotify.qml" line="51"/>
         <source>Clear All</source>
         <translation>Вилучити все</translation>
     </message>
@@ -10,12 +11,10 @@
 <context>
     <name>NotifyHeader</name>
     <message>
-        <location filename="../NotifyHeader.qml" line="42"/>
         <source>Notification Center</source>
         <translation>Центр сповіщень</translation>
     </message>
     <message>
-        <location filename="../NotifyHeader.qml" line="90"/>
         <source>Clear All</source>
         <translation>Вилучити все</translation>
     </message>
@@ -23,17 +22,14 @@
 <context>
     <name>NotifySetting</name>
     <message>
-        <location filename="../NotifySetting.qml" line="18"/>
         <source>Unpin</source>
         <translation>Відшпилити</translation>
     </message>
     <message>
-        <location filename="../NotifySetting.qml" line="18"/>
         <source>Pin</source>
         <translation>Пришпилити</translation>
     </message>
     <message>
-        <location filename="../NotifySetting.qml" line="26"/>
         <source>Notification Setting</source>
         <translation>Параметри сповіщень</translation>
     </message>
@@ -41,27 +37,22 @@
 <context>
     <name>notifycenter::AppNotifyItem</name>
     <message>
-        <location filename="../notifyitem.cpp" line="78"/>
         <source>Just now</source>
         <translation>Щойно</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="80"/>
         <source>%1 minutes ago</source>
         <translation>%1 хвилин тому</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="84"/>
         <source>1 hour ago</source>
         <translation>1 годину тому</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="86"/>
         <source>%1 hours ago</source>
         <translation>%1 годин тому</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="90"/>
         <source>Yesterday </source>
         <translation>Вчора</translation>
     </message>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_zh_CN.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_zh_CN.ts
@@ -1,8 +1,9 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_CN">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_CN">
 <context>
     <name>GroupNotify</name>
     <message>
-        <location filename="../GroupNotify.qml" line="51"/>
         <source>Clear All</source>
         <translation>全部清除</translation>
     </message>
@@ -10,12 +11,10 @@
 <context>
     <name>NotifyHeader</name>
     <message>
-        <location filename="../NotifyHeader.qml" line="42"/>
         <source>Notification Center</source>
         <translation>通知中心</translation>
     </message>
     <message>
-        <location filename="../NotifyHeader.qml" line="90"/>
         <source>Clear All</source>
         <translation>全部清除</translation>
     </message>
@@ -23,17 +22,14 @@
 <context>
     <name>NotifySetting</name>
     <message>
-        <location filename="../NotifySetting.qml" line="18"/>
         <source>Unpin</source>
         <translation>取消置顶</translation>
     </message>
     <message>
-        <location filename="../NotifySetting.qml" line="18"/>
         <source>Pin</source>
         <translation>置顶</translation>
     </message>
     <message>
-        <location filename="../NotifySetting.qml" line="26"/>
         <source>Notification Setting</source>
         <translation>通知设置</translation>
     </message>
@@ -41,27 +37,22 @@
 <context>
     <name>notifycenter::AppNotifyItem</name>
     <message>
-        <location filename="../notifyitem.cpp" line="78"/>
         <source>Just now</source>
         <translation>刚刚</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="80"/>
         <source>%1 minutes ago</source>
         <translation>%1分钟前</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="84"/>
         <source>1 hour ago</source>
         <translation>1小时前</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="86"/>
         <source>%1 hours ago</source>
         <translation>%1小时前</translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="90"/>
         <source>Yesterday </source>
         <translation>昨天 </translation>
     </message>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_zh_HK.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_zh_HK.ts
@@ -4,7 +4,6 @@
 <context>
     <name>GroupNotify</name>
     <message>
-        <location filename="../GroupNotify.qml" line="51"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12,12 +11,10 @@
 <context>
     <name>NotifyHeader</name>
     <message>
-        <location filename="../NotifyHeader.qml" line="42"/>
         <source>Notification Center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../NotifyHeader.qml" line="90"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -25,17 +22,14 @@
 <context>
     <name>NotifySetting</name>
     <message>
-        <location filename="../NotifySetting.qml" line="18"/>
         <source>Unpin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../NotifySetting.qml" line="18"/>
         <source>Pin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../NotifySetting.qml" line="26"/>
         <source>Notification Setting</source>
         <translation type="unfinished"></translation>
     </message>
@@ -43,27 +37,22 @@
 <context>
     <name>notifycenter::AppNotifyItem</name>
     <message>
-        <location filename="../notifyitem.cpp" line="78"/>
         <source>Just now</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="80"/>
         <source>%1 minutes ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="84"/>
         <source>1 hour ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="86"/>
         <source>%1 hours ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="90"/>
         <source>Yesterday </source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_zh_TW.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_zh_TW.ts
@@ -4,7 +4,6 @@
 <context>
     <name>GroupNotify</name>
     <message>
-        <location filename="../GroupNotify.qml" line="51"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12,12 +11,10 @@
 <context>
     <name>NotifyHeader</name>
     <message>
-        <location filename="../NotifyHeader.qml" line="42"/>
         <source>Notification Center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../NotifyHeader.qml" line="90"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -25,17 +22,14 @@
 <context>
     <name>NotifySetting</name>
     <message>
-        <location filename="../NotifySetting.qml" line="18"/>
         <source>Unpin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../NotifySetting.qml" line="18"/>
         <source>Pin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../NotifySetting.qml" line="26"/>
         <source>Notification Setting</source>
         <translation type="unfinished"></translation>
     </message>
@@ -43,27 +37,22 @@
 <context>
     <name>notifycenter::AppNotifyItem</name>
     <message>
-        <location filename="../notifyitem.cpp" line="78"/>
         <source>Just now</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="80"/>
         <source>%1 minutes ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="84"/>
         <source>1 hour ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="86"/>
         <source>%1 hours ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../notifyitem.cpp" line="90"/>
         <source>Yesterday </source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/notification/osd/default/translations/org.deepin.ds.osd.default.ts
+++ b/panels/notification/osd/default/translations/org.deepin.ds.osd.default.ts
@@ -4,102 +4,82 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="54"/>
         <source>WLAN on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="55"/>
         <source>WLAN off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="56"/>
         <source>Caps Lock on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="57"/>
         <source>Caps Lock off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="58"/>
         <source>Numeric keypad on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="59"/>
         <source>Numeric keypad off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="60"/>
         <source>Touchpad on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="61"/>
         <source>Touchpad off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="62"/>
         <source>Touchpad toggle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="63"/>
         <source>Fn toggle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="64"/>
         <source>Airplane mode on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="65"/>
         <source>Airplane mode off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="66"/>
         <source>Mute on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="67"/>
         <source>Mute off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="68"/>
         <source>Balanced power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="69"/>
         <source>Power saver</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="70"/>
         <source>High performance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="71"/>
         <source>Window effect enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="72"/>
         <source>Window effect disabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="73"/>
         <source>Failed to enable window effects</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/notification/osd/default/translations/org.deepin.ds.osd.default_az.ts
+++ b/panels/notification/osd/default/translations/org.deepin.ds.osd.default_az.ts
@@ -1,103 +1,85 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="az">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="az">
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="54"/>
         <source>WLAN on</source>
         <translation>WLAN مفعل</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="55"/>
         <source>WLAN off</source>
         <translation>WLAN مغلق</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="56"/>
         <source>Caps Lock on</source>
         <translation>فتح 键锁定</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="57"/>
         <source>Caps Lock off</source>
         <translation>غلق 键锁定</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="58"/>
         <source>Numeric keypad on</source>
         <translation>فتح لوحة الأرقام</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="59"/>
         <source>Numeric keypad off</source>
         <translation>غلق لوحة الأرقام</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="60"/>
         <source>Touchpad on</source>
         <translation>فتح لوحة اللمس</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="61"/>
         <source>Touchpad off</source>
         <translation>غلق لوحة اللمس</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="62"/>
         <source>Touchpad toggle</source>
         <translation>GGLE لوحة اللمس</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="63"/>
         <source>Fn toggle</source>
         <translation>GGLE لوحة التحكم</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="64"/>
         <source>Airplane mode on</source>
         <translation>فتح وضع الطائرة</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="65"/>
         <source>Airplane mode off</source>
         <translation>غلق وضع الطائرة</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="66"/>
         <source>Mute on</source>
         <translation>فتح الصمت</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="67"/>
         <source>Mute off</source>
         <translation>غلق الصمت</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="68"/>
         <source>Balanced power</source>
         <translation>طاقة متوازنة</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="69"/>
         <source>Power saver</source>
         <translation>توفير الطاقة</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="70"/>
         <source>High performance</source>
         <translation>أداء عالٍ</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="71"/>
         <source>Window effect enabled</source>
         <translation>تم تفعيل تأثيرات النافذة</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="72"/>
         <source>Window effect disabled</source>
         <translation>تم تعطيل تأثيرات النافذة</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="73"/>
         <source>Failed to enable window effects</source>
         <translation>فشل في تفعيل تأثيرات النافذة</translation>
     </message>

--- a/panels/notification/osd/default/translations/org.deepin.ds.osd.default_bo.ts
+++ b/panels/notification/osd/default/translations/org.deepin.ds.osd.default_bo.ts
@@ -4,102 +4,82 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="54"/>
         <source>WLAN on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="55"/>
         <source>WLAN off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="56"/>
         <source>Caps Lock on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="57"/>
         <source>Caps Lock off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="58"/>
         <source>Numeric keypad on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="59"/>
         <source>Numeric keypad off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="60"/>
         <source>Touchpad on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="61"/>
         <source>Touchpad off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="62"/>
         <source>Touchpad toggle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="63"/>
         <source>Fn toggle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="64"/>
         <source>Airplane mode on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="65"/>
         <source>Airplane mode off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="66"/>
         <source>Mute on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="67"/>
         <source>Mute off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="68"/>
         <source>Balanced power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="69"/>
         <source>Power saver</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="70"/>
         <source>High performance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="71"/>
         <source>Window effect enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="72"/>
         <source>Window effect disabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="73"/>
         <source>Failed to enable window effects</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/notification/osd/default/translations/org.deepin.ds.osd.default_ca.ts
+++ b/panels/notification/osd/default/translations/org.deepin.ds.osd.default_ca.ts
@@ -1,103 +1,85 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ca">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ca">
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="54"/>
         <source>WLAN on</source>
         <translation>WLAN activada</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="55"/>
         <source>WLAN off</source>
         <translation>WLAN desactivada</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="56"/>
         <source>Caps Lock on</source>
         <translation>Blocatge de majúscules activat</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="57"/>
         <source>Caps Lock off</source>
         <translation>Blocatge de majúscules desactivat</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="58"/>
         <source>Numeric keypad on</source>
         <translation>Teclat numèric activat</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="59"/>
         <source>Numeric keypad off</source>
         <translation>Teclat numèric desactivat</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="60"/>
         <source>Touchpad on</source>
         <translation>Ratolí tàctil activat</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="61"/>
         <source>Touchpad off</source>
         <translation>Ratolí tàctil desactivat</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="62"/>
         <source>Touchpad toggle</source>
         <translation>Commuta el ratolí tàctil</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="63"/>
         <source>Fn toggle</source>
         <translation>Commutació d&apos;Fn</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="64"/>
         <source>Airplane mode on</source>
         <translation>Mode d&apos;avió activat</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="65"/>
         <source>Airplane mode off</source>
         <translation>Mode d&apos;avió desactivat</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="66"/>
         <source>Mute on</source>
         <translation>Silenci activat</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="67"/>
         <source>Mute off</source>
         <translation>Silenci desactivat</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="68"/>
         <source>Balanced power</source>
         <translation>Energia equilibrada</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="69"/>
         <source>Power saver</source>
         <translation>Estalviador d&apos;energia</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="70"/>
         <source>High performance</source>
         <translation>Rendiment alt</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="71"/>
         <source>Window effect enabled</source>
         <translation>Efectes de finestra habilitats</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="72"/>
         <source>Window effect disabled</source>
         <translation>Efectes de finestra inhabilitats</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="73"/>
         <source>Failed to enable window effects</source>
         <translation>Ha fallat activar els efectes de les finestres.</translation>
     </message>

--- a/panels/notification/osd/default/translations/org.deepin.ds.osd.default_es.ts
+++ b/panels/notification/osd/default/translations/org.deepin.ds.osd.default_es.ts
@@ -1,103 +1,85 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="es">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="es">
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="54"/>
         <source>WLAN on</source>
         <translation>WLAN encendido</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="55"/>
         <source>WLAN off</source>
         <translation>WLAN apagado</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="56"/>
         <source>Caps Lock on</source>
         <translation>Bloq Mayús activado</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="57"/>
         <source>Caps Lock off</source>
         <translation>Bloq Mayús desactivado</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="58"/>
         <source>Numeric keypad on</source>
         <translation>Teclado numérico activado</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="59"/>
         <source>Numeric keypad off</source>
         <translation>Teclado numérico desactivado</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="60"/>
         <source>Touchpad on</source>
         <translation>Panel táctil activado.</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="61"/>
         <source>Touchpad off</source>
         <translation>Panel táctil desactivado.</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="62"/>
         <source>Touchpad toggle</source>
         <translation>Alternar panel táctil</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="63"/>
         <source>Fn toggle</source>
         <translation>Alternar Fn</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="64"/>
         <source>Airplane mode on</source>
         <translation>Modo avión activado</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="65"/>
         <source>Airplane mode off</source>
         <translation>Modo avión desactivado.</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="66"/>
         <source>Mute on</source>
         <translation>Silencio activado.</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="67"/>
         <source>Mute off</source>
         <translation>Silencio desactivado.</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="68"/>
         <source>Balanced power</source>
         <translation>Energía equilibrada</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="69"/>
         <source>Power saver</source>
         <translation>Ahorro de energía</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="70"/>
         <source>High performance</source>
         <translation>Alto rendimiento</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="71"/>
         <source>Window effect enabled</source>
         <translation>Efectos de ventana activados</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="72"/>
         <source>Window effect disabled</source>
         <translation>Efectos de ventana desactivados</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="73"/>
         <source>Failed to enable window effects</source>
         <translation>Error al activar efectos de ventana</translation>
     </message>

--- a/panels/notification/osd/default/translations/org.deepin.ds.osd.default_fi.ts
+++ b/panels/notification/osd/default/translations/org.deepin.ds.osd.default_fi.ts
@@ -1,103 +1,85 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="fi">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fi">
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="54"/>
         <source>WLAN on</source>
         <translation>WLAN päällä</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="55"/>
         <source>WLAN off</source>
         <translation>WLAN pois</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="56"/>
         <source>Caps Lock on</source>
         <translation>Caps Lock päällä</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="57"/>
         <source>Caps Lock off</source>
         <translation>Caps Lock pois</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="58"/>
         <source>Numeric keypad on</source>
         <translation>Numeronäppäimet päällä</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="59"/>
         <source>Numeric keypad off</source>
         <translation>Numeronäppäimet pois</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="60"/>
         <source>Touchpad on</source>
         <translation>Kosketuslevy päällä</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="61"/>
         <source>Touchpad off</source>
         <translation>Kosketuslevy pois</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="62"/>
         <source>Touchpad toggle</source>
         <translation>Kosketuslevy painike</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="63"/>
         <source>Fn toggle</source>
         <translation>Fn-painike</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="64"/>
         <source>Airplane mode on</source>
         <translation>Lentotila päällä</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="65"/>
         <source>Airplane mode off</source>
         <translation>Lentotila pois</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="66"/>
         <source>Mute on</source>
         <translation>Mykistys päällä</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="67"/>
         <source>Mute off</source>
         <translation>Mykistys pois</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="68"/>
         <source>Balanced power</source>
         <translation>Tasapainoinen teho</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="69"/>
         <source>Power saver</source>
         <translation>Virransäästö</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="70"/>
         <source>High performance</source>
         <translation>Korkea suoritusteho</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="71"/>
         <source>Window effect enabled</source>
         <translation>Ikkunatehosteet käytössä</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="72"/>
         <source>Window effect disabled</source>
         <translation>Ikkunatehosteet poistettu</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="73"/>
         <source>Failed to enable window effects</source>
         <translation>Ikkunatehosteiden käyttöönotto epäonnistui</translation>
     </message>

--- a/panels/notification/osd/default/translations/org.deepin.ds.osd.default_fr.ts
+++ b/panels/notification/osd/default/translations/org.deepin.ds.osd.default_fr.ts
@@ -1,103 +1,85 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="fr">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fr">
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="54"/>
         <source>WLAN on</source>
         <translation>Wifi activé</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="55"/>
         <source>WLAN off</source>
         <translation>Wifi désactivé</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="56"/>
         <source>Caps Lock on</source>
         <translation>Verrouillage majuscules activé</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="57"/>
         <source>Caps Lock off</source>
         <translation>Verrouillage majuscules désactivé</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="58"/>
         <source>Numeric keypad on</source>
         <translation>Pavé numérique activé</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="59"/>
         <source>Numeric keypad off</source>
         <translation>Pavé numérique désactivé</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="60"/>
         <source>Touchpad on</source>
         <translation>Pavé tactile activé</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="61"/>
         <source>Touchpad off</source>
         <translation>Pavé tactile désactivé</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="62"/>
         <source>Touchpad toggle</source>
         <translation>Basculer le pavé tactile</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="63"/>
         <source>Fn toggle</source>
         <translation>Basculer les touches Fn</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="64"/>
         <source>Airplane mode on</source>
         <translation>Mode avion activé</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="65"/>
         <source>Airplane mode off</source>
         <translation>Mode avion désactivé</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="66"/>
         <source>Mute on</source>
         <translation>Sourdine activée</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="67"/>
         <source>Mute off</source>
         <translation>Sourdine désactivée</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="68"/>
         <source>Balanced power</source>
         <translation>Mode d&apos;énergie équilibré</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="69"/>
         <source>Power saver</source>
         <translation>Mode d&apos;économie d&apos;énergie</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="70"/>
         <source>High performance</source>
         <translation>Mode haute performance</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="71"/>
         <source>Window effect enabled</source>
         <translation>Effets de fenêtres activés</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="72"/>
         <source>Window effect disabled</source>
         <translation>Effets de fenêtres désactivés</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="73"/>
         <source>Failed to enable window effects</source>
         <translation>Impossible d&apos;activer les effets de fenêtres</translation>
     </message>

--- a/panels/notification/osd/default/translations/org.deepin.ds.osd.default_hu.ts
+++ b/panels/notification/osd/default/translations/org.deepin.ds.osd.default_hu.ts
@@ -1,103 +1,85 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="hu">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="hu">
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="54"/>
         <source>WLAN on</source>
         <translation>Vezeték nélküli hálózat bekapcsolva</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="55"/>
         <source>WLAN off</source>
         <translation>Vezeték nélküli hálózat kikapcsolva</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="56"/>
         <source>Caps Lock on</source>
         <translation>Caps Lock bekapcsolva</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="57"/>
         <source>Caps Lock off</source>
         <translation>Caps Lock kikapcsolva</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="58"/>
         <source>Numeric keypad on</source>
         <translation>Számbillentyűzet bekapcsolva</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="59"/>
         <source>Numeric keypad off</source>
         <translation>Számbillentyűzet kikapcsolva</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="60"/>
         <source>Touchpad on</source>
         <translation>Érintőpad bekapcsolva</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="61"/>
         <source>Touchpad off</source>
         <translation>Érintőpad kikapcsolva</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="62"/>
         <source>Touchpad toggle</source>
         <translation>Érintőpad gombok</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="63"/>
         <source>Fn toggle</source>
         <translation>Funkció kapcsoló</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="64"/>
         <source>Airplane mode on</source>
         <translation>Repülőgép üzemmód bekapcsolva</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="65"/>
         <source>Airplane mode off</source>
         <translation>Repülőgép üzemmód kikapcsolva</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="66"/>
         <source>Mute on</source>
         <translation>Némítás bekapcsolva</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="67"/>
         <source>Mute off</source>
         <translation>Némítás kikapcsolva</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="68"/>
         <source>Balanced power</source>
         <translation>Kiegyensúlyozott teljesítmény</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="69"/>
         <source>Power saver</source>
         <translation>Energiatakarékos mód</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="70"/>
         <source>High performance</source>
         <translation>Magas teljesítmény </translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="71"/>
         <source>Window effect enabled</source>
         <translation>Az ablakeffektusok engedélyezve</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="72"/>
         <source>Window effect disabled</source>
         <translation>Az ablakeffektusok letiltva</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="73"/>
         <source>Failed to enable window effects</source>
         <translation>Az ablakeffektusok engedélyezése sikertelen</translation>
     </message>

--- a/panels/notification/osd/default/translations/org.deepin.ds.osd.default_it.ts
+++ b/panels/notification/osd/default/translations/org.deepin.ds.osd.default_it.ts
@@ -4,102 +4,82 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="54"/>
         <source>WLAN on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="55"/>
         <source>WLAN off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="56"/>
         <source>Caps Lock on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="57"/>
         <source>Caps Lock off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="58"/>
         <source>Numeric keypad on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="59"/>
         <source>Numeric keypad off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="60"/>
         <source>Touchpad on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="61"/>
         <source>Touchpad off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="62"/>
         <source>Touchpad toggle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="63"/>
         <source>Fn toggle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="64"/>
         <source>Airplane mode on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="65"/>
         <source>Airplane mode off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="66"/>
         <source>Mute on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="67"/>
         <source>Mute off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="68"/>
         <source>Balanced power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="69"/>
         <source>Power saver</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="70"/>
         <source>High performance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="71"/>
         <source>Window effect enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="72"/>
         <source>Window effect disabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="73"/>
         <source>Failed to enable window effects</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/notification/osd/default/translations/org.deepin.ds.osd.default_ja.ts
+++ b/panels/notification/osd/default/translations/org.deepin.ds.osd.default_ja.ts
@@ -1,103 +1,85 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ja">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ja">
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="54"/>
         <source>WLAN on</source>
         <translation>無線LAN ON</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="55"/>
         <source>WLAN off</source>
         <translation>無線LAN OFF</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="56"/>
         <source>Caps Lock on</source>
         <translation>Caps Lock ON</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="57"/>
         <source>Caps Lock off</source>
         <translation>Caps Lock OFF</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="58"/>
         <source>Numeric keypad on</source>
         <translation>テンキー ON</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="59"/>
         <source>Numeric keypad off</source>
         <translation>テンキー OFF</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="60"/>
         <source>Touchpad on</source>
         <translation>タッチパッド ON</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="61"/>
         <source>Touchpad off</source>
         <translation>タッチパッド OFF</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="62"/>
         <source>Touchpad toggle</source>
         <translation>タッチパッド トグル</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="63"/>
         <source>Fn toggle</source>
         <translation>Fn トグル</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="64"/>
         <source>Airplane mode on</source>
         <translation>機内モード ON</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="65"/>
         <source>Airplane mode off</source>
         <translation>機内モードOFF</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="66"/>
         <source>Mute on</source>
         <translation>ミュート ON</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="67"/>
         <source>Mute off</source>
         <translation>ミュート OFF</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="68"/>
         <source>Balanced power</source>
         <translation>バランス</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="69"/>
         <source>Power saver</source>
         <translation>省電力</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="70"/>
         <source>High performance</source>
         <translation>高パフォーマンス</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="71"/>
         <source>Window effect enabled</source>
         <translation>ウィンドウ エフェクトが有効化されました</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="72"/>
         <source>Window effect disabled</source>
         <translation>ウィンドウ エフェクト が無効化されました</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="73"/>
         <source>Failed to enable window effects</source>
         <translation>ウィンドウ エフェクトを有効化できませんでした</translation>
     </message>

--- a/panels/notification/osd/default/translations/org.deepin.ds.osd.default_ko.ts
+++ b/panels/notification/osd/default/translations/org.deepin.ds.osd.default_ko.ts
@@ -4,102 +4,82 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="54"/>
         <source>WLAN on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="55"/>
         <source>WLAN off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="56"/>
         <source>Caps Lock on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="57"/>
         <source>Caps Lock off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="58"/>
         <source>Numeric keypad on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="59"/>
         <source>Numeric keypad off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="60"/>
         <source>Touchpad on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="61"/>
         <source>Touchpad off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="62"/>
         <source>Touchpad toggle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="63"/>
         <source>Fn toggle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="64"/>
         <source>Airplane mode on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="65"/>
         <source>Airplane mode off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="66"/>
         <source>Mute on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="67"/>
         <source>Mute off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="68"/>
         <source>Balanced power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="69"/>
         <source>Power saver</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="70"/>
         <source>High performance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="71"/>
         <source>Window effect enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="72"/>
         <source>Window effect disabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="73"/>
         <source>Failed to enable window effects</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/notification/osd/default/translations/org.deepin.ds.osd.default_nb_NO.ts
+++ b/panels/notification/osd/default/translations/org.deepin.ds.osd.default_nb_NO.ts
@@ -4,102 +4,82 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="54"/>
         <source>WLAN on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="55"/>
         <source>WLAN off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="56"/>
         <source>Caps Lock on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="57"/>
         <source>Caps Lock off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="58"/>
         <source>Numeric keypad on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="59"/>
         <source>Numeric keypad off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="60"/>
         <source>Touchpad on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="61"/>
         <source>Touchpad off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="62"/>
         <source>Touchpad toggle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="63"/>
         <source>Fn toggle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="64"/>
         <source>Airplane mode on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="65"/>
         <source>Airplane mode off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="66"/>
         <source>Mute on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="67"/>
         <source>Mute off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="68"/>
         <source>Balanced power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="69"/>
         <source>Power saver</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="70"/>
         <source>High performance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="71"/>
         <source>Window effect enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="72"/>
         <source>Window effect disabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="73"/>
         <source>Failed to enable window effects</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/notification/osd/default/translations/org.deepin.ds.osd.default_pl.ts
+++ b/panels/notification/osd/default/translations/org.deepin.ds.osd.default_pl.ts
@@ -1,103 +1,85 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pl">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pl">
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="54"/>
         <source>WLAN on</source>
         <translation>WLAN włączony</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="55"/>
         <source>WLAN off</source>
         <translation>WLAN wyłączony</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="56"/>
         <source>Caps Lock on</source>
         <translation>Caps Lock włączony</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="57"/>
         <source>Caps Lock off</source>
         <translation>Caps Lock wyłączony</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="58"/>
         <source>Numeric keypad on</source>
         <translation>Klawiatura numeryczna włączona</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="59"/>
         <source>Numeric keypad off</source>
         <translation>Klawiatura numeryczna wyłączona</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="60"/>
         <source>Touchpad on</source>
         <translation>Panel dotykowy włączony</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="61"/>
         <source>Touchpad off</source>
         <translation>Panel dotykowy wyłączony</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="62"/>
         <source>Touchpad toggle</source>
         <translation>Przełączanie panela dotykowego</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="63"/>
         <source>Fn toggle</source>
         <translation>Przełącznik Fn</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="64"/>
         <source>Airplane mode on</source>
         <translation>Tryb samolotowy włączony</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="65"/>
         <source>Airplane mode off</source>
         <translation>Tryb samolotowy wyłączony</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="66"/>
         <source>Mute on</source>
         <translation>Wyciszenie włączone</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="67"/>
         <source>Mute off</source>
         <translation>Wyciszenie wyłączone</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="68"/>
         <source>Balanced power</source>
         <translation>Zasilanie zrównoważone</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="69"/>
         <source>Power saver</source>
         <translation>Oszczędność energii</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="70"/>
         <source>High performance</source>
         <translation>Wysoka wydajność</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="71"/>
         <source>Window effect enabled</source>
         <translation>Włączono efekty okna</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="72"/>
         <source>Window effect disabled</source>
         <translation>Wyłączono efekty okna</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="73"/>
         <source>Failed to enable window effects</source>
         <translation>Nie udało się włączyć niektórych efektów okna</translation>
     </message>

--- a/panels/notification/osd/default/translations/org.deepin.ds.osd.default_pt_BR.ts
+++ b/panels/notification/osd/default/translations/org.deepin.ds.osd.default_pt_BR.ts
@@ -1,103 +1,85 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pt_BR">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pt_BR">
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="54"/>
         <source>WLAN on</source>
         <translation>Wi-Fi ativado</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="55"/>
         <source>WLAN off</source>
         <translation>Wi-Fi desativado</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="56"/>
         <source>Caps Lock on</source>
         <translation>Caps Lock ativado</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="57"/>
         <source>Caps Lock off</source>
         <translation>Caps Lock desativado</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="58"/>
         <source>Numeric keypad on</source>
         <translation>Teclado numérico ativado</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="59"/>
         <source>Numeric keypad off</source>
         <translation>Teclado numérico desativado</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="60"/>
         <source>Touchpad on</source>
         <translation>Touchpad ativado</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="61"/>
         <source>Touchpad off</source>
         <translation>Touchpad desativado</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="62"/>
         <source>Touchpad toggle</source>
         <translation>Alternar touchpad</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="63"/>
         <source>Fn toggle</source>
         <translation>Alternar Fn</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="64"/>
         <source>Airplane mode on</source>
         <translation>Modo avião ativado</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="65"/>
         <source>Airplane mode off</source>
         <translation>Modo avião desativado</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="66"/>
         <source>Mute on</source>
         <translation>Mudo ativado</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="67"/>
         <source>Mute off</source>
         <translation>Mudo desativado</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="68"/>
         <source>Balanced power</source>
         <translation>Equilibrado</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="69"/>
         <source>Power saver</source>
         <translation>Economia de energia</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="70"/>
         <source>High performance</source>
         <translation>Alto desempenho</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="71"/>
         <source>Window effect enabled</source>
         <translation>Efeitos visuais ativados</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="72"/>
         <source>Window effect disabled</source>
         <translation>Efeitos visuais desativados</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="73"/>
         <source>Failed to enable window effects</source>
         <translation>Falha ao ativar os efeitos visuais</translation>
     </message>

--- a/panels/notification/osd/default/translations/org.deepin.ds.osd.default_ru.ts
+++ b/panels/notification/osd/default/translations/org.deepin.ds.osd.default_ru.ts
@@ -1,103 +1,85 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ru">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ru">
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="54"/>
         <source>WLAN on</source>
         <translation>WLAN вкл</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="55"/>
         <source>WLAN off</source>
         <translation>WLAN выкл</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="56"/>
         <source>Caps Lock on</source>
         <translation>Caps Lock вкл</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="57"/>
         <source>Caps Lock off</source>
         <translation>Caps Lock выкл</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="58"/>
         <source>Numeric keypad on</source>
         <translation>Цифровая клавиатура вкл</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="59"/>
         <source>Numeric keypad off</source>
         <translation>Цифровая клавиатура выкл</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="60"/>
         <source>Touchpad on</source>
         <translation>Тачпад вкл</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="61"/>
         <source>Touchpad off</source>
         <translation>Тачпад выкл</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="62"/>
         <source>Touchpad toggle</source>
         <translation>Переключатель тачпада</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="63"/>
         <source>Fn toggle</source>
         <translation>Переключатель Fn</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="64"/>
         <source>Airplane mode on</source>
         <translation>Авиарежим вкл </translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="65"/>
         <source>Airplane mode off</source>
         <translation>Авиарежим выкл </translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="66"/>
         <source>Mute on</source>
         <translation>Звук выкл</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="67"/>
         <source>Mute off</source>
         <translation>Звук вкл</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="68"/>
         <source>Balanced power</source>
         <translation>Сбалансированный режим</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="69"/>
         <source>Power saver</source>
         <translation>Экономия заряда</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="70"/>
         <source>High performance</source>
         <translation>Высокая производительность</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="71"/>
         <source>Window effect enabled</source>
         <translation>Оконные эффекты вкл</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="72"/>
         <source>Window effect disabled</source>
         <translation>Оконные эффекты выкл</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="73"/>
         <source>Failed to enable window effects</source>
         <translation>Не удалось включить эффекты окон</translation>
     </message>

--- a/panels/notification/osd/default/translations/org.deepin.ds.osd.default_uk.ts
+++ b/panels/notification/osd/default/translations/org.deepin.ds.osd.default_uk.ts
@@ -1,103 +1,85 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="uk">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="uk">
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="54"/>
         <source>WLAN on</source>
         <translation>WLAN увімкнено</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="55"/>
         <source>WLAN off</source>
         <translation>WLAN вимкнено</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="56"/>
         <source>Caps Lock on</source>
         <translation>Caps Lock увімкнено</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="57"/>
         <source>Caps Lock off</source>
         <translation>Caps Lock вимкнено</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="58"/>
         <source>Numeric keypad on</source>
         <translation>Цифрову панель увімкнено</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="59"/>
         <source>Numeric keypad off</source>
         <translation>Цифрову панель вимкнено</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="60"/>
         <source>Touchpad on</source>
         <translation>Сенсорну панель увімкнено</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="61"/>
         <source>Touchpad off</source>
         <translation>Сенсорну панель вимкнено</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="62"/>
         <source>Touchpad toggle</source>
         <translation>Перемикач сенсорної панелі</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="63"/>
         <source>Fn toggle</source>
         <translation>Перемикач Fn</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="64"/>
         <source>Airplane mode on</source>
         <translation>Режим польоту увімкнено</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="65"/>
         <source>Airplane mode off</source>
         <translation>Режим польоту вимкнено</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="66"/>
         <source>Mute on</source>
         <translation>Вимикання звуку увімкнено</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="67"/>
         <source>Mute off</source>
         <translation>Вимикання звуку вимкнено</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="68"/>
         <source>Balanced power</source>
         <translation>Збалансоване живлення</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="69"/>
         <source>Power saver</source>
         <translation>Заощадження енергії</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="70"/>
         <source>High performance</source>
         <translation>Висока швидкодія</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="71"/>
         <source>Window effect enabled</source>
         <translation>Ефект вікна увімкнений</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="72"/>
         <source>Window effect disabled</source>
         <translation>Ефект вікна вимкнений</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="73"/>
         <source>Failed to enable window effects</source>
         <translation>Не вдалося увімкнути ефекти вікон</translation>
     </message>

--- a/panels/notification/osd/default/translations/org.deepin.ds.osd.default_zh_CN.ts
+++ b/panels/notification/osd/default/translations/org.deepin.ds.osd.default_zh_CN.ts
@@ -1,103 +1,85 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_CN">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_CN">
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="54"/>
         <source>WLAN on</source>
         <translation>打开wifi</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="55"/>
         <source>WLAN off</source>
         <translation>关闭wifi</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="56"/>
         <source>Caps Lock on</source>
         <translation>大写</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="57"/>
         <source>Caps Lock off</source>
         <translation>小写</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="58"/>
         <source>Numeric keypad on</source>
         <translation>打开数字键盘</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="59"/>
         <source>Numeric keypad off</source>
         <translation>关闭数字键盘</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="60"/>
         <source>Touchpad on</source>
         <translation>打开触控板</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="61"/>
         <source>Touchpad off</source>
         <translation>关闭触控板</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="62"/>
         <source>Touchpad toggle</source>
         <translation>触摸板切换</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="63"/>
         <source>Fn toggle</source>
         <translation>Fn切换</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="64"/>
         <source>Airplane mode on</source>
         <translation>打开飞行模式</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="65"/>
         <source>Airplane mode off</source>
         <translation>关闭飞行模式</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="66"/>
         <source>Mute on</source>
         <translation>开启静音</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="67"/>
         <source>Mute off</source>
         <translation>关闭静音</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="68"/>
         <source>Balanced power</source>
         <translation>平衡模式</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="69"/>
         <source>Power saver</source>
         <translation>省电模式</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="70"/>
         <source>High performance</source>
         <translation>性能模式</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="71"/>
         <source>Window effect enabled</source>
         <translation>开启窗口特效</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="72"/>
         <source>Window effect disabled</source>
         <translation>关闭窗口特效</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="73"/>
         <source>Failed to enable window effects</source>
         <translation>打开窗口特效失败</translation>
     </message>

--- a/panels/notification/osd/default/translations/org.deepin.ds.osd.default_zh_HK.ts
+++ b/panels/notification/osd/default/translations/org.deepin.ds.osd.default_zh_HK.ts
@@ -1,103 +1,85 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_HK">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_HK">
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="54"/>
         <source>WLAN on</source>
         <translation>打開wifi</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="55"/>
         <source>WLAN off</source>
         <translation>關閉wifi</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="56"/>
         <source>Caps Lock on</source>
         <translation>大寫</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="57"/>
         <source>Caps Lock off</source>
         <translation>小寫</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="58"/>
         <source>Numeric keypad on</source>
         <translation>打開數字鍵盤</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="59"/>
         <source>Numeric keypad off</source>
         <translation>關閉數字鍵盤</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="60"/>
         <source>Touchpad on</source>
         <translation>打開觸控板</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="61"/>
         <source>Touchpad off</source>
         <translation>關閉觸控板</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="62"/>
         <source>Touchpad toggle</source>
         <translation>觸控板切換</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="63"/>
         <source>Fn toggle</source>
         <translation>Fn切換</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="64"/>
         <source>Airplane mode on</source>
         <translation>開啟飛航模式</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="65"/>
         <source>Airplane mode off</source>
         <translation>關閉飛航模式</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="66"/>
         <source>Mute on</source>
         <translation>開啟靜音</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="67"/>
         <source>Mute off</source>
         <translation>關閉靜音</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="68"/>
         <source>Balanced power</source>
         <translation>平衡模式</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="69"/>
         <source>Power saver</source>
         <translation>省電模式</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="70"/>
         <source>High performance</source>
         <translation>高性能模式</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="71"/>
         <source>Window effect enabled</source>
         <translation>打開窗口特效</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="72"/>
         <source>Window effect disabled</source>
         <translation>關閉窗口特效</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="73"/>
         <source>Failed to enable window effects</source>
         <translation>打開窗口特效失敗</translation>
     </message>

--- a/panels/notification/osd/default/translations/org.deepin.ds.osd.default_zh_TW.ts
+++ b/panels/notification/osd/default/translations/org.deepin.ds.osd.default_zh_TW.ts
@@ -1,103 +1,85 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_TW">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_TW">
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="54"/>
         <source>WLAN on</source>
         <translation>打開wifi</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="55"/>
         <source>WLAN off</source>
         <translation>關閉wifi</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="56"/>
         <source>Caps Lock on</source>
         <translation>大寫</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="57"/>
         <source>Caps Lock off</source>
         <translation>小寫</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="58"/>
         <source>Numeric keypad on</source>
         <translation>打開數字鍵盤</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="59"/>
         <source>Numeric keypad off</source>
         <translation>關閉數字鍵盤</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="60"/>
         <source>Touchpad on</source>
         <translation>打開觸控板</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="61"/>
         <source>Touchpad off</source>
         <translation>關閉觸控板</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="62"/>
         <source>Touchpad toggle</source>
         <translation>觸控板切換</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="63"/>
         <source>Fn toggle</source>
         <translation>Fn切換</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="64"/>
         <source>Airplane mode on</source>
         <translation>開啟飛航模式</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="65"/>
         <source>Airplane mode off</source>
         <translation>關閉飛航模式</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="66"/>
         <source>Mute on</source>
         <translation>開啟靜音</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="67"/>
         <source>Mute off</source>
         <translation>關閉靜音</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="68"/>
         <source>Balanced power</source>
         <translation>平衡模式</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="69"/>
         <source>Power saver</source>
         <translation>省電模式</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="70"/>
         <source>High performance</source>
         <translation>高性能模式</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="71"/>
         <source>Window effect enabled</source>
         <translation>打開窗口特效</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="72"/>
         <source>Window effect disabled</source>
         <translation>關閉窗口特效</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="73"/>
         <source>Failed to enable window effects</source>
         <translation>打開窗口特效失敗</translation>
     </message>

--- a/panels/notification/osd/displaymode/translations/org.deepin.ds.osd.displaymode.ts
+++ b/panels/notification/osd/displaymode/translations/org.deepin.ds.osd.displaymode.ts
@@ -4,17 +4,14 @@
 <context>
     <name>osd::DisPlayModeApplet</name>
     <message>
-        <location filename="../displaymodeapplet.cpp" line="151"/>
         <source>Duplicate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../displaymodeapplet.cpp" line="152"/>
         <source>Extend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../displaymodeapplet.cpp" line="157"/>
         <source>Only on %1</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/notification/osd/displaymode/translations/org.deepin.ds.osd.displaymode_az.ts
+++ b/panels/notification/osd/displaymode/translations/org.deepin.ds.osd.displaymode_az.ts
@@ -1,18 +1,17 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="az">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="az">
 <context>
     <name>osd::DisPlayModeApplet</name>
     <message>
-        <location filename="../displaymodeapplet.cpp" line="151"/>
         <source>Duplicate</source>
         <translation>إعادة إنتاج</translation>
     </message>
     <message>
-        <location filename="../displaymodeapplet.cpp" line="152"/>
         <source>Extend</source>
         <translation>تمتد</translation>
     </message>
     <message>
-        <location filename="../displaymodeapplet.cpp" line="157"/>
         <source>Only on %1</source>
         <translation>فقط على %1</translation>
     </message>

--- a/panels/notification/osd/displaymode/translations/org.deepin.ds.osd.displaymode_bo.ts
+++ b/panels/notification/osd/displaymode/translations/org.deepin.ds.osd.displaymode_bo.ts
@@ -4,17 +4,14 @@
 <context>
     <name>osd::DisPlayModeApplet</name>
     <message>
-        <location filename="../displaymodeapplet.cpp" line="151"/>
         <source>Duplicate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../displaymodeapplet.cpp" line="152"/>
         <source>Extend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../displaymodeapplet.cpp" line="157"/>
         <source>Only on %1</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/notification/osd/displaymode/translations/org.deepin.ds.osd.displaymode_ca.ts
+++ b/panels/notification/osd/displaymode/translations/org.deepin.ds.osd.displaymode_ca.ts
@@ -1,18 +1,17 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ca">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ca">
 <context>
     <name>osd::DisPlayModeApplet</name>
     <message>
-        <location filename="../displaymodeapplet.cpp" line="151"/>
         <source>Duplicate</source>
         <translation>Duplica</translation>
     </message>
     <message>
-        <location filename="../displaymodeapplet.cpp" line="152"/>
         <source>Extend</source>
         <translation>Estén</translation>
     </message>
     <message>
-        <location filename="../displaymodeapplet.cpp" line="157"/>
         <source>Only on %1</source>
         <translation>Només a %1</translation>
     </message>

--- a/panels/notification/osd/displaymode/translations/org.deepin.ds.osd.displaymode_es.ts
+++ b/panels/notification/osd/displaymode/translations/org.deepin.ds.osd.displaymode_es.ts
@@ -1,18 +1,17 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="es">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="es">
 <context>
     <name>osd::DisPlayModeApplet</name>
     <message>
-        <location filename="../displaymodeapplet.cpp" line="151"/>
         <source>Duplicate</source>
         <translation>Duplicada</translation>
     </message>
     <message>
-        <location filename="../displaymodeapplet.cpp" line="152"/>
         <source>Extend</source>
         <translation>Extendida</translation>
     </message>
     <message>
-        <location filename="../displaymodeapplet.cpp" line="157"/>
         <source>Only on %1</source>
         <translation>Solo en %1</translation>
     </message>

--- a/panels/notification/osd/displaymode/translations/org.deepin.ds.osd.displaymode_fi.ts
+++ b/panels/notification/osd/displaymode/translations/org.deepin.ds.osd.displaymode_fi.ts
@@ -1,18 +1,17 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="fi">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fi">
 <context>
     <name>osd::DisPlayModeApplet</name>
     <message>
-        <location filename="../displaymodeapplet.cpp" line="151"/>
         <source>Duplicate</source>
         <translation>Kahdenna</translation>
     </message>
     <message>
-        <location filename="../displaymodeapplet.cpp" line="152"/>
         <source>Extend</source>
         <translation>Laajenna</translation>
     </message>
     <message>
-        <location filename="../displaymodeapplet.cpp" line="157"/>
         <source>Only on %1</source>
         <translation>Vain %1</translation>
     </message>

--- a/panels/notification/osd/displaymode/translations/org.deepin.ds.osd.displaymode_fr.ts
+++ b/panels/notification/osd/displaymode/translations/org.deepin.ds.osd.displaymode_fr.ts
@@ -1,18 +1,17 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="fr">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fr">
 <context>
     <name>osd::DisPlayModeApplet</name>
     <message>
-        <location filename="../displaymodeapplet.cpp" line="151"/>
         <source>Duplicate</source>
         <translation>Dupliquer</translation>
     </message>
     <message>
-        <location filename="../displaymodeapplet.cpp" line="152"/>
         <source>Extend</source>
         <translation>Étendre</translation>
     </message>
     <message>
-        <location filename="../displaymodeapplet.cpp" line="157"/>
         <source>Only on %1</source>
         <translation>Uniquement sur %1</translation>
     </message>

--- a/panels/notification/osd/displaymode/translations/org.deepin.ds.osd.displaymode_hu.ts
+++ b/panels/notification/osd/displaymode/translations/org.deepin.ds.osd.displaymode_hu.ts
@@ -1,18 +1,17 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="hu">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="hu">
 <context>
     <name>osd::DisPlayModeApplet</name>
     <message>
-        <location filename="../displaymodeapplet.cpp" line="151"/>
         <source>Duplicate</source>
         <translation>Megkettőzés</translation>
     </message>
     <message>
-        <location filename="../displaymodeapplet.cpp" line="152"/>
         <source>Extend</source>
         <translation>Kiterjesztés</translation>
     </message>
     <message>
-        <location filename="../displaymodeapplet.cpp" line="157"/>
         <source>Only on %1</source>
         <translation>Megjelenítés csak a %1-n</translation>
     </message>

--- a/panels/notification/osd/displaymode/translations/org.deepin.ds.osd.displaymode_it.ts
+++ b/panels/notification/osd/displaymode/translations/org.deepin.ds.osd.displaymode_it.ts
@@ -4,17 +4,14 @@
 <context>
     <name>osd::DisPlayModeApplet</name>
     <message>
-        <location filename="../displaymodeapplet.cpp" line="151"/>
         <source>Duplicate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../displaymodeapplet.cpp" line="152"/>
         <source>Extend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../displaymodeapplet.cpp" line="157"/>
         <source>Only on %1</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/notification/osd/displaymode/translations/org.deepin.ds.osd.displaymode_ja.ts
+++ b/panels/notification/osd/displaymode/translations/org.deepin.ds.osd.displaymode_ja.ts
@@ -1,18 +1,17 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ja">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ja">
 <context>
     <name>osd::DisPlayModeApplet</name>
     <message>
-        <location filename="../displaymodeapplet.cpp" line="151"/>
         <source>Duplicate</source>
         <translation>複製</translation>
     </message>
     <message>
-        <location filename="../displaymodeapplet.cpp" line="152"/>
         <source>Extend</source>
         <translation>拡張</translation>
     </message>
     <message>
-        <location filename="../displaymodeapplet.cpp" line="157"/>
         <source>Only on %1</source>
         <translation>%1 のみ</translation>
     </message>

--- a/panels/notification/osd/displaymode/translations/org.deepin.ds.osd.displaymode_ko.ts
+++ b/panels/notification/osd/displaymode/translations/org.deepin.ds.osd.displaymode_ko.ts
@@ -4,17 +4,14 @@
 <context>
     <name>osd::DisPlayModeApplet</name>
     <message>
-        <location filename="../displaymodeapplet.cpp" line="151"/>
         <source>Duplicate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../displaymodeapplet.cpp" line="152"/>
         <source>Extend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../displaymodeapplet.cpp" line="157"/>
         <source>Only on %1</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/notification/osd/displaymode/translations/org.deepin.ds.osd.displaymode_nb_NO.ts
+++ b/panels/notification/osd/displaymode/translations/org.deepin.ds.osd.displaymode_nb_NO.ts
@@ -4,17 +4,14 @@
 <context>
     <name>osd::DisPlayModeApplet</name>
     <message>
-        <location filename="../displaymodeapplet.cpp" line="151"/>
         <source>Duplicate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../displaymodeapplet.cpp" line="152"/>
         <source>Extend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../displaymodeapplet.cpp" line="157"/>
         <source>Only on %1</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/notification/osd/displaymode/translations/org.deepin.ds.osd.displaymode_pl.ts
+++ b/panels/notification/osd/displaymode/translations/org.deepin.ds.osd.displaymode_pl.ts
@@ -1,18 +1,17 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pl">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pl">
 <context>
     <name>osd::DisPlayModeApplet</name>
     <message>
-        <location filename="../displaymodeapplet.cpp" line="151"/>
         <source>Duplicate</source>
         <translation>Duplikuj</translation>
     </message>
     <message>
-        <location filename="../displaymodeapplet.cpp" line="152"/>
         <source>Extend</source>
         <translation>Rozszerz</translation>
     </message>
     <message>
-        <location filename="../displaymodeapplet.cpp" line="157"/>
         <source>Only on %1</source>
         <translation>Tylko na %1</translation>
     </message>

--- a/panels/notification/osd/displaymode/translations/org.deepin.ds.osd.displaymode_pt_BR.ts
+++ b/panels/notification/osd/displaymode/translations/org.deepin.ds.osd.displaymode_pt_BR.ts
@@ -1,18 +1,17 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pt_BR">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pt_BR">
 <context>
     <name>osd::DisPlayModeApplet</name>
     <message>
-        <location filename="../displaymodeapplet.cpp" line="151"/>
         <source>Duplicate</source>
         <translation>Duplicar</translation>
     </message>
     <message>
-        <location filename="../displaymodeapplet.cpp" line="152"/>
         <source>Extend</source>
         <translation>Estender</translation>
     </message>
     <message>
-        <location filename="../displaymodeapplet.cpp" line="157"/>
         <source>Only on %1</source>
         <translation>Somente em %1</translation>
     </message>

--- a/panels/notification/osd/displaymode/translations/org.deepin.ds.osd.displaymode_ru.ts
+++ b/panels/notification/osd/displaymode/translations/org.deepin.ds.osd.displaymode_ru.ts
@@ -1,18 +1,17 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ru">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ru">
 <context>
     <name>osd::DisPlayModeApplet</name>
     <message>
-        <location filename="../displaymodeapplet.cpp" line="151"/>
         <source>Duplicate</source>
         <translation>Повторяющийся</translation>
     </message>
     <message>
-        <location filename="../displaymodeapplet.cpp" line="152"/>
         <source>Extend</source>
         <translation>Расширить</translation>
     </message>
     <message>
-        <location filename="../displaymodeapplet.cpp" line="157"/>
         <source>Only on %1</source>
         <translation>Только на %1</translation>
     </message>

--- a/panels/notification/osd/displaymode/translations/org.deepin.ds.osd.displaymode_uk.ts
+++ b/panels/notification/osd/displaymode/translations/org.deepin.ds.osd.displaymode_uk.ts
@@ -1,18 +1,17 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="uk">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="uk">
 <context>
     <name>osd::DisPlayModeApplet</name>
     <message>
-        <location filename="../displaymodeapplet.cpp" line="151"/>
         <source>Duplicate</source>
         <translation>Дублювати</translation>
     </message>
     <message>
-        <location filename="../displaymodeapplet.cpp" line="152"/>
         <source>Extend</source>
         <translation>Розширити</translation>
     </message>
     <message>
-        <location filename="../displaymodeapplet.cpp" line="157"/>
         <source>Only on %1</source>
         <translation>Лише на %1</translation>
     </message>

--- a/panels/notification/osd/displaymode/translations/org.deepin.ds.osd.displaymode_zh_CN.ts
+++ b/panels/notification/osd/displaymode/translations/org.deepin.ds.osd.displaymode_zh_CN.ts
@@ -1,18 +1,17 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_CN">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_CN">
 <context>
     <name>osd::DisPlayModeApplet</name>
     <message>
-        <location filename="../displaymodeapplet.cpp" line="151"/>
         <source>Duplicate</source>
         <translation>复制</translation>
     </message>
     <message>
-        <location filename="../displaymodeapplet.cpp" line="152"/>
         <source>Extend</source>
         <translation>扩展</translation>
     </message>
     <message>
-        <location filename="../displaymodeapplet.cpp" line="157"/>
         <source>Only on %1</source>
         <translation>仅 %1</translation>
     </message>

--- a/panels/notification/osd/displaymode/translations/org.deepin.ds.osd.displaymode_zh_HK.ts
+++ b/panels/notification/osd/displaymode/translations/org.deepin.ds.osd.displaymode_zh_HK.ts
@@ -1,18 +1,17 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_HK">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_HK">
 <context>
     <name>osd::DisPlayModeApplet</name>
     <message>
-        <location filename="../displaymodeapplet.cpp" line="151"/>
         <source>Duplicate</source>
         <translation>複制</translation>
     </message>
     <message>
-        <location filename="../displaymodeapplet.cpp" line="152"/>
         <source>Extend</source>
         <translation>擴展</translation>
     </message>
     <message>
-        <location filename="../displaymodeapplet.cpp" line="157"/>
         <source>Only on %1</source>
         <translation>僅 %1</translation>
     </message>

--- a/panels/notification/osd/displaymode/translations/org.deepin.ds.osd.displaymode_zh_TW.ts
+++ b/panels/notification/osd/displaymode/translations/org.deepin.ds.osd.displaymode_zh_TW.ts
@@ -1,18 +1,17 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_TW">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_TW">
 <context>
     <name>osd::DisPlayModeApplet</name>
     <message>
-        <location filename="../displaymodeapplet.cpp" line="151"/>
         <source>Duplicate</source>
         <translation>複制</translation>
     </message>
     <message>
-        <location filename="../displaymodeapplet.cpp" line="152"/>
         <source>Extend</source>
         <translation>擴展</translation>
     </message>
     <message>
-        <location filename="../displaymodeapplet.cpp" line="157"/>
         <source>Only on %1</source>
         <translation>僅 %1</translation>
     </message>

--- a/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect.ts
+++ b/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect.ts
@@ -4,32 +4,26 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="206"/>
         <source>Optimal performance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="207"/>
         <source>Optimal performance: Disable all interface and window effects for efficient system performance.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="213"/>
         <source>Balance: Limit some window effects for excellent visuals while maintaining smooth system performance.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="219"/>
         <source>Best visuals: Enable all interface and window effects for the best visual experience.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="212"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="218"/>
         <source>Best Visuals</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_az.ts
+++ b/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_az.ts
@@ -4,32 +4,26 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="206"/>
         <source>Optimal performance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="207"/>
         <source>Optimal performance: Disable all interface and window effects for efficient system performance.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="213"/>
         <source>Balance: Limit some window effects for excellent visuals while maintaining smooth system performance.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="219"/>
         <source>Best visuals: Enable all interface and window effects for the best visual experience.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="212"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="218"/>
         <source>Best Visuals</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_bo.ts
+++ b/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_bo.ts
@@ -4,32 +4,26 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="206"/>
         <source>Optimal performance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="207"/>
         <source>Optimal performance: Disable all interface and window effects for efficient system performance.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="213"/>
         <source>Balance: Limit some window effects for excellent visuals while maintaining smooth system performance.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="219"/>
         <source>Best visuals: Enable all interface and window effects for the best visual experience.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="212"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="218"/>
         <source>Best Visuals</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_ca.ts
+++ b/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_ca.ts
@@ -4,32 +4,26 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="206"/>
         <source>Optimal performance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="207"/>
         <source>Optimal performance: Disable all interface and window effects for efficient system performance.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="213"/>
         <source>Balance: Limit some window effects for excellent visuals while maintaining smooth system performance.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="219"/>
         <source>Best visuals: Enable all interface and window effects for the best visual experience.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="212"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="218"/>
         <source>Best Visuals</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_es.ts
+++ b/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_es.ts
@@ -4,32 +4,26 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="206"/>
         <source>Optimal performance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="207"/>
         <source>Optimal performance: Disable all interface and window effects for efficient system performance.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="213"/>
         <source>Balance: Limit some window effects for excellent visuals while maintaining smooth system performance.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="219"/>
         <source>Best visuals: Enable all interface and window effects for the best visual experience.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="212"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="218"/>
         <source>Best Visuals</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_fi.ts
+++ b/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_fi.ts
@@ -4,32 +4,26 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="206"/>
         <source>Optimal performance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="207"/>
         <source>Optimal performance: Disable all interface and window effects for efficient system performance.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="213"/>
         <source>Balance: Limit some window effects for excellent visuals while maintaining smooth system performance.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="219"/>
         <source>Best visuals: Enable all interface and window effects for the best visual experience.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="212"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="218"/>
         <source>Best Visuals</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_fr.ts
+++ b/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_fr.ts
@@ -4,32 +4,26 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="206"/>
         <source>Optimal performance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="207"/>
         <source>Optimal performance: Disable all interface and window effects for efficient system performance.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="213"/>
         <source>Balance: Limit some window effects for excellent visuals while maintaining smooth system performance.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="219"/>
         <source>Best visuals: Enable all interface and window effects for the best visual experience.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="212"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="218"/>
         <source>Best Visuals</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_hu.ts
+++ b/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_hu.ts
@@ -4,32 +4,26 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="206"/>
         <source>Optimal performance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="207"/>
         <source>Optimal performance: Disable all interface and window effects for efficient system performance.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="213"/>
         <source>Balance: Limit some window effects for excellent visuals while maintaining smooth system performance.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="219"/>
         <source>Best visuals: Enable all interface and window effects for the best visual experience.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="212"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="218"/>
         <source>Best Visuals</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_it.ts
+++ b/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_it.ts
@@ -4,32 +4,26 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="206"/>
         <source>Optimal performance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="207"/>
         <source>Optimal performance: Disable all interface and window effects for efficient system performance.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="213"/>
         <source>Balance: Limit some window effects for excellent visuals while maintaining smooth system performance.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="219"/>
         <source>Best visuals: Enable all interface and window effects for the best visual experience.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="212"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="218"/>
         <source>Best Visuals</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_ja.ts
+++ b/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_ja.ts
@@ -4,32 +4,26 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="206"/>
         <source>Optimal performance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="207"/>
         <source>Optimal performance: Disable all interface and window effects for efficient system performance.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="213"/>
         <source>Balance: Limit some window effects for excellent visuals while maintaining smooth system performance.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="219"/>
         <source>Best visuals: Enable all interface and window effects for the best visual experience.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="212"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="218"/>
         <source>Best Visuals</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_ko.ts
+++ b/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_ko.ts
@@ -4,32 +4,26 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="206"/>
         <source>Optimal performance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="207"/>
         <source>Optimal performance: Disable all interface and window effects for efficient system performance.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="213"/>
         <source>Balance: Limit some window effects for excellent visuals while maintaining smooth system performance.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="219"/>
         <source>Best visuals: Enable all interface and window effects for the best visual experience.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="212"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="218"/>
         <source>Best Visuals</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_nb_NO.ts
+++ b/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_nb_NO.ts
@@ -4,32 +4,26 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="206"/>
         <source>Optimal performance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="207"/>
         <source>Optimal performance: Disable all interface and window effects for efficient system performance.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="213"/>
         <source>Balance: Limit some window effects for excellent visuals while maintaining smooth system performance.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="219"/>
         <source>Best visuals: Enable all interface and window effects for the best visual experience.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="212"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="218"/>
         <source>Best Visuals</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_pl.ts
+++ b/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_pl.ts
@@ -4,32 +4,26 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="206"/>
         <source>Optimal performance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="207"/>
         <source>Optimal performance: Disable all interface and window effects for efficient system performance.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="213"/>
         <source>Balance: Limit some window effects for excellent visuals while maintaining smooth system performance.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="219"/>
         <source>Best visuals: Enable all interface and window effects for the best visual experience.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="212"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="218"/>
         <source>Best Visuals</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_pt_BR.ts
+++ b/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_pt_BR.ts
@@ -4,32 +4,26 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="206"/>
         <source>Optimal performance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="207"/>
         <source>Optimal performance: Disable all interface and window effects for efficient system performance.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="213"/>
         <source>Balance: Limit some window effects for excellent visuals while maintaining smooth system performance.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="219"/>
         <source>Best visuals: Enable all interface and window effects for the best visual experience.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="212"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="218"/>
         <source>Best Visuals</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_ru.ts
+++ b/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_ru.ts
@@ -4,32 +4,26 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="206"/>
         <source>Optimal performance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="207"/>
         <source>Optimal performance: Disable all interface and window effects for efficient system performance.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="213"/>
         <source>Balance: Limit some window effects for excellent visuals while maintaining smooth system performance.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="219"/>
         <source>Best visuals: Enable all interface and window effects for the best visual experience.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="212"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="218"/>
         <source>Best Visuals</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_uk.ts
+++ b/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_uk.ts
@@ -4,32 +4,26 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="206"/>
         <source>Optimal performance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="207"/>
         <source>Optimal performance: Disable all interface and window effects for efficient system performance.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="213"/>
         <source>Balance: Limit some window effects for excellent visuals while maintaining smooth system performance.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="219"/>
         <source>Best visuals: Enable all interface and window effects for the best visual experience.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="212"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="218"/>
         <source>Best Visuals</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_zh_CN.ts
+++ b/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_zh_CN.ts
@@ -4,32 +4,26 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="206"/>
         <source>Optimal performance</source>
         <translation>最佳性能</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="207"/>
         <source>Optimal performance: Disable all interface and window effects for efficient system performance.</source>
         <translation>最佳性能：关闭所有界面和窗口特效，保障系统高效运行.</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="212"/>
         <source>Balance</source>
         <translation>均衡</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="213"/>
         <source>Balance: Limit some window effects for excellent visuals while maintaining smooth system performance.</source>
         <translation>均衡：限制部分窗口特效，保障出色的视觉效果，同时维持系统流畅运行</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="218"/>
         <source>Best Visuals</source>
         <translation>最佳视觉</translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="219"/>
         <source>Best visuals: Enable all interface and window effects for the best visual experience.</source>
         <translation>最佳视觉：启用所有界面和窗口特效，体验最佳视觉效果</translation>
     </message>

--- a/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_zh_HK.ts
+++ b/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_zh_HK.ts
@@ -4,32 +4,26 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="206"/>
         <source>Optimal performance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="207"/>
         <source>Optimal performance: Disable all interface and window effects for efficient system performance.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="213"/>
         <source>Balance: Limit some window effects for excellent visuals while maintaining smooth system performance.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="219"/>
         <source>Best visuals: Enable all interface and window effects for the best visual experience.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="212"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="218"/>
         <source>Best Visuals</source>
         <translation type="unfinished"></translation>
     </message>

--- a/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_zh_TW.ts
+++ b/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_zh_TW.ts
@@ -4,32 +4,26 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../package/main.qml" line="206"/>
         <source>Optimal performance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="207"/>
         <source>Optimal performance: Disable all interface and window effects for efficient system performance.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="213"/>
         <source>Balance: Limit some window effects for excellent visuals while maintaining smooth system performance.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="219"/>
         <source>Best visuals: Enable all interface and window effects for the best visual experience.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="212"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/main.qml" line="218"/>
         <source>Best Visuals</source>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
根据产品文档,调整dock两种模式的显示名称文案,并与控制中心的文案对齐.

## Summary by Sourcery

Update copywriting for dock modes to align with product documentation and control center terminology

New Features:
- Added two new dock mode labels: 'Classic Mode' and 'Centered Mode'

Chores:
- Updated translation files to reflect new dock mode terminology