### PR TITLE
fix: replace NumberAnimation with XAnimator in notification bubble

### DIFF
--- a/panels/notification/bubble/package/main.qml
+++ b/panels/notification/bubble/package/main.qml
@@ -70,7 +70,7 @@ Window {
         verticalLayoutDirection: ListView.BottomToTop
         add: Transition {
             id: addTrans
-            NumberAnimation { properties: "x"; from: addTrans.ViewTransition.item.width; duration: 600; easing.type: Easing.OutExpo }
+            XAnimator { target: addTrans.ViewTransition.item; from: addTrans.ViewTransition.item.width; duration: 600; easing.type: Easing.OutExpo }
         }
         delegate: Bubble {
             width: 360


### PR DESCRIPTION
The change replaces NumberAnimation with XAnimator for the notification
bubble transition animation. XAnimator is more efficient for animating
x-position changes as it's specifically designed for this purpose and
can leverage hardware acceleration. This improves performance and makes
the animation smoother, especially when multiple notifications appear
in quick succession. The duration and easing type remain the same to
maintain consistent visual behavior.

fix: 在通知气泡中用 XAnimator 替换 NumberAnimation

此次更改将通知气泡的过渡动画从 NumberAnimation 替换为 XAnimator。
XAnimator 专门用于处理 x 轴位置变化的动画，能更好地利用硬件加速，从而提
高性能并使动画更加流畅，特别是在快速连续出现多个通知时。保持相同的持续时
间和缓动类型以确保视觉行为一致。

pms: BUG-297317
