### PR TITLE
chore: bump version to 1.99.35

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+dde-shell (1.99.35) unstable; urgency=medium
+
+  * chore: drop no longer existed translation resource 
+  * chore: update copywriting of dock modes 
+  * feat: Add animation for position switching to dock	
+  * Update translations from Transifex
+
+-- Wu Jiangyu <wujiangyu@uniontech.com>  Tue, 13 May 2025 17:20:000 +0800
+
 dde-shell (1.99.34) unstable; urgency=medium
 
   * refactor: simplify notification action handling


### PR DESCRIPTION
chore: drop no longer existed translation resource chore: update copywriting of dock modes
feat: Add animation for position switching to dock Update translations from Transifex

Log: as title

## Summary by Sourcery

Bump version to 1.99.35, remove a deprecated translation resource, refine dock mode copywriting, introduce animation for dock position changes, and update translations from Transifex.

New Features:
- Add animation for dock position switching

Enhancements:
- Remove obsolete translation resource
- Update copywriting for dock modes

Chores:
- Bump version to 1.99.35
- Refresh translations from Transifex