### PR TITLE
fix: adapt import change of QtQml.Models in Qt 6.9

### DIFF
--- a/panels/dock/tray/package/StashedItemDelegateChooser.qml
+++ b/panels/dock/tray/package/StashedItemDelegateChooser.qml
@@ -8,7 +8,8 @@ import QtQuick.Layouts
 import org.deepin.dtk 1.0
 import org.deepin.ds.dock 1.0
 import Qt.labs.platform 1.1 as LP
-import Qt.labs.qmlmodels 1.2 as LQM // qml6-module-qt-labs-qmlmodels
+import Qt.labs.qmlmodels 1.2 as LQM // for Qt < 6.9
+import QtQml.Models as LQM // for Qt >= 6.9
 import org.deepin.ds.dock.tray 1.0 as DDT
 
 LQM.DelegateChooser {

--- a/panels/dock/tray/package/TrayItemDelegateChooser.qml
+++ b/panels/dock/tray/package/TrayItemDelegateChooser.qml
@@ -6,7 +6,8 @@ import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
 import Qt.labs.platform 1.1 as LP
-import Qt.labs.qmlmodels 1.2 as LQM // qml6-module-qt-labs-qmlmodels
+import Qt.labs.qmlmodels 1.2 as LQM // for Qt < 6.9
+import QtQml.Models as LQM // for Qt >= 6.9
 import org.deepin.ds.dock.tray 1.0 as DDT
 
 LQM.DelegateChooser {


### PR DESCRIPTION
修复 Qt 6.9 QtQml.Models 导入名称变化导致在 Qt 6.9 上托盘区域功能缺失的问题。

Log:

## Summary by Sourcery

Adapt model imports to restore tray area functionality on Qt 6.9 by conditionally importing Qt.labs.qmlmodels for older versions and QtQml.Models for Qt ≥6.9.

Bug Fixes:
- Restore missing tray area functionality on Qt 6.9 by updating QML model imports to QtQml.Models.

Enhancements:
- Add conditional imports for Qt.labs.qmlmodels and QtQml.Models to support both pre-Qt 6.9 and Qt 6.9+ environments.