### PR TITLE
fix: add missing winIconRole to DockCombineModel

### DIFF
--- a/panels/dock/taskmanager/dockcombinemodel.cpp
+++ b/panels/dock/taskmanager/dockcombinemodel.cpp
@@ -23,6 +23,7 @@ DockCombineModel::DockCombineModel(QAbstractItemModel *major, QAbstractItemModel
                   {TaskManager::ActionsRole, RoleCombineModel::roleNames().key(MODEL_ACTIONS)},
                   {TaskManager::NameRole, RoleCombineModel::roleNames().key(MODEL_NAME)},
                   {TaskManager::WinIdRole, RoleCombineModel::roleNames().key(MODEL_WINID)},
+                  {TaskManager::WinIconRole, RoleCombineModel::roleNames().key(MODEL_WINICON)},
                   {TaskManager::WinTitleRole, RoleCombineModel::roleNames().key(MODEL_TITLE)}};
 }
 
@@ -36,6 +37,7 @@ QHash<int, QByteArray> DockCombineModel::roleNames() const
             {TaskManager::ActionsRole, MODEL_ACTIONS},
             {TaskManager::NameRole, MODEL_NAME},
             {TaskManager::WinIdRole, MODEL_WINID},
+            {TaskManager::WinIconRole, MODEL_WINICON},
             {TaskManager::WinTitleRole, MODEL_TITLE}};
 }
 


### PR DESCRIPTION
修正未来 dataModel 切换到 DockItemModel 后,无应用图标的应用不会将窗口图标作为 fallback 图标的问题.

(当前还未切换，不构成影响）

## Summary by Sourcery

Add missing WinIconRole to DockCombineModel role mappings to ensure window icons can be used as fallback for applications without an icon.

Bug Fixes:
- Include WinIconRole in the constructor’s role mapping to surface the window icon role.
- Add WinIconRole entry to the roleNames() method to complete the model’s role definitions.