### PR TITLE
feat: add smart hide when hide desktop.

### DIFF
--- a/panels/dock/x11dockhelper.h
+++ b/panels/dock/x11dockhelper.h
@@ -80,8 +80,12 @@ private Q_SLOTS:
 
     void updateDockArea();
 
+    // KWin D-Bus signal handler
+    void onShowingDesktopChanged(bool showing);
+
 private:
     friend class XcbEventFilter;
+    void setupKWinDBusConnection();
 
 private:
     QHash<xcb_window_t, X11DockWakeUpArea *> m_areas;
@@ -89,6 +93,7 @@ private:
     QHash<xcb_window_t, WindowData*> m_windows;
     XcbEventFilter *m_xcbHelper;
     QTimer *m_updateDockAreaTimer;
+    bool m_showingDesktop;
 };
 
 class X11DockWakeUpArea : public QObject, public DockWakeUpArea


### PR DESCRIPTION
as title.

PMS-BUG-309173

## Summary by Sourcery

Implement smart-hide on desktop-hide actions by monitoring window state transitions and updating dock visibility accordingly

New Features:
- Track and update window hidden state on _NET_WM_STATE changes (including Win+D desktop hide) to trigger smart-hide behavior

Enhancements:
- Always treat minimized or hidden windows as non-overlapping with the dock area