### PR TITLE
feat: add preview follows the system opacity.

### DIFF
--- a/panels/dock/taskmanager/taskmanager.cpp
+++ b/panels/dock/taskmanager/taskmanager.cpp
@@ -152,6 +152,14 @@ bool TaskManager::init()
         m_windowFullscreen = isFullscreen;
         emit windowFullscreenChanged(isFullscreen);
     });
+
+    // 设置preview opacity
+    DS_NAMESPACE::DAppletBridge appearanceBridge("org.deepin.ds.dde-appearance");
+    auto appearanceApplet = appearanceBridge.applet();
+    if (appearanceApplet) {
+        modifyOpacityChanged();
+        connect(appearanceApplet, SIGNAL(opacityChanged()), this, SLOT(modifyOpacityChanged()));
+    }
     return true;
 }
 
@@ -416,6 +424,19 @@ void TaskManager::activateWindow(uint32_t windowID)
     qWarning() << "activateWindow not supported on this platform";
     Q_UNUSED(windowID)
 #endif
+}
+
+void TaskManager::modifyOpacityChanged()
+{
+    DS_NAMESPACE::DAppletBridge appearanceBridge("org.deepin.ds.dde-appearance");
+    auto appearanceApplet = appearanceBridge.applet();
+    if (appearanceApplet) {
+        double opacity = appearanceApplet->property("opacity").toReal();
+        auto x11Monitor = qobject_cast<X11WindowMonitor*>(m_windowMonitor.data());
+        x11Monitor->setPreviewOpacity(opacity);
+    }else{
+        qWarning() << "modifyOpacityChanged: appearanceApplet is null";
+    }
 }
 
 D_APPLET_CLASS(TaskManager)

--- a/panels/dock/taskmanager/taskmanager.h
+++ b/panels/dock/taskmanager/taskmanager.h
@@ -109,6 +109,7 @@ Q_SIGNALS:
 
 private Q_SLOTS:
     void handleWindowAdded(QPointer<AbstractWindow> window);
+    void modifyOpacityChanged();
 
 private:
     void loadDockedAppItems();

--- a/panels/dock/taskmanager/x11windowmonitor.cpp
+++ b/panels/dock/taskmanager/x11windowmonitor.cpp
@@ -45,6 +45,7 @@ bool XcbEventFilter::nativeEventFilter(const QByteArray &eventType, void *messag
 
 X11WindowMonitor::X11WindowMonitor(QObject* parent)
     : AbstractWindowMonitor(parent)
+    , m_opacity(0.2)
 {
     monitor = this;
     connect(this, &X11WindowMonitor::windowMapped, this, &X11WindowMonitor::onWindowMapped);
@@ -109,6 +110,7 @@ void X11WindowMonitor::showItemPreview(const QPointer<AppItem> &item, QObject* r
 
     if (m_windowPreview.isNull()) {
         m_windowPreview.reset(new X11WindowPreviewContainer(this));
+        m_windowPreview->setMaskAlpha(static_cast<int>(m_opacity * 255));
         m_windowPreview->windowHandle()->setTransientParent(qobject_cast<QWindow *>(relativePositionItem));
     }
 
@@ -139,6 +141,14 @@ void X11WindowMonitor::cancelPreviewWindow()
             .service("com.deepin.wm")
             .method("CancelPreviewWindow")
             .call().waitForFinished();
+}
+
+void X11WindowMonitor::setPreviewOpacity(double opacity)
+{
+    m_opacity = opacity;
+    if (!m_windowPreview.isNull()) {
+        m_windowPreview->setMaskAlpha(static_cast<int>(m_opacity * 255));
+    }
 }
 
 void X11WindowMonitor::onWindowMapped(xcb_window_t xcb_window)

--- a/panels/dock/taskmanager/x11windowmonitor.h
+++ b/panels/dock/taskmanager/x11windowmonitor.h
@@ -41,6 +41,7 @@ public:
     virtual void hideItemPreview() override;
     void previewWindow(uint32_t winId);
     void cancelPreviewWindow();
+    void setPreviewOpacity(double opacity);
 
 Q_SIGNALS:
     void windowMapped(xcb_window_t window);
@@ -62,5 +63,7 @@ private:
     QScopedPointer<XcbEventFilter> m_xcbEventFilter;
     QScopedPointer<X11WindowPreviewContainer> m_windowPreview;
     QHash<xcb_window_t, QSharedPointer<X11Window>> m_windows;
+    double m_opacity;
+
 };
 }


### PR DESCRIPTION
as title.

PMS-BUG-314371

## Summary by Sourcery

Add system opacity support to X11 window previews by subscribing to the Deepin appearance DBus interface and redrawing the preview background with the current opacity.

New Features:
- Retrieve system window opacity from org.deepin.dde.Appearance1 via DBus.
- Listen for opacity change signals and update preview transparency dynamically.
- Implement custom paintEvent to draw rounded preview backgrounds using the system opacity value.