### PR TITLE
fix: The tray window panel automatically opens

### DIFF
--- a/panels/dock/tray/package/ActionShowStashDelegate.qml
+++ b/panels/dock/tray/package/ActionShowStashDelegate.qml
@@ -38,6 +38,14 @@ AppletItemButton {
 
         return Qt.point(x + width / 2, y + height / 2)
     }
+    Connections {
+        target: stashedPopup
+        function onPopupVisibleChanged() {
+            if (!stashedPopup.popupVisible && !stashedPopup.stashItemDragging) {
+                dropHoverIndex = -1
+            }
+        }
+    }
 
     onItemGlobalPointChanged: {
         stashedPopup.collapsedBtnCenterPoint = itemGlobalPoint


### PR DESCRIPTION
Introduce a Connections block to handle `stashedPopup.popupVisibleChanged` signal. When the popup is hidden and no item is being dragged, reset `dropHoverIndex` to -1. This ensures proper state management when the popup visibility changes.

pms: BUG-317959

## Summary by Sourcery

Bug Fixes:
- Reset dropHoverIndex when the stash popup is hidden and no item is dragging to prevent stale hover state.