### PR TITLE
fix: Fixed the blurriness of the preview window to separate the X11 a…

### DIFF
--- a/panels/dock/taskmanager/taskmanager.cpp
+++ b/panels/dock/taskmanager/taskmanager.cpp
@@ -432,9 +432,10 @@ void TaskManager::modifyOpacityChanged()
     auto appearanceApplet = appearanceBridge.applet();
     if (appearanceApplet) {
         double opacity = appearanceApplet->property("opacity").toReal();
-        auto x11Monitor = qobject_cast<X11WindowMonitor*>(m_windowMonitor.data());
-        x11Monitor->setPreviewOpacity(opacity);
-    }else{
+        if (auto x11Monitor = qobject_cast<X11WindowMonitor*>(m_windowMonitor.data())) {
+            x11Monitor->setPreviewOpacity(opacity);
+        }
+    } else {
         qWarning() << "modifyOpacityChanged: appearanceApplet is null";
     }
 }


### PR DESCRIPTION
…nd wayland environments.

PMS-BUG-314371 .

Logs:

## Summary by Sourcery

Bug Fixes:
- Apply preview opacity updates only when running on the XCB (X11) platform, avoiding unintended effects on Wayland