### PR TITLE
fix: update connection for active window icon change

### DIFF
--- a/panels/dock/taskmanager/appitem.cpp
+++ b/panels/dock/taskmanager/appitem.cpp
@@ -327,7 +327,7 @@ void AppItem::updateCurrentActiveWindow(QPointer<AbstractWindow> window)
     }
 
     m_currentActiveWindow = window;
-    connect(m_currentActiveWindow.get(), &AbstractWindow::iconChanged, this, &AppItem::iconChanged);
+    connect(m_currentActiveWindow.get(), &AbstractWindow::iconChanged, this, &AppItem::iconChanged, Qt::QueuedConnection);
 
     Q_EMIT currentActiveWindowChanged();
 }


### PR DESCRIPTION
当前有多个源头触发 iconChanged: AppItem::currentActiveWindowChanged 和 DesktopfileAbstractParser::iconChanged。这会导致 iconName 的 loop binding。此修改将其中一个调整为 QueuedConnection 来避免循环绑定。

（注：是在尝试排查和修复其他 bug 时进行的修复，但发现这个修正并没有解决原本目标要解决的bug，只解决了这个警告）

## Summary by Sourcery

Bug Fixes:
- Change the connection for AbstractWindow::iconChanged in AppItem to a queued connection to prevent loop bindings