### PR TITLE
chore: bump version to 2.0.3

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,14 @@
+dde-shell (2.0.3) unstable; urgency=medium
+
+  * feat: enhance notification validation and cleanup
+  * refactor: remove debug panel and legacy DBus code
+  * refactor: update notification handling and data access logic
+  * fix: sort notifications by timestamp before display
+  * i18n: Updates for project Deepin Desktop Environment (#1174)
+  * chore: reduce layershell emulate log message's log level
+
+ -- WuJiangYu <wujiangyu@uniontech.com>  Thu, 10 Jul 2025 20:15:01 +0800
+
 dde-shell (2.0.2) unstable; urgency=medium
 
   * fix: fix safe build.


### PR DESCRIPTION
update changelog to 2.0.3

## Summary by Sourcery

Bump project version to 2.0.3 and update Debian package changelog accordingly

Build:
- Update Debian changelog to version 2.0.3

Chores:
- Bump project version to 2.0.3