### PR TITLE
chore: set libdde-shell.so SOVERSION to 1

### DIFF
--- a/frame/CMakeLists.txt
+++ b/frame/CMakeLists.txt
@@ -87,7 +87,7 @@ qt_generate_wayland_protocol_client_sources(dde-shell-frame FILES
 
 set_target_properties(dde-shell-frame PROPERTIES
     VERSION ${CMAKE_PROJECT_VERSION}
-    SOVERSION ${CMAKE_PROJECT_VERSION_MAJOR}
+    SOVERSION 1
     OUTPUT_NAME dde-shell
     EXPORT_NAME Shell
 )


### PR DESCRIPTION
To separate version for other components and ABI version of libdde-shell.so

旨在允许任意 bump 打包时的版本号，避免需要各个依赖 `libdde-shell.so` 的项目 rebuild...

## Summary by Sourcery

Enhancements:
- Set libdde-shell.so SOVERSION to 1 to decouple the library's ABI version from the project version