### PR TITLE
chore: bump version to 1.99.39

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,16 @@
+dde-shell (1.99.39) unstable; urgency=medium
+
+  * chore: tweak role{group,combine}model
+  * fix: fix warnings.
+  * feat: add activeWindow Dbus interface.
+  * i18n: Updates for project Deepin Desktop Environment (#1147)
+  * fix: The tray application flashes an icon when opened Improve tray
+    item visibility handling during updates
+  * fix: layershell calcular in x11 emulation
+  * chore: use ICU for relative dateime formatting
+
+ -- WuJiangYu <wujiangyu@uniontech.com>  Thu, 12 Jun 2025 17:50:39 +0800
+
 dde-shell (1.99.38) unstable; urgency=medium
 
   * fix: The tray window panel automatically opens 


### PR DESCRIPTION
update changelog to 1.99.39

## Summary by Sourcery

Chores:
- Update Debian changelog to reflect version 1.99.39