### PR TITLE
feat: add icon theme change handling for X11 windows

### DIFF
--- a/panels/notification/center/notifystagingmodel.cpp
+++ b/panels/notification/center/notifystagingmodel.cpp
@@ -162,6 +162,10 @@ void NotifyStagingModel::open()
     if (entities.size() <= 0)
         return;
 
+    std::sort(entities.begin(), entities.end(), [](const NotifyEntity &item1, const NotifyEntity &item2) {
+        return item1.cTime() > item2.cTime();
+    });
+
     beginResetModel();
 
     const auto count = std::min(static_cast<int>(entities.size()), BubbleMaxCount);


### PR DESCRIPTION
1. Added resetIcon() method to X11Window class to clear cached icon and
emit change signal
2. Implemented icon theme change detection in X11WindowMonitor
3. Added connection to DGuiApplicationHelper's theme change signal
4. When theme changes, all window icons are reset to force reload with
new theme
5. This ensures task manager icons update properly when system icon
theme changes

feat: 为X11窗口添加图标主题变更处理

1. 在X11Window类中添加resetIcon()方法用于清除缓存的图标并发出变更信号
2. 在X11WindowMonitor中实现图标主题变更检测
3. 添加与DGuiApplicationHelper主题变更信号的连接
4. 当主题变更时，所有窗口图标会被重置以强制使用新主题重新加载
5. 这确保了任务管理器图标在系统图标主题变更时能正确更新

## Summary by Sourcery

Handle icon theme changes for X11 windows by clearing cached icons and forcing reload when the system icon theme changes

New Features:
- Detect system icon theme changes in X11WindowMonitor and trigger icon resets for all tracked windows
- Add X11Window::resetIcon() to clear cached icons and emit the iconChanged signal