### PR TITLE
fix: sort notifications by timestamp before display

### DIFF
--- a/panels/notification/center/notifystagingmodel.cpp
+++ b/panels/notification/center/notifystagingmodel.cpp
@@ -162,6 +162,10 @@ void NotifyStagingModel::open()
     if (entities.size() <= 0)
         return;
 
+    std::sort(entities.begin(), entities.end(), [](const NotifyEntity &item1, const NotifyEntity &item2) {
+        return item1.cTime() > item2.cTime();
+    });
+
     beginResetModel();
 
     const auto count = std::min(static_cast<int>(entities.size()), BubbleMaxCount);


### PR DESCRIPTION
1. Added sorting of notification entities by creation time (cTime) in
descending order
2. Ensures newest notifications appear first in the list
3. Improves user experience by showing most recent notifications at
the top
4. Sorting happens before the model reset to maintain data consistency

fix: 在显示前按时间戳排序通知

1. 添加了按创建时间(cTime)降序排列通知实体的功能
2. 确保最新的通知显示在列表最前面
3. 通过将最新通知显示在顶部来提升用户体验
4. 排序操作在模型重置前完成以保持数据一致性

pms:BUG-299935

## Summary by Sourcery

Bug Fixes:
- Add sorting of notification entities by cTime in descending order to display the most recent notifications first