### PR TITLE
feat: enhance notification icon handling

### DIFF
--- a/panels/notification/bubble/bubbleitem.cpp
+++ b/panels/notification/bubble/bubbleitem.cpp
@@ -7,6 +7,8 @@
 #include <QUrl>
 #include <QTimer>
 #include <QImage>
+#include <QDir>
+#include <QFile>
 #include <QDBusArgument>
 #include <QTemporaryFile>
 #include <QLoggingCategory>
@@ -140,15 +142,24 @@ static QString imagePathOfNotification(const QVariantMap &hints, const QString &
     if (img.isNull()) {
         img = decodeImageFromBase64(imageData);
     }
+
     if (!img.isNull()) {
-        QTemporaryFile file("notification_icon");
-        img.save(file.fileName());
-        return file.fileName();
+        QTemporaryFile file(QDir::temp().filePath("notification_icon_XXXXXX.png"));
+        if (file.open()) {
+            QString filePath = file.fileName();
+            if (img.save(filePath)) {
+                file.setAutoRemove(false);
+                file.close();
+                qDebug(notifyLog) << "Created temporary icon file:" << filePath;
+                return filePath;
+            }
+
+            file.close();
+            return {};
+        }
     }
 
-    DGUI_USE_NAMESPACE;
-    auto icon = DIconTheme::findQIcon(appName, DIconTheme::findQIcon("application-x-desktop"));
-    return icon.name();
+    return {};
 }
 
 
@@ -164,6 +175,14 @@ BubbleItem::BubbleItem(const NotifyEntity &entity, QObject *parent)
     , m_timeTip(tr("just now"))
 {
     setEntity(entity);
+}
+
+BubbleItem::~BubbleItem()
+{
+    // clean up temporary icon file.
+    if (!m_tempIconPath.isEmpty() && QFile::exists(m_tempIconPath)) {
+        QFile::remove(m_tempIconPath);
+    }
 }
 
 void BubbleItem::setEntity(const NotifyEntity &entity)
@@ -192,13 +211,19 @@ QString BubbleItem::appName() const
     return m_entity.appName();
 }
 
-QString BubbleItem::appIcon() const
+QString BubbleItem::appIcon()
 {
     if (!m_entity.appIcon().isEmpty()) {
         return m_entity.appIcon();
     }
 
-    return imagePathOfNotification(m_entity.hints(), m_entity.appIcon(), m_entity.appName());
+    if (!m_tempIconPath.isEmpty() && QFile::exists(m_tempIconPath)) {
+        return m_tempIconPath;
+    }
+
+    m_tempIconPath = imagePathOfNotification(m_entity.hints(), m_entity.appIcon(), m_entity.appName());
+    // if this is empty path, UI can fallback to application-x-desktop icon.
+    return m_tempIconPath;
 }
 
 QString BubbleItem::summary() const

--- a/panels/notification/bubble/bubbleitem.h
+++ b/panels/notification/bubble/bubbleitem.h
@@ -18,6 +18,7 @@ public:
 
     explicit BubbleItem(QObject *parent = nullptr);
     explicit BubbleItem(const NotifyEntity &entity, QObject *parent = nullptr);
+    ~BubbleItem();
 
 public:
     void setEntity(const NotifyEntity &entity);
@@ -26,7 +27,7 @@ public:
     qint64 id() const;
     uint bubbleId() const;
     QString appName() const;
-    QString appIcon() const;
+    QString appIcon();
     QString summary() const;
     QString body() const;
     uint replacesId() const;
@@ -65,6 +66,7 @@ private:
     bool m_enablePreview = true;
     QVariantList m_actions;
     QString m_defaultAction;
+    QString m_tempIconPath;
 };
 
 }


### PR DESCRIPTION
as title

Log: as title

## Summary by Sourcery

Enhance notification icon handling by generating unique temporary icon files in the system temp directory, caching and cleaning them up in the BubbleItem lifecycle, and delegating fallback to the UI when no icon is available

Enhancements:
- Generate unique notification icon files using QTemporaryFile in the system temp directory with debug logging
- Cache the temporary icon path in BubbleItem and return it on subsequent calls to appIcon
- Introduce a BubbleItem destructor to remove the temporary icon file on object destruction
- Remove in-code fallback to a default theme icon to allow the UI to handle missing icons