### PR TITLE
fix: support string list in notification hints

### DIFF
--- a/panels/notification/common/notifyentity.cpp
+++ b/panels/notification/common/notifyentity.cpp
@@ -14,6 +14,7 @@ Q_LOGGING_CATEGORY(notifyLog, "dde.shell.notification")
 #define ACTION_SEGMENT ("|")
 #define HINT_SEGMENT ("|")
 #define KEY_VALUE_SEGMENT ("!!!")
+#define LIST_VALUE_SEGMENT (":::")
 
 static const uint NoReplaceId = 0;
 
@@ -294,7 +295,13 @@ QString NotifyEntity::convertHintsToString(const QVariantMap &map)
         QString key = it.key();
         text += key;
         text += KEY_VALUE_SEGMENT;
-        QString value = it.value().toString();
+        QString value;
+        if (it.value().typeId() == QMetaType::QStringList) {
+            QStringList tmp = it.value().toStringList();
+            value = tmp.join(LIST_VALUE_SEGMENT);
+        } else {
+            value = it.value().toString();
+        }
         text += value;
         text += HINT_SEGMENT;
     }
@@ -328,7 +335,13 @@ QVariantMap NotifyEntity::parseHint(const QString &hint)
         if (list.size() != 2)
             continue;
         const QString &key = list[0];
-        QVariant value = QVariant::fromValue(list[1]);
+        QVariant value;
+        auto listValue = list[1].split(LIST_VALUE_SEGMENT);
+        if (listValue.size() > 1) {
+            value = QVariant::fromValue(listValue);
+        } else {
+            value = QVariant::fromValue(list[1]);
+        }
 
         map.insert(key, value);
     }

--- a/panels/notification/server/notificationmanager.cpp
+++ b/panels/notification/server/notificationmanager.cpp
@@ -512,7 +512,14 @@ void NotificationManager::doActionInvoked(const NotifyEntity &entity, const QStr
     QMap<QString, QVariant>::const_iterator i = hints.constBegin();
     while (i != hints.constEnd()) {
         if (i.key() == "x-deepin-action-" + actionId) {
-            QStringList args = i.value().toString().split(",");
+            QStringList args;
+            if (i.value().typeId() == QMetaType::QStringList) {
+                args = i.value().toStringList();
+            } else {
+                qDebug(notifyLog) << "Deprecate hint format, use string list instead of string."
+                                  << "actionId:" << actionId << ", value:" << i.value();
+                args = i.value().toString().split(",");
+            }
             if (!args.isEmpty()) {
                 QString cmd = args.takeFirst(); // 命令
 


### PR DESCRIPTION
1. Added LIST_VALUE_SEGMENT constant for string list serialization
2. Modified convertHintsToString to handle QStringList values by joining
with separator
3. Updated parseHint to reconstruct QStringList from serialized format
4. Improved action handling in NotificationManager to properly process
string list hints
5. Added deprecation warning for old string format hints

These changes were necessary to properly support complex hint values
in notifications, particularly for action parameters that may contain
multiple values. The previous implementation only supported simple
string values, which limited functionality.

fix: 支持通知提示中的字符串列表

1. 添加 LIST_VALUE_SEGMENT 常量用于字符串列表序列化
2. 修改 convertHintsToString 方法以处理 QStringList 值并使用分隔符连接
3. 更新 parseHint 方法从序列化格式重建 QStringList
4. 改进 NotificationManager 中的动作处理以正确处理字符串列表提示
5. 为旧的字符串格式提示添加弃用警告

这些变更是为了在通知中正确支持复杂的提示值，特别是可能包含多个值的动作参
数。之前的实现仅支持简单字符串值，限制了功能。

pms: BUG-317649

## Summary by Sourcery

Support and process QStringList values in notification hints by enhancing serialization/deserialization and action handling, and emit deprecation warnings for legacy formats.

New Features:
- Enable serialization and reconstruction of QStringList as hint values in notifications.

Enhancements:
- Add LIST_VALUE_SEGMENT delimiter for serializing list hints.
- Extend convertHintsToString and parseHint to handle list-based hint values.
- Update NotificationManager to process list-formatted action hints and warn on deprecated comma-separated formats.