### PR TITLE
chore: use ICU for relative dateime formatting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,7 @@ include(KDEGitCommitHooks)
 
 find_package(Qt${QT_VERSION_MAJOR} ${REQUIRED_QT_VERSION} REQUIRED COMPONENTS Core Gui Concurrent Quick WaylandClient DBus LinguistTools Sql)
 find_package(Dtk${DTK_VERSION_MAJOR} REQUIRED COMPONENTS Core Gui)
+find_package(ICU 74.2 REQUIRED COMPONENTS uc i18n io)
 find_package(WaylandProtocols REQUIRED)
 find_package(PkgConfig REQUIRED)
 

--- a/debian/control
+++ b/debian/control
@@ -21,6 +21,7 @@ Build-Depends:
  libdtk6core-dev,
  libdtk6widget-dev,
  libdtkcommon-dev,
+ libicu-dev,
  libxcb-ewmh-dev,
  libxcb-res0-dev,
  libxcb-util-dev,

--- a/panels/notification/CMakeLists.txt
+++ b/panels/notification/CMakeLists.txt
@@ -35,6 +35,9 @@ target_link_libraries(ds-notification-shared PUBLIC
     Qt${QT_VERSION_MAJOR}::Core
     Qt${QT_VERSION_MAJOR}::Sql
     Dtk${DTK_VERSION_MAJOR}::Core
+    ICU::uc
+    ICU::i18n
+    ICU::io
 )
 
 install(TARGETS ds-notification-shared DESTINATION "${LIB_INSTALL_DIR}")


### PR DESCRIPTION
使用 ICU 提供相对时间格式的时间展示,避免拼接字符串造成不易于本地化的问题.

## Summary by Sourcery

Use ICU libraries to provide localized relative datetime formatting in notification items, replacing manual string concatenation for improved i18n support.

Enhancements:
- Replace manual minute/hour/day string concatenation with ICU RelativeDateTimeFormatter for localized relative times
- Introduce SimpleDateFormat and formatter.combineDateAndTime to handle 'yesterday' time display via ICU
- Add utility functions to convert between ICU UnicodeString and QString
- Use QLocale::system().dateFormat for older date formatting

Build:
- Add ICU uc, i18n, and io dependencies in CMakeLists and link ICU libraries