### PR TITLE
chore: bump version to 1.99.36

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-shell (1.99.36) unstable; urgency=medium
+
+  * feat: introduce RoleGroupModel
+  * refactor: update display mode icons and logic
+
+ -- YeShanShan <yeshanshan@uniontech.com>  Thu, 15 May 2025 21:15:21 +0800
+
 dde-shell (1.99.35) unstable; urgency=medium
 
   * chore: drop no longer existed translation resource 


### PR DESCRIPTION
update changelog to 1.99.36

## Summary by Sourcery

Chores:
- Update Debian changelog for version 1.99.36 release