### PR TITLE
refactor: update notification handling and data access logic

### DIFF
--- a/panels/notification/center/notifystagingmodel.cpp
+++ b/panels/notification/center/notifystagingmodel.cpp
@@ -144,7 +144,7 @@ void NotifyStagingModel::remove(qint64 id)
 
             qDebug(notifyLog) << "Insert notify" << newEntity.bubbleId();
             beginInsertRows(QModelIndex(), insertedIndex, insertedIndex);
-            auto notify = new BubbleNotifyItem(newEntity);
+            auto notify = new AppNotifyItem(newEntity);
             m_appNotifies.insert(insertedIndex, notify);
             endInsertRows();
         }
@@ -170,7 +170,7 @@ void NotifyStagingModel::open()
 
     const auto count = std::min(static_cast<int>(entities.size()), BubbleMaxCount);
     for (int i = 0; i < count; i++) {
-        auto notify = new BubbleNotifyItem(entities.at(i));
+        auto notify = new AppNotifyItem(entities.at(i));
         m_appNotifies << notify;
     }
     updateOverlapCount(entities.size());

--- a/panels/notification/common/dataaccessorproxy.cpp
+++ b/panels/notification/common/dataaccessorproxy.cpp
@@ -16,6 +16,7 @@ DataAccessorProxy *DataAccessorProxy::instance()
     if (!gInstance) {
         gInstance = new DataAccessorProxy();
         gInstance->m_impl = new MemoryAccessor();
+        gInstance->m_source = new MemoryAccessor();
     }
     return gInstance;
 }
@@ -30,6 +31,12 @@ DataAccessorProxy::~DataAccessorProxy()
 
 void DataAccessorProxy::setSource(DataAccessor *source)
 {
+    if (!source)
+        return;
+
+    if (m_source) {
+        delete m_source;
+    }
     m_source = source;
 }
 
@@ -38,11 +45,11 @@ qint64 DataAccessorProxy::addEntity(const NotifyEntity &entity)
     if (entity.processedType() == NotifyEntity::NotProcessed) {
         return m_impl->addEntity(entity);
     } else {
-        if (m_source && m_source->isValid() && !filterToSource(entity)) {
+        if (!filterToSource(entity)) {
             return m_source->addEntity(entity);
         }
     }
-    return m_impl->addEntity(entity);
+    return -1;
 }
 
 qint64 DataAccessorProxy::replaceEntity(qint64 id, const NotifyEntity &entity)
@@ -50,35 +57,27 @@ qint64 DataAccessorProxy::replaceEntity(qint64 id, const NotifyEntity &entity)
     if (entity.processedType() == NotifyEntity::NotProcessed) {
         return m_impl->replaceEntity(id, entity);
     } else {
-        if (m_source && m_source->isValid()) {
-            return m_source->replaceEntity(id, entity);
-        }
+        return m_source->replaceEntity(id, entity);
     }
-    return m_impl->replaceEntity(id, entity);
 }
 
 void DataAccessorProxy::updateEntityProcessedType(qint64 id, int processedType)
 {
     if (routerToSource(id, processedType)) {
         m_impl->updateEntityProcessedType(id, processedType);
-        if (m_source && m_source->isValid()) {
-            auto entity = m_impl->fetchEntity(id);
-            if (!filterToSource(entity)) {
-                const auto sId = m_source->addEntity(entity);
-                if (sId > 0) {
-                    m_impl->removeEntity(id);
-                    entity.setId(sId);
-                }
-            } else {
+        auto entity = m_impl->fetchEntity(id);
+        if (!filterToSource(entity)) {
+            const auto sId = m_source->addEntity(entity);
+            if (sId > 0) {
                 m_impl->removeEntity(id);
+                entity.setId(sId);
             }
+        } else {
+            m_impl->removeEntity(id);
         }
-        return;
-    }
-    if (m_source && m_source->isValid()) {
+    } else {
         return m_source->updateEntityProcessedType(id, processedType);
     }
-    return m_impl->updateEntityProcessedType(id, processedType);
 }
 
 NotifyEntity DataAccessorProxy::fetchEntity(qint64 id)
@@ -86,10 +85,8 @@ NotifyEntity DataAccessorProxy::fetchEntity(qint64 id)
     auto entity = m_impl->fetchEntity(id);
     if (entity.isValid())
         return entity;
-    if (m_source && m_source->isValid()) {
-        return m_source->fetchEntity(id);
-    }
-    return {};
+
+    return m_source->fetchEntity(id);
 }
 
 int DataAccessorProxy::fetchEntityCount(const QString &appName, int processedType) const
@@ -97,11 +94,8 @@ int DataAccessorProxy::fetchEntityCount(const QString &appName, int processedTyp
     if (processedType == NotifyEntity::NotProcessed) {
         return m_impl->fetchEntityCount(appName, processedType);
     } else {
-        if (m_source && m_source->isValid()) {
-            return m_source->fetchEntityCount(appName, processedType);
-        }
+        return m_source->fetchEntityCount(appName, processedType);
     }
-    return m_impl->fetchEntityCount(appName, processedType);
 }
 
 NotifyEntity DataAccessorProxy::fetchLastEntity(const QString &appName, int processedType)
@@ -109,11 +103,8 @@ NotifyEntity DataAccessorProxy::fetchLastEntity(const QString &appName, int proc
     if (processedType == NotifyEntity::NotProcessed) {
         return m_impl->fetchLastEntity(appName, processedType);
     } else {
-        if (m_source && m_source->isValid()) {
-            return m_source->fetchLastEntity(appName, processedType);
-        }
+        return m_source->fetchLastEntity(appName, processedType);
     }
-    return m_impl->fetchLastEntity(appName, processedType);
 }
 
 NotifyEntity DataAccessorProxy::fetchLastEntity(uint notifyId)
@@ -121,10 +112,8 @@ NotifyEntity DataAccessorProxy::fetchLastEntity(uint notifyId)
     auto entity = m_impl->fetchLastEntity(notifyId);
     if (entity.isValid())
         return entity;
-    if (m_source && m_source->isValid()) {
-        return m_source->fetchLastEntity(notifyId);
-    }
-    return {};
+
+    return m_source->fetchLastEntity(notifyId);
 }
 
 QList<NotifyEntity> DataAccessorProxy::fetchEntities(const QString &appName, int processedType, int maxCount)
@@ -132,45 +121,32 @@ QList<NotifyEntity> DataAccessorProxy::fetchEntities(const QString &appName, int
     if (processedType == NotifyEntity::NotProcessed) {
         return m_impl->fetchEntities(appName, processedType, maxCount);
     }
-    if (m_source && m_source->isValid()) {
-        return m_source->fetchEntities(appName, processedType, maxCount);
-    }
-    return m_impl->fetchEntities(appName, processedType, maxCount);
+
+    return m_source->fetchEntities(appName, processedType, maxCount);
 }
 
 QList<QString> DataAccessorProxy::fetchApps(int maxCount) const
 {
-    if (m_source && m_source->isValid()) {
-        return m_source->fetchApps(maxCount);
-    }
-    return m_impl->fetchApps(maxCount);
+    return m_source->fetchApps(maxCount);
 }
 
 void DataAccessorProxy::removeEntity(qint64 id)
 {
-    m_impl->removeEntity(id);
-
-    if (m_source && m_source->isValid()) {
+    if (m_impl->fetchEntity(id).isValid()) {
+        m_impl->removeEntity(id);
+    } else {
         m_source->removeEntity(id);
     }
 }
 
 void DataAccessorProxy::removeEntityByApp(const QString &appName)
 {
-    m_impl->removeEntityByApp(appName);
-
-    if (m_source && m_source->isValid()) {
-        m_source->removeEntityByApp(appName);
-    }
+    m_source->removeEntityByApp(appName);
 }
 
 void DataAccessorProxy::clear()
 {
-    m_impl->clear();
-
-    if (m_source && m_source->isValid()) {
-        m_source->clear();
-    }
+    m_source->clear();
 }
 
 bool DataAccessorProxy::routerToSource(qint64 id, int processedType) const


### PR DESCRIPTION
1. Changed BubbleNotifyItem to AppNotifyItem in NotifyStagingModel for
better naming consistency
2. Simplified DataAccessorProxy by removing redundant source validity
checks
3. Improved entity routing logic with clearer conditions
4. Added proper source initialization in DataAccessorProxy constructor
5. Enhanced removeEntity() to check entity validity before removal
6. Streamlined clear() and removeEntityByApp() to only operate on source

The changes improve code maintainability and reduce redundant
checks while maintaining the same functionality. The naming change
from BubbleNotifyItem to AppNotifyItem better reflects the item's
purpose, and the data access logic simplification makes the code more
straightforward and less error-prone.

refactor: 更新通知处理和数据访问逻辑

1. 在 NotifyStagingModel 中将 BubbleNotifyItem 改为 AppNotifyItem 以提高
命名一致性
2. 通过移除冗余的源有效性检查简化了 DataAccessorProxy
3. 使用更清晰的条件改进了实体路由逻辑
4. 在 DataAccessorProxy 构造函数中添加了适当的源初始化
5. 增强了 removeEntity() 在删除前检查实体有效性
6. 简化了 clear() 和 removeEntityByApp() 使其仅操作源数据

这些变更提高了代码可维护性，在保持相同功能的同时减少了冗余检查。从
BubbleNotifyItem 到 AppNotifyItem 的命名更改更好地反映了项目的用途，数据
访问逻辑的简化使代码更加直接且不易出错。

pms: BUG-305735