### PR TITLE
fix: handle empty icon name in notification item

### DIFF
--- a/panels/notification/plugin/NotifyItemContent.qml
+++ b/panels/notification/plugin/NotifyItemContent.qml
@@ -124,7 +124,7 @@ NotifyItem {
         }
 
         DciIcon {
-            name: root.iconName
+            name: root.iconName !== "" ? root.iconName : "application-x-desktop"
             sourceSize: Qt.size(24, 24)
             Layout.alignment: Qt.AlignLeft | Qt.AlignTop
             Layout.topMargin: 8


### PR DESCRIPTION
1. Modified DciIcon name property to use a fallback value when iconName
is empty
2. Added default icon "application-x-desktop" to prevent missing icon
display
3. Ensures notifications always show an appropriate icon even when none
is specified

fix: 处理通知项中图标名称为空的情况

1. 修改 DciIcon 的 name 属性，在 iconName 为空时使用回退值
2. 添加默认图标 "application-x-desktop" 防止图标缺失显示
3. 确保即使未指定图标时通知也能显示适当的图标

pms: BUG-311315

## Summary by Sourcery

Bug Fixes:
- Use "application-x-desktop" as a default icon when iconName is empty to prevent missing icon display in notifications