### PR TITLE
fix: incorrectly removed window in AbstractWindowMonitor

### DIFF
--- a/panels/dock/taskmanager/abstractwindowmonitor.cpp
+++ b/panels/dock/taskmanager/abstractwindowmonitor.cpp
@@ -101,8 +101,8 @@ void AbstractWindowMonitor::destroyWindow(AbstractWindow * window)
     if (pos == -1)
         return;
 
-    beginRemoveRows(QModelIndex(), pos, pos + 1);
-    m_trackedWindows.removeOne(window);
+    beginRemoveRows(QModelIndex(), pos, pos);
+    m_trackedWindows.removeAt(pos);
     endRemoveRows();
 }
 


### PR DESCRIPTION
AbstractWindowMonitor 在跟踪移除窗口事件时,对 model 状态的维护不正确, 实际移除的元素数量和beginRemoveRows中传递的数量不匹配,可能导致模型状态有误导致的潜在崩溃或视图错误.

## Summary by Sourcery

Bug Fixes:
- Correct the end index for beginRemoveRows to match the single removed row, avoiding mismatches between actual removals and reported ranges.