### PR TITLE
fix: The tray application flashes an icon when opened

### DIFF
--- a/panels/dock/tray/package/ActionLegacyTrayPluginDelegate.qml
+++ b/panels/dock/tray/package/ActionLegacyTrayPluginDelegate.qml
@@ -29,7 +29,7 @@ AppletItemButton {
 
     padding: 0
 
-    visible: !Drag.active
+    visible: !Drag.active && itemVisible
     hoverEnabled: inputEventsEnabled
 
     function updatePluginMargins()

--- a/panels/dock/tray/package/ActionShowStashDelegate.qml
+++ b/panels/dock/tray/package/ActionShowStashDelegate.qml
@@ -12,7 +12,7 @@ import org.deepin.ds.dock.tray 1.0 as DDT
 
 AppletItemButton {
     id: root
-    property bool isDropHover: model.visualIndex === dropHoverIndex && dropHoverIndex !== -1
+    property bool isDropHover: model.visualIndex === dropHoverIndex && dropHoverIndex !== -1 && Panel.contextDragging
 
     icon.name: {
         switch (Panel.position) {

--- a/panels/dock/tray/package/StashedItemPositioner.qml
+++ b/panels/dock/tray/package/StashedItemPositioner.qml
@@ -4,10 +4,11 @@
 
 import QtQuick
 import QtQuick.Controls
+import org.deepin.ds.dock.tray 1.0 as DDT
 
 Control {
     id: root
-    property bool itemVisible: true
+    property bool itemVisible: !DDT.TraySortOrderModel.isUpdating
 
     spacing: 0
     padding: 0

--- a/panels/dock/tray/package/TrayItemPositioner.qml
+++ b/panels/dock/tray/package/TrayItemPositioner.qml
@@ -9,6 +9,9 @@ import org.deepin.ds.dock.tray 1.0 as DDT
 Control {
     id: root
     property bool itemVisible: {
+        if (DDT.TraySortOrderModel.isUpdating) {
+            return false
+        }
         if (model.sectionType === "collapsable") return !collapsed && model.visibility
         return model.sectionType !== "stashed" && model.visibility
     }

--- a/panels/dock/tray/traysortordermodel.cpp
+++ b/panels/dock/tray/traysortordermodel.cpp
@@ -328,6 +328,9 @@ QStandardItem *TraySortOrderModel::createTrayItem(const QString &name,
 
 void TraySortOrderModel::updateVisualIndexes()
 {
+    m_isUpdating = true;
+    emit isUpdatingChanged(true);
+    
     for (int i = 0; i < rowCount(); i++) {
         item(i)->setData(-1, TraySortOrderModel::VisualIndexRole);
     }
@@ -440,6 +443,9 @@ void TraySortOrderModel::updateVisualIndexes()
 
     // update visible item count property
     setProperty("visualItemCount", currentVisualIndex);
+    
+    m_isUpdating = false;
+    emit isUpdatingChanged(false);
 
     qDebug() << "update" << m_visualItemCount << currentVisualIndex;
 }

--- a/panels/dock/tray/traysortordermodel.h
+++ b/panels/dock/tray/traysortordermodel.h
@@ -25,6 +25,7 @@ class TraySortOrderModel : public QStandardItemModel
     Q_PROPERTY(bool collapsed MEMBER m_collapsed NOTIFY collapsedChanged)
     Q_PROPERTY(bool isCollapsing MEMBER m_isCollapsing NOTIFY isCollapsingChanged)
     Q_PROPERTY(bool actionsAlwaysVisible MEMBER m_actionsAlwaysVisible NOTIFY actionsAlwaysVisibleChanged)
+    Q_PROPERTY(bool isUpdating MEMBER m_isUpdating NOTIFY isUpdatingChanged)
     Q_PROPERTY(QList<QVariantMap> availableSurfaces MEMBER m_availableSurfaces NOTIFY availableSurfacesChanged)
 public:
     // enum SectionTypes {
@@ -67,6 +68,7 @@ signals:
     void collapsedChanged(bool);
     void isCollapsingChanged(bool);
     void actionsAlwaysVisibleChanged(bool);
+    void isUpdatingChanged(bool);
     void visualItemCountChanged(int);
     void availableSurfacesChanged(const QList<QVariantMap> &);
 
@@ -75,6 +77,7 @@ private:
     bool m_collapsed = false;
     bool m_isCollapsing = false;
     bool m_actionsAlwaysVisible = false;
+    bool m_isUpdating = false;
     std::unique_ptr<Dtk::Core::DConfig> m_dconfig;
     // this is for the plugins that currently available.
     QList<QVariantMap> m_availableSurfaces;


### PR DESCRIPTION
Improve tray item visibility handling during updates

- Add `isUpdating` flag to TraySortOrderModel to track visual index updates
- Hide tray items during model updates to prevent visual glitches
- Only show drop hover indicators during active drag operations
- Add `itemVisible` checks to delegate visibility conditions

This ensures smoother visual transitions when the tray model is being updated and prevents artifacts during drag operations.

pms: BUG-289521