### PR TITLE
fix: correct iterator position calculation in DockGlobalElementModel

### DIFF
--- a/panels/dock/taskmanager/dockglobalelementmodel.cpp
+++ b/panels/dock/taskmanager/dockglobalelementmodel.cpp
@@ -30,7 +30,7 @@ DockGlobalElementModel::DockGlobalElementModel(QAbstractItemModel *appsModel, Do
                 return std::get<1>(data) == m_appsModel && std::get<2>(data) == i;
             });
             if (it != m_data.end()) {
-                auto pos = it - m_data.end();
+                auto pos = it - m_data.begin();
                 beginRemoveRows(QModelIndex(), pos, pos);
                 m_data.remove(pos);
                 endRemoveRows();


### PR DESCRIPTION
1. Fixed incorrect calculation of position when removing elements from m_data
2. Changed from using m_data.end() to m_data.begin() for proper position determination
3. This ensures correct row removal behavior in the model's data management
4. Prevents potential crashes or incorrect model states due to invalid position calculations

fix: 修复 DockGlobalElementModel 中的迭代器位置计算问题

1. 修复了从 m_data 中移除元素时位置计算错误的问题
2. 将 m_data.end() 改为使用 m_data.begin() 以正确确定位置
3. 确保模型数据管理中的正确行移除行为
4. 防止由于无效位置计算导致的潜在崩溃或模型状态错误

Pms: BUG-318455 BUG-319543