### PR TITLE
chore: adjust dockedElements DConfig

### DIFF
--- a/panels/dock/taskmanager/dconfig/org.deepin.ds.dock.taskmanager.json
+++ b/panels/dock/taskmanager/dconfig/org.deepin.ds.dock.taskmanager.json
@@ -44,7 +44,7 @@
 			"visibility": "private"
 		},
 		"dockedElements": {
-			"value": ["desktop/dde-file-manager", "desktop/deepin-app-storedesktop", "desktop/org.deepin.browser", "desktop/deepin-mail", "desktop/deepin-terminal", "desktop/dde-calendar", "desktop/deepin-music", "desktop/deepin-editor", "desktop/deepin-calculator", "desktop/org.deepin.dde.control-center", "desktop/dde-trash"],
+			"value": ["desktop/dde-file-manager", "desktop/deepin-app-store", "desktop/org.deepin.browser", "desktop/deepin-mail", "desktop/deepin-terminal", "desktop/dde-calendar", "desktop/deepin-music", "desktop/deepin-editor", "desktop/deepin-calculator", "desktop/org.deepin.dde.control-center"],
 			"serial": 0,
 			"flags": [],
 			"name": "dockedElements",


### PR DESCRIPTION
调整 dockedElements DConfig.
尽管这个配置目前还没有实装,但目前应当保持此配置的正确性,以及和现在在
实际使用的 Docked_Items 配置实际内容保持一致.

当前默认驻留项目遵循相关产品需求.
