### PR TITLE
chore: remove dde-control-center-dock package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -73,11 +73,3 @@ Depends: ${shlibs:Depends}, ${misc:Depends}, libdde-shell( =${binary:Version}),
 Multi-Arch: same
 Description: DDE Shell example
  This package contains some plugins based on dde-shell plugin system.
-
-Package: dde-control-center-dock
-Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}
-Conflicts: dde-dock-dcc-plugin
-Replaces: dde-dock-dcc-plugin
-Multi-Arch: same
-Description: A dock plugin for dde-control-center


### PR DESCRIPTION
1. Removed the dde-control-center-dock package definition from debian/ control
2. The functionality has been moved to the control center
3. This change reflects the consolidation of dock-related features into the main control center package

chore: 移除 dde-control-center-dock 包

1. 从 debian/control 文件中移除了 dde-control-center-dock 包定义
2. 相关功能已迁移至控制中心
3. 此变更反映了将停靠栏相关功能整合到主控制中心包中

## Summary by Sourcery

Build:
- Remove dde-control-center-dock package definition from debian/control and integrate its features into dde-control-center