### PR TITLE
chore: tweak role{group,combine}model

### DIFF
--- a/panels/dock/taskmanager/rolecombinemodel.cpp
+++ b/panels/dock/taskmanager/rolecombinemodel.cpp
@@ -126,23 +126,28 @@ RoleCombineModel::RoleCombineModel(QAbstractItemModel* major, QAbstractItemModel
 
     // create minor role map
     auto minorRolenames = m_minor->roleNames();
-    auto thisRoleNames = roleNames();
-    std::for_each(minorRolenames.constBegin(), minorRolenames.constEnd(), [&minorRolenames, &thisRoleNames, this](auto &roleName){
-        m_minorRolesMap.insert(thisRoleNames.key(roleName), minorRolenames.key(roleName));
+    m_roleNames = createRoleNames();
+    std::for_each(minorRolenames.constBegin(), minorRolenames.constEnd(), [&minorRolenames, this](auto &roleName) {
+        m_minorRolesMap.insert(m_roleNames.key(roleName), minorRolenames.key(roleName));
     });
 }
 
-QHash<int, QByteArray> RoleCombineModel::roleNames() const
+QHash<int, QByteArray> RoleCombineModel::createRoleNames() const
 {
     auto roleNames = sourceModel()->roleNames();
     auto keys = sourceModel()->roleNames().keys();
     auto lastRole = *(std::max_element(keys.constBegin(), keys.constEnd()));
     auto minorRoleNames = m_minor->roleNames().values();
-    std::for_each(minorRoleNames.constBegin(), minorRoleNames.constEnd(), [&lastRole, &roleNames, this](auto &roleName){
+    std::for_each(minorRoleNames.constBegin(), minorRoleNames.constEnd(), [&lastRole, &roleNames, this](auto &roleName) {
         roleNames.insert(++lastRole, roleName);
     });
 
     return roleNames;
+}
+
+QHash<int, QByteArray> RoleCombineModel::roleNames() const
+{
+    return m_roleNames;
 }
 
 int RoleCombineModel::rowCount(const QModelIndex &parent) const

--- a/panels/dock/taskmanager/rolecombinemodel.h
+++ b/panels/dock/taskmanager/rolecombinemodel.h
@@ -34,10 +34,15 @@ public:
     QModelIndex mapFromSource(const QModelIndex &sourceIndex) const override;
 
 private:
+    QHash<int, QByteArray> createRoleNames() const;
+
+private:
     QAbstractItemModel* m_minor;
 
     // Hash table used to map this QModelIndex row & column 2 origin QModelIndex row & column.
     QMap<QPair<int, int> ,QPair<int, int>> m_indexMap;
     // Hash table map role in this model to role in origin model.
     QHash<int, int> m_minorRolesMap;
+
+    QHash<int, QByteArray> m_roleNames;
 };

--- a/panels/dock/taskmanager/rolegroupmodel.cpp
+++ b/panels/dock/taskmanager/rolegroupmodel.cpp
@@ -109,6 +109,9 @@ void RoleGroupModel::setSourceModel(QAbstractItemModel *model)
 
 int RoleGroupModel::rowCount(const QModelIndex &parent) const
 {
+    if (!sourceModel()) {
+        return 0;
+    }
     if (parent.isValid()) {
         auto list = m_rowMap.value(parent.row(), nullptr);
         return nullptr == list ? 0 : list->size();


### PR DESCRIPTION
调整 RoleGroupModel 以及 RoleCombineModel 便于后续维护.

(这是迁移自图标拆分分支的变更)

Log:

## Summary by Sourcery

Refactor role handling in proxy models by splitting and caching roleNames in RoleCombineModel for easier maintenance, and add a safety check in RoleGroupModel::rowCount.

Enhancements:
- Refactor RoleCombineModel to separate roleNames creation into createRoleNames and cache results in m_roleNames
- Update RoleCombineModel’s minor role mapping to use the cached role names
- Add a null-check guard in RoleGroupModel::rowCount to handle unset source models