### PR TITLE
chore: simplify window effect descriptions

### DIFF
--- a/panels/notification/osd/windoweffect/package/main.qml
+++ b/panels/notification/osd/windoweffect/package/main.qml
@@ -206,19 +206,19 @@ AppletItem {
             value: main.WindowEffectType.Normal
             iconName: "osd_screen_highperformance"
             title: qsTr("Optimal performance")
-            description: qsTr("Optimal performance: Disable all interface and window effects for efficient system performance.")
+            description: qsTr("Disable all interface and window effects for efficient system performance")
         }
         ListElement {
             value: main.WindowEffectType.Better
             iconName: "osd_screen_balance"
             title: qsTr("Balance")
-            description: qsTr("Balance: Limit some window effects for excellent visuals while maintaining smooth system performance.")
+            description: qsTr("Limit some window effects for excellent visuals while maintaining smooth system performance")
         }
         ListElement {
             value: main.WindowEffectType.Best
             iconName: "osd_screen_bestvisual"
             title: qsTr("Best Visuals")
-            description: qsTr("Best visuals: Enable all interface and window effects for the best visual experience.")
+            description: qsTr("Enable all interface and window effects for the best visual experience")
         }
     }
 }

--- a/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect.ts
+++ b/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect.ts
@@ -8,23 +8,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Optimal performance: Disable all interface and window effects for efficient system performance.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Balance: Limit some window effects for excellent visuals while maintaining smooth system performance.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Best visuals: Enable all interface and window effects for the best visual experience.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Best Visuals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable all interface and window effects for efficient system performance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Limit some window effects for excellent visuals while maintaining smooth system performance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable all interface and window effects for the best visual experience</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_az.ts
+++ b/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_az.ts
@@ -8,23 +8,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Optimal performance: Disable all interface and window effects for efficient system performance.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Balance: Limit some window effects for excellent visuals while maintaining smooth system performance.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Best visuals: Enable all interface and window effects for the best visual experience.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Best Visuals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable all interface and window effects for efficient system performance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Limit some window effects for excellent visuals while maintaining smooth system performance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable all interface and window effects for the best visual experience</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_bo.ts
+++ b/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_bo.ts
@@ -8,23 +8,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Optimal performance: Disable all interface and window effects for efficient system performance.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Balance: Limit some window effects for excellent visuals while maintaining smooth system performance.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Best visuals: Enable all interface and window effects for the best visual experience.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Best Visuals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable all interface and window effects for efficient system performance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Limit some window effects for excellent visuals while maintaining smooth system performance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable all interface and window effects for the best visual experience</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_ca.ts
+++ b/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_ca.ts
@@ -8,23 +8,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Optimal performance: Disable all interface and window effects for efficient system performance.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Balance: Limit some window effects for excellent visuals while maintaining smooth system performance.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Best visuals: Enable all interface and window effects for the best visual experience.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Best Visuals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable all interface and window effects for efficient system performance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Limit some window effects for excellent visuals while maintaining smooth system performance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable all interface and window effects for the best visual experience</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_es.ts
+++ b/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_es.ts
@@ -8,23 +8,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Optimal performance: Disable all interface and window effects for efficient system performance.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Balance: Limit some window effects for excellent visuals while maintaining smooth system performance.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Best visuals: Enable all interface and window effects for the best visual experience.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Best Visuals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable all interface and window effects for efficient system performance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Limit some window effects for excellent visuals while maintaining smooth system performance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable all interface and window effects for the best visual experience</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_fi.ts
+++ b/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_fi.ts
@@ -8,23 +8,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Optimal performance: Disable all interface and window effects for efficient system performance.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Balance: Limit some window effects for excellent visuals while maintaining smooth system performance.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Best visuals: Enable all interface and window effects for the best visual experience.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Best Visuals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable all interface and window effects for efficient system performance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Limit some window effects for excellent visuals while maintaining smooth system performance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable all interface and window effects for the best visual experience</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_fr.ts
+++ b/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_fr.ts
@@ -8,23 +8,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Optimal performance: Disable all interface and window effects for efficient system performance.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Balance: Limit some window effects for excellent visuals while maintaining smooth system performance.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Best visuals: Enable all interface and window effects for the best visual experience.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Best Visuals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable all interface and window effects for efficient system performance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Limit some window effects for excellent visuals while maintaining smooth system performance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable all interface and window effects for the best visual experience</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_hu.ts
+++ b/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_hu.ts
@@ -8,23 +8,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Optimal performance: Disable all interface and window effects for efficient system performance.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Balance: Limit some window effects for excellent visuals while maintaining smooth system performance.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Best visuals: Enable all interface and window effects for the best visual experience.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Best Visuals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable all interface and window effects for efficient system performance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Limit some window effects for excellent visuals while maintaining smooth system performance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable all interface and window effects for the best visual experience</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_it.ts
+++ b/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_it.ts
@@ -8,23 +8,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Optimal performance: Disable all interface and window effects for efficient system performance.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Balance: Limit some window effects for excellent visuals while maintaining smooth system performance.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Best visuals: Enable all interface and window effects for the best visual experience.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Best Visuals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable all interface and window effects for efficient system performance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Limit some window effects for excellent visuals while maintaining smooth system performance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable all interface and window effects for the best visual experience</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_ja.ts
+++ b/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_ja.ts
@@ -8,23 +8,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Optimal performance: Disable all interface and window effects for efficient system performance.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Balance: Limit some window effects for excellent visuals while maintaining smooth system performance.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Best visuals: Enable all interface and window effects for the best visual experience.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Best Visuals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable all interface and window effects for efficient system performance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Limit some window effects for excellent visuals while maintaining smooth system performance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable all interface and window effects for the best visual experience</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_ko.ts
+++ b/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_ko.ts
@@ -8,23 +8,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Optimal performance: Disable all interface and window effects for efficient system performance.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Balance: Limit some window effects for excellent visuals while maintaining smooth system performance.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Best visuals: Enable all interface and window effects for the best visual experience.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Best Visuals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable all interface and window effects for efficient system performance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Limit some window effects for excellent visuals while maintaining smooth system performance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable all interface and window effects for the best visual experience</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_nb_NO.ts
+++ b/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_nb_NO.ts
@@ -8,23 +8,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Optimal performance: Disable all interface and window effects for efficient system performance.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Balance: Limit some window effects for excellent visuals while maintaining smooth system performance.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Best visuals: Enable all interface and window effects for the best visual experience.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Best Visuals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable all interface and window effects for efficient system performance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Limit some window effects for excellent visuals while maintaining smooth system performance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable all interface and window effects for the best visual experience</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_pl.ts
+++ b/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_pl.ts
@@ -8,23 +8,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Optimal performance: Disable all interface and window effects for efficient system performance.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Balance: Limit some window effects for excellent visuals while maintaining smooth system performance.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Best visuals: Enable all interface and window effects for the best visual experience.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Best Visuals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable all interface and window effects for efficient system performance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Limit some window effects for excellent visuals while maintaining smooth system performance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable all interface and window effects for the best visual experience</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_pt_BR.ts
+++ b/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_pt_BR.ts
@@ -8,23 +8,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Optimal performance: Disable all interface and window effects for efficient system performance.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Balance: Limit some window effects for excellent visuals while maintaining smooth system performance.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Best visuals: Enable all interface and window effects for the best visual experience.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Best Visuals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable all interface and window effects for efficient system performance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Limit some window effects for excellent visuals while maintaining smooth system performance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable all interface and window effects for the best visual experience</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_ru.ts
+++ b/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_ru.ts
@@ -8,23 +8,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Optimal performance: Disable all interface and window effects for efficient system performance.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Balance: Limit some window effects for excellent visuals while maintaining smooth system performance.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Best visuals: Enable all interface and window effects for the best visual experience.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Best Visuals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable all interface and window effects for efficient system performance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Limit some window effects for excellent visuals while maintaining smooth system performance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable all interface and window effects for the best visual experience</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_uk.ts
+++ b/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_uk.ts
@@ -8,23 +8,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Optimal performance: Disable all interface and window effects for efficient system performance.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Balance: Limit some window effects for excellent visuals while maintaining smooth system performance.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Best visuals: Enable all interface and window effects for the best visual experience.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Best Visuals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable all interface and window effects for efficient system performance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Limit some window effects for excellent visuals while maintaining smooth system performance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable all interface and window effects for the best visual experience</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_zh_CN.ts
+++ b/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_zh_CN.ts
@@ -8,24 +8,24 @@
         <translation>最佳性能</translation>
     </message>
     <message>
-        <source>Optimal performance: Disable all interface and window effects for efficient system performance.</source>
-        <translation>最佳性能：关闭所有界面和窗口特效，保障系统高效运行.</translation>
-    </message>
-    <message>
         <source>Balance</source>
         <translation>均衡</translation>
-    </message>
-    <message>
-        <source>Balance: Limit some window effects for excellent visuals while maintaining smooth system performance.</source>
-        <translation>均衡：限制部分窗口特效，保障出色的视觉效果，同时维持系统流畅运行</translation>
     </message>
     <message>
         <source>Best Visuals</source>
         <translation>最佳视觉</translation>
     </message>
     <message>
-        <source>Best visuals: Enable all interface and window effects for the best visual experience.</source>
-        <translation>最佳视觉：启用所有界面和窗口特效，体验最佳视觉效果</translation>
+        <source>Disable all interface and window effects for efficient system performance</source>
+        <translation>关闭所有界面和窗口特效，保障系统高效运行</translation>
+    </message>
+    <message>
+        <source>Limit some window effects for excellent visuals while maintaining smooth system performance</source>
+        <translation>限制部分窗口特效，保障出色的视觉效果，同时维持系统流畅运行</translation>
+    </message>
+    <message>
+        <source>Enable all interface and window effects for the best visual experience</source>
+        <translation>启用所有界面和窗口特效，体验最佳视觉效果</translation>
     </message>
 </context>
 </TS>

--- a/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_zh_HK.ts
+++ b/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_zh_HK.ts
@@ -8,23 +8,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Optimal performance: Disable all interface and window effects for efficient system performance.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Balance: Limit some window effects for excellent visuals while maintaining smooth system performance.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Best visuals: Enable all interface and window effects for the best visual experience.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Best Visuals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable all interface and window effects for efficient system performance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Limit some window effects for excellent visuals while maintaining smooth system performance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable all interface and window effects for the best visual experience</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_zh_TW.ts
+++ b/panels/notification/osd/windoweffect/translations/org.deepin.ds.osd.windoweffect_zh_TW.ts
@@ -8,23 +8,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Optimal performance: Disable all interface and window effects for efficient system performance.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Balance: Limit some window effects for excellent visuals while maintaining smooth system performance.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Best visuals: Enable all interface and window effects for the best visual experience.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Best Visuals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable all interface and window effects for efficient system performance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Limit some window effects for excellent visuals while maintaining smooth system performance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable all interface and window effects for the best visual experience</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
1. Removed redundant prefixes ("Optimal performance:", "Balance:", "Best visuals:") from descriptions in main.qml
2. Updated translation files to match the simplified descriptions
3. This change makes the UI text more concise while maintaining clarity
4. The modification affects all language translations to ensure consistency

chore: 简化窗口特效描述文本

1. 移除了 main.qml 中描述文本的多余前缀（"最佳性能："、"均衡："、"最佳 视觉："）
2. 更新翻译文件以匹配简化后的描述文本
3. 这一改动使界面文本更加简洁同时保持清晰
4. 修改影响了所有语言翻译以确保一致性

pms: BUG-313277

## Summary by Sourcery

Simplify the window effect mode descriptions by removing redundant prefixes and update all translation files to reflect the new, concise text

Enhancements:
- Remove redundant prefixes from window effect descriptions in the UI
- Update translations across all languages to match the simplified descriptions