### PR TITLE
fix: remove redundant mode property in NotifyItemContent

### DIFF
--- a/panels/notification/plugin/NotifyItemContent.qml
+++ b/panels/notification/plugin/NotifyItemContent.qml
@@ -130,7 +130,6 @@ NotifyItem {
             Layout.topMargin: 8
             Layout.leftMargin: 10
             palette: DTK.makeIconPalette(root.palette)
-            mode: root.ColorSelector.controlState
             theme: root.ColorSelector.controlTheme
         }
 


### PR DESCRIPTION
The mode property was removed from the IconItem component in
NotifyItemContent.qml as it was redundant and not being used. The
controlState is already being handled by the ColorSelector through the
palette property. This cleanup improves code maintainability by removing
unused properties.

fix: 移除 NotifyItemContent 中冗余的 mode 属性

从 NotifyItemContent.qml 的 IconItem 组件中移除了 mode 属性，因为该属性
是冗余的且未被使用。controlState 已经通过 palette 属性由 ColorSelector
处理。这一清理工作通过移除未使用的属性提高了代码的可维护性。

pms: BUG-316705
