### PR TITLE
fix: smart hide state not updated when window closed

### DIFF
--- a/panels/dock/x11dockhelper.cpp
+++ b/panels/dock/x11dockhelper.cpp
@@ -403,13 +403,18 @@ void X11DockHelper::onWindowClientListChanged()
             onWindowAdded(window);
         }
     }
+    bool mightNeedRecheckDockOverlap = false;
     for (auto it = m_windows.cbegin(); it != m_windows.cend();) {
         if (!windows.contains(it.key())) {
             delete it.value();
             it = m_windows.erase(it);
+            mightNeedRecheckDockOverlap = true;
         } else {
             it++;
         }
+    }
+    if (mightNeedRecheckDockOverlap) {
+        Q_EMIT isWindowOverlapChanged(isWindowOverlap());
     }
 }
 


### PR DESCRIPTION
修复关闭窗口时,智能隐藏状态未刷新的问题.

## Summary by Sourcery

Bug Fixes:
- Refresh smart hide state when closing windows by emitting isWindowOverlapChanged upon window removal