### PR TITLE
fix: update tanslation with Lock dock.

### DIFF
--- a/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager.ts
+++ b/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager.ts
@@ -24,4 +24,27 @@
         <translation type="unfinished"></translation>
     </message>
 </context>
+<context>
+    <name>dock::DockGlobalElementModel</name>
+    <message>
+        <source>Open</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Undock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Force Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close All</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
 </TS>

--- a/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_az.ts
+++ b/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_az.ts
@@ -24,4 +24,27 @@
         <translation type="unfinished"></translation>
     </message>
 </context>
+<context>
+    <name>dock::DockGlobalElementModel</name>
+    <message>
+        <source>Open</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Undock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Force Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close All</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
 </TS>

--- a/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_bo.ts
+++ b/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_bo.ts
@@ -24,4 +24,27 @@
         <translation type="unfinished"></translation>
     </message>
 </context>
+<context>
+    <name>dock::DockGlobalElementModel</name>
+    <message>
+        <source>Open</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Undock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Force Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close All</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
 </TS>

--- a/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_ca.ts
+++ b/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_ca.ts
@@ -24,4 +24,27 @@
         <translation type="unfinished"></translation>
     </message>
 </context>
+<context>
+    <name>dock::DockGlobalElementModel</name>
+    <message>
+        <source>Open</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Undock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Force Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close All</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
 </TS>

--- a/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_es.ts
+++ b/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_es.ts
@@ -24,4 +24,27 @@
         <translation type="unfinished"></translation>
     </message>
 </context>
+<context>
+    <name>dock::DockGlobalElementModel</name>
+    <message>
+        <source>Open</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Undock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Force Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close All</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
 </TS>

--- a/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_fi.ts
+++ b/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_fi.ts
@@ -24,4 +24,27 @@
         <translation type="unfinished"></translation>
     </message>
 </context>
+<context>
+    <name>dock::DockGlobalElementModel</name>
+    <message>
+        <source>Open</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Undock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Force Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close All</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
 </TS>

--- a/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_fr.ts
+++ b/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_fr.ts
@@ -24,4 +24,27 @@
         <translation type="unfinished"></translation>
     </message>
 </context>
+<context>
+    <name>dock::DockGlobalElementModel</name>
+    <message>
+        <source>Open</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Undock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Force Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close All</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
 </TS>

--- a/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_hu.ts
+++ b/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_hu.ts
@@ -24,4 +24,27 @@
         <translation type="unfinished"></translation>
     </message>
 </context>
+<context>
+    <name>dock::DockGlobalElementModel</name>
+    <message>
+        <source>Open</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Undock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Force Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close All</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
 </TS>

--- a/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_it.ts
+++ b/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_it.ts
@@ -24,4 +24,27 @@
         <translation type="unfinished"></translation>
     </message>
 </context>
+<context>
+    <name>dock::DockGlobalElementModel</name>
+    <message>
+        <source>Open</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Undock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Force Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close All</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
 </TS>

--- a/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_ja.ts
+++ b/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_ja.ts
@@ -24,4 +24,27 @@
         <translation type="unfinished"></translation>
     </message>
 </context>
+<context>
+    <name>dock::DockGlobalElementModel</name>
+    <message>
+        <source>Open</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Undock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Force Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close All</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
 </TS>

--- a/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_ko.ts
+++ b/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_ko.ts
@@ -24,4 +24,27 @@
         <translation type="unfinished"></translation>
     </message>
 </context>
+<context>
+    <name>dock::DockGlobalElementModel</name>
+    <message>
+        <source>Open</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Undock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Force Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close All</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
 </TS>

--- a/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_nb_NO.ts
+++ b/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_nb_NO.ts
@@ -24,4 +24,27 @@
         <translation type="unfinished"></translation>
     </message>
 </context>
+<context>
+    <name>dock::DockGlobalElementModel</name>
+    <message>
+        <source>Open</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Undock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Force Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close All</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
 </TS>

--- a/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_pl.ts
+++ b/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_pl.ts
@@ -24,4 +24,27 @@
         <translation type="unfinished"></translation>
     </message>
 </context>
+<context>
+    <name>dock::DockGlobalElementModel</name>
+    <message>
+        <source>Open</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Undock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Force Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close All</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
 </TS>

--- a/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_pt_BR.ts
+++ b/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_pt_BR.ts
@@ -24,4 +24,27 @@
         <translation type="unfinished"></translation>
     </message>
 </context>
+<context>
+    <name>dock::DockGlobalElementModel</name>
+    <message>
+        <source>Open</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Undock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Force Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close All</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
 </TS>

--- a/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_ru.ts
+++ b/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_ru.ts
@@ -24,4 +24,27 @@
         <translation type="unfinished"></translation>
     </message>
 </context>
+<context>
+    <name>dock::DockGlobalElementModel</name>
+    <message>
+        <source>Open</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Undock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Force Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close All</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
 </TS>

--- a/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_uk.ts
+++ b/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_uk.ts
@@ -24,4 +24,27 @@
         <translation type="unfinished"></translation>
     </message>
 </context>
+<context>
+    <name>dock::DockGlobalElementModel</name>
+    <message>
+        <source>Open</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Undock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Force Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close All</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
 </TS>

--- a/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_zh_CN.ts
+++ b/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_zh_CN.ts
@@ -24,4 +24,27 @@
         <translation>关闭所有</translation>
     </message>
 </context>
+<context>
+    <name>dock::DockGlobalElementModel</name>
+    <message>
+        <source>Open</source>
+        <translation>打开</translation>
+    </message>
+    <message>
+        <source>Undock</source>
+        <translation>移除驻留</translation>
+    </message>
+    <message>
+        <source>Dock</source>
+        <translation>驻留</translation>
+    </message>
+    <message>
+        <source>Force Quit</source>
+        <translation>强制退出</translation>
+    </message>
+    <message>
+        <source>Close All</source>
+        <translation>关闭所有</translation>
+    </message>
+</context>
 </TS>

--- a/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_zh_HK.ts
+++ b/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_zh_HK.ts
@@ -24,4 +24,27 @@
         <translation>關閉所有</translation>
     </message>
 </context>
+<context>
+    <name>dock::DockGlobalElementModel</name>
+    <message>
+        <source>Open</source>
+        <translation>打開</translation>
+    </message>
+    <message>
+        <source>Undock</source>
+        <translation>移除駐留</translation>
+    </message>
+    <message>
+        <source>Dock</source>
+        <translation>駐留</translation>
+    </message>
+    <message>
+        <source>Force Quit</source>
+        <translation>強制退出</translation>
+    </message>
+    <message>
+        <source>Close All</source>
+        <translation>關閉所有</translation>
+    </message>
+</context>
 </TS>

--- a/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_zh_TW.ts
+++ b/panels/dock/taskmanager/translations/org.deepin.ds.dock.taskmanager_zh_TW.ts
@@ -24,4 +24,27 @@
         <translation>關閉所有</translation>
     </message>
 </context>
+<context>
+    <name>dock::DockGlobalElementModel</name>
+    <message>
+        <source>Open</source>
+        <translation>打開</translation>
+    </message>
+    <message>
+        <source>Undock</source>
+        <translation>移除駐留</translation>
+    </message>
+    <message>
+        <source>Dock</source>
+        <translation>駐留</translation>
+    </message>
+    <message>
+        <source>Force Quit</source>
+        <translation>強制退出</translation>
+    </message>
+    <message>
+        <source>Close All</source>
+        <translation>關閉所有</translation>
+    </message>
+</context>
 </TS>

--- a/panels/dock/translations/org.deepin.ds.dock.ts
+++ b/panels/dock/translations/org.deepin.ds.dock.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1">
+<TS version="2.1" language="_CN">
 <context>
     <name>main</name>
     <message>
@@ -66,6 +66,10 @@
     <message>
         <source>Dock Settings</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
+        <translation>禁用自由调节</translation>
     </message>
 </context>
 </TS>

--- a/panels/dock/translations/org.deepin.ds.dock_az.ts
+++ b/panels/dock/translations/org.deepin.ds.dock_az.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="az">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="az">
 <context>
     <name>main</name>
     <message>
@@ -64,6 +66,10 @@
     <message>
         <source>Dock Settings</source>
         <translation>إعدادات الرف</translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/panels/dock/translations/org.deepin.ds.dock_bo.ts
+++ b/panels/dock/translations/org.deepin.ds.dock_bo.ts
@@ -67,5 +67,9 @@
         <source>Dock Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Lock the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/panels/dock/translations/org.deepin.ds.dock_ca.ts
+++ b/panels/dock/translations/org.deepin.ds.dock_ca.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ca">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ca">
 <context>
     <name>main</name>
     <message>
@@ -64,6 +66,10 @@
     <message>
         <source>Dock Settings</source>
         <translation>Paràmetres de l&apos;acoblador</translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/panels/dock/translations/org.deepin.ds.dock_es.ts
+++ b/panels/dock/translations/org.deepin.ds.dock_es.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="es">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="es">
 <context>
     <name>main</name>
     <message>
@@ -64,6 +66,10 @@
     <message>
         <source>Dock Settings</source>
         <translation>Ajustes del muelle</translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/panels/dock/translations/org.deepin.ds.dock_fi.ts
+++ b/panels/dock/translations/org.deepin.ds.dock_fi.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="fi">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fi">
 <context>
     <name>main</name>
     <message>
@@ -64,6 +66,10 @@
     <message>
         <source>Dock Settings</source>
         <translation>Paneeli asetukset</translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/panels/dock/translations/org.deepin.ds.dock_fr.ts
+++ b/panels/dock/translations/org.deepin.ds.dock_fr.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="fr">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fr">
 <context>
     <name>main</name>
     <message>
@@ -64,6 +66,10 @@
     <message>
         <source>Dock Settings</source>
         <translation>Réglages du dock</translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/panels/dock/translations/org.deepin.ds.dock_hu.ts
+++ b/panels/dock/translations/org.deepin.ds.dock_hu.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="hu">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="hu">
 <context>
     <name>main</name>
     <message>
@@ -64,6 +66,10 @@
     <message>
         <source>Dock Settings</source>
         <translation>Dokkoló beállításai</translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/panels/dock/translations/org.deepin.ds.dock_it.ts
+++ b/panels/dock/translations/org.deepin.ds.dock_it.ts
@@ -67,5 +67,9 @@
         <source>Dock Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Lock the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/panels/dock/translations/org.deepin.ds.dock_ja.ts
+++ b/panels/dock/translations/org.deepin.ds.dock_ja.ts
@@ -67,5 +67,9 @@
         <source>Dock Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Lock the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/panels/dock/translations/org.deepin.ds.dock_ko.ts
+++ b/panels/dock/translations/org.deepin.ds.dock_ko.ts
@@ -1,17 +1,19 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ko">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ko">
 <context>
     <name>main</name>
     <message>
         <source>Indicator Style</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Fashion Mode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Efficient Mode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Classic Mode</source>
@@ -27,7 +29,7 @@
     </message>
     <message>
         <source>Position</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Mode</source>
@@ -51,19 +53,23 @@
     </message>
     <message>
         <source>Keep Shown</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Keep Hidden</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Smart Hide</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Dock Settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/panels/dock/translations/org.deepin.ds.dock_nb_NO.ts
+++ b/panels/dock/translations/org.deepin.ds.dock_nb_NO.ts
@@ -67,5 +67,9 @@
         <source>Dock Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Lock the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/panels/dock/translations/org.deepin.ds.dock_pl.ts
+++ b/panels/dock/translations/org.deepin.ds.dock_pl.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pl">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pl">
 <context>
     <name>main</name>
     <message>
@@ -64,6 +66,10 @@
     <message>
         <source>Dock Settings</source>
         <translation>Ustawienia doku</translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/panels/dock/translations/org.deepin.ds.dock_pt_BR.ts
+++ b/panels/dock/translations/org.deepin.ds.dock_pt_BR.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pt_BR">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pt_BR">
 <context>
     <name>main</name>
     <message>
@@ -64,6 +66,10 @@
     <message>
         <source>Dock Settings</source>
         <translation>Configurações do dock</translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/panels/dock/translations/org.deepin.ds.dock_ru.ts
+++ b/panels/dock/translations/org.deepin.ds.dock_ru.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ru">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ru">
 <context>
     <name>main</name>
     <message>
@@ -64,6 +66,10 @@
     <message>
         <source>Dock Settings</source>
         <translation>Настройки Dock</translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/panels/dock/translations/org.deepin.ds.dock_uk.ts
+++ b/panels/dock/translations/org.deepin.ds.dock_uk.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="uk">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="uk">
 <context>
     <name>main</name>
     <message>
@@ -64,6 +66,10 @@
     <message>
         <source>Dock Settings</source>
         <translation>Параметри бічної панелі</translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/panels/dock/translations/org.deepin.ds.dock_zh_CN.ts
+++ b/panels/dock/translations/org.deepin.ds.dock_zh_CN.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_CN">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_CN">
 <context>
     <name>main</name>
     <message>
@@ -64,6 +66,10 @@
     <message>
         <source>Dock Settings</source>
         <translation>任务栏设置</translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
+        <translation>禁用自由调节</translation>
     </message>
 </context>
 </TS>

--- a/panels/dock/translations/org.deepin.ds.dock_zh_HK.ts
+++ b/panels/dock/translations/org.deepin.ds.dock_zh_HK.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_HK">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_HK">
 <context>
     <name>main</name>
     <message>
@@ -64,6 +66,10 @@
     <message>
         <source>Dock Settings</source>
         <translation>任務欄設置</translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
+        <translation>禁用自由調節</translation>
     </message>
 </context>
 </TS>

--- a/panels/dock/translations/org.deepin.ds.dock_zh_TW.ts
+++ b/panels/dock/translations/org.deepin.ds.dock_zh_TW.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_TW">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_TW">
 <context>
     <name>main</name>
     <message>
@@ -64,6 +66,10 @@
     <message>
         <source>Dock Settings</source>
         <translation>任務欄設置</translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
+        <translation>禁用自由調節</translation>
     </message>
 </context>
 </TS>

--- a/panels/notification/bubble/translations/org.deepin.ds.notificationbubble_zh_HK.ts
+++ b/panels/notification/bubble/translations/org.deepin.ds.notificationbubble_zh_HK.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_HK">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_HK">
 <context>
     <name>notification::BubbleItem</name>
     <message>

--- a/panels/notification/bubble/translations/org.deepin.ds.notificationbubble_zh_TW.ts
+++ b/panels/notification/bubble/translations/org.deepin.ds.notificationbubble_zh_TW.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_TW">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_TW">
 <context>
     <name>notification::BubbleItem</name>
     <message>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_zh_HK.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_zh_HK.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_HK">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_HK">
 <context>
     <name>GroupNotify</name>
     <message>
@@ -52,7 +54,7 @@
     </message>
     <message>
         <source>Yesterday </source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_zh_TW.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_zh_TW.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_TW">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_TW">
 <context>
     <name>GroupNotify</name>
     <message>
@@ -52,7 +54,7 @@
     </message>
     <message>
         <source>Yesterday </source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/panels/notification/osd/displaymode/translations/org.deepin.ds.osd.displaymode_zh_CN.ts
+++ b/panels/notification/osd/displaymode/translations/org.deepin.ds.osd.displaymode_zh_CN.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_CN">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_CN">
 <context>
     <name>osd::DisPlayModeApplet</name>
     <message>

--- a/panels/notification/osd/displaymode/translations/org.deepin.ds.osd.displaymode_zh_HK.ts
+++ b/panels/notification/osd/displaymode/translations/org.deepin.ds.osd.displaymode_zh_HK.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_HK">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_HK">
 <context>
     <name>osd::DisPlayModeApplet</name>
     <message>

--- a/panels/notification/osd/displaymode/translations/org.deepin.ds.osd.displaymode_zh_TW.ts
+++ b/panels/notification/osd/displaymode/translations/org.deepin.ds.osd.displaymode_zh_TW.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_TW">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_TW">
 <context>
     <name>osd::DisPlayModeApplet</name>
     <message>


### PR DESCRIPTION
as title.

Log:

## Summary by Sourcery

Update translation files for dock and notification panels: standardize TS XML headers and formatting, and add missing localization entries.

New Features:
- Add "Lock the Dock" translation key in the dock settings across all languages
- Introduce translation entries for Dock taskmanager global actions: Open, Undock, Dock, Force Quit, and Close All

Enhancements:
- Normalize TS XML headers by adding encoding declarations and separate DOCTYPE lines
- Convert self-closing <translation> tags to explicit open/close tags and ensure proper language attributes in TS files