### PR TITLE
chore: reduce layershell emulate log message's log level

### DIFF
--- a/frame/layershell/dlayershellwindow.cpp
+++ b/frame/layershell/dlayershellwindow.cpp
@@ -127,7 +127,6 @@ void DLayerShellWindow::setKeyboardInteractivity(DLayerShellWindow::KeyboardInte
         d->keyboardInteractivity = interactivity;
         Q_EMIT keyboardInteractivityChanged();
     }
-    
 }
 
 DLayerShellWindow::KeyboardInteractivity DLayerShellWindow::keyboardInteractivity() const
@@ -164,7 +163,7 @@ void DLayerShellWindow::setCloseOnDismissed(bool close)
 {
     if (close != d->closeOnDismissed) {
         d->closeOnDismissed = close;
-    }   
+    }
 }
 
 void DLayerShellWindow::setScope(const QString& scope)
@@ -172,7 +171,7 @@ void DLayerShellWindow::setScope(const QString& scope)
     if (scope != d->scope) {
         d->scope = scope;
         Q_EMIT scopeChanged();
-    }   
+    }
 }
 
 QString DLayerShellWindow::scope() const
@@ -215,7 +214,7 @@ DLayerShellWindow::DLayerShellWindow(QWindow* window)
 #ifdef BUILD_WITH_X11
     else if (auto xcbWindow = dynamic_cast<QNativeInterface::Private::QXcbWindow*>(window->handle())) {
         new LayerShellEmulation(window, this);
-        qCWarning(layershellwindow) << "not a wayland window, try to emulate on x11";
+        qCInfo(layershellwindow) << "not a wayland window, try to emulate on x11";
     }
 #endif
     else {


### PR DESCRIPTION
降低 layershell 协议模拟行为对应的日志等级

## Summary by Sourcery

Reduce the log severity of the layershell X11 emulation warning and apply minor formatting cleanups

Chores:
- Change layershell fallback log from warning to info
- Remove extraneous trailing whitespace in setter methods