### PR TITLE
refactor: migrate taskmanager model to the new DockItemModel

### DIFF
--- a/panels/dock/taskmanager/abstractwindowmonitor.h
+++ b/panels/dock/taskmanager/abstractwindowmonitor.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "abstracttaskmanagerinterface.h"
 #include "abstractwindow.h"
 #include "taskmanager.h"
 
@@ -14,7 +15,7 @@
 
 namespace dock {
 class AppItem;
-class AbstractWindowMonitor : public QAbstractListModel
+class AbstractWindowMonitor : public QAbstractListModel, public AbstractTaskManagerInterface
 {
     Q_OBJECT
 
@@ -34,9 +35,19 @@ public:
     // TODO: remove this when Modelized finizhed.
     virtual QPointer<AbstractWindow> getWindowByWindowId(ulong windowId) = 0;
 
+    void requestActivate(const QModelIndex &index) const override;
+    void requestOpenUrls(const QModelIndex &index, const QList<QUrl> &urls) const override;
+    void requestNewInstance(const QModelIndex &index, const QString &action) const override;
+    void requestClose(const QModelIndex &index, bool force = false) const override;
+    void requestUpdateWindowGeometry(const QModelIndex &index, const QRect &geometry, QObject *delegate = nullptr) const override;
+
+    virtual void
+    requestPreview(QAbstractItemModel *sourceModel, QWindow *relativePositionItem, int32_t previewXoffset, int32_t previewYoffset, uint32_t direction) = 0;
+
+    void requestWindowsView(const QModelIndexList &indexes) const override;
+
     virtual void presentWindows(QList<uint32_t> windowsId) = 0;
 
-    virtual void showItemPreview(const QPointer<AppItem>& item, QObject* relativePositionItem, int32_t previewXoffset, int32_t previewYoffset, uint32_t direction) = 0;
     virtual void hideItemPreview() = 0;
 
 Q_SIGNALS:
@@ -44,6 +55,7 @@ Q_SIGNALS:
     // true -> At least one window is at fullscreen state. false -> none of the windows is at fullscreen state.
     void windowFullscreenChanged(bool);
     void WindowMonitorShutdown();
+    void previewShouldClear();
 
 private:
     QList<AbstractWindow*> m_trackedWindows;

--- a/panels/dock/taskmanager/dockcombinemodel.cpp
+++ b/panels/dock/taskmanager/dockcombinemodel.cpp
@@ -53,6 +53,7 @@ QVariant DockCombineModel::data(const QModelIndex &index, int role) const
         return res;
     }
     case TaskManager::IconNameRole: {
+        QString winTitle = RoleCombineModel::data(index, m_roleMaps.value(TaskManager::WinIconRole)).toString();
         auto icon = RoleCombineModel::data(index, m_roleMaps.value(TaskManager::IconNameRole)).toString();
         if (icon.isEmpty()) {
             icon = RoleCombineModel::data(index, m_roleMaps.value(TaskManager::WinIconRole)).toString();

--- a/panels/dock/taskmanager/dockgroupmodel.cpp
+++ b/panels/dock/taskmanager/dockgroupmodel.cpp
@@ -91,8 +91,10 @@ QVariantList DockGroupModel::all(const QModelIndex &index, int role) const
     QVariantList res;
     auto rowCount = RoleGroupModel::rowCount(index);
     for (int i = 0; i < rowCount; i++) {
-        auto window = RoleGroupModel::data(index, role);
-        if (window.isValid())
+        auto childIndex = RoleGroupModel::index(i, 0, index);
+        auto window = RoleGroupModel::data(childIndex, role);
+        // Check if the data is valid and not empty
+        if (window.isValid() && !window.toString().isEmpty())
             res.append(window);
     }
 

--- a/panels/dock/taskmanager/dockitemmodel.cpp
+++ b/panels/dock/taskmanager/dockitemmodel.cpp
@@ -95,8 +95,14 @@ void DockItemModel::setSourceModel(QAbstractItemModel *model)
 
 void DockItemModel::dumpItemInfo(const QModelIndex &index)
 {
-    qDebug() << "Index in DockItemModel:" << index << "DesktopIdRole:" << data(index, TaskManager::DesktopIdRole)
-             << "ItemIdRole:" << data(index, TaskManager::ItemIdRole) << "DockedRole:" << data(index, TaskManager::DockedRole);
+    // clang-format off
+    qDebug() << "Index in DockItemModel:" << index
+             << "DesktopIdRole:" << data(index, TaskManager::DesktopIdRole)
+             << "ItemIdRole:" << data(index, TaskManager::ItemIdRole)
+             << "WinIconRole:" << data(index, TaskManager::WinIconRole)
+             << "IconNameRole:" << data(index, TaskManager::IconNameRole)
+             << "DockedRole:" << data(index, TaskManager::DockedRole);
+    // clang-format on
 }
 
 QHash<int, QByteArray> DockItemModel::roleNames() const

--- a/panels/dock/taskmanager/package/TaskManager.qml
+++ b/panels/dock/taskmanager/package/TaskManager.qml
@@ -82,11 +82,13 @@ ContainmentItem {
             }
             delegate: Item {
                 id: delegateRoot
+                required property int index
                 required property bool active
                 required property bool attention
                 required property string itemId
                 required property string name
                 required property string iconName
+                required property string icon // winIconName
                 required property string menus
                 required property list<string> windows
                 z: attention ? -1 : 0
@@ -113,6 +115,7 @@ ContainmentItem {
                 implicitHeight: useColumnLayout ? visualModel.cellWidth : taskmanager.implicitHeight
 
                 property int visualIndex: DelegateModel.itemsIndex
+                property var modelIndex: visualModel.modelIndex(index)
 
                 AppItem {
                     id: app
@@ -126,9 +129,9 @@ ContainmentItem {
                     menus: delegateRoot.menus
                     windows: delegateRoot.windows
                     visualIndex: delegateRoot.visualIndex
+                    modelIndex: delegateRoot.modelIndex
                     ListView.delayRemove: Drag.active
                     Component.onCompleted: {
-                        clickItem.connect(taskmanager.Applet.clickItem)
                         dropFilesOnItem.connect(taskmanager.Applet.dropFilesOnItem)
                     }
                     onDragFinished: function() {

--- a/panels/dock/taskmanager/rolecombinemodel.cpp
+++ b/panels/dock/taskmanager/rolecombinemodel.cpp
@@ -318,7 +318,6 @@ QHash<int, QByteArray> RoleCombineModel::createRoleNames() const
     std::for_each(minorRoleNames.constBegin(), minorRoleNames.constEnd(), [&lastRole, &roleNames, this](auto &roleName) {
         roleNames.insert(++lastRole, roleName);
     });
-
     return roleNames;
 }
 

--- a/panels/dock/taskmanager/taskmanager.h
+++ b/panels/dock/taskmanager/taskmanager.h
@@ -10,7 +10,7 @@
 #include "dockcombinemodel.h"
 #include "dockglobalelementmodel.h"
 #include "dockitemmodel.h"
-#include "itemmodel.h"
+#include "hoverpreviewproxymodel.h"
 
 #include <QPointer>
 
@@ -63,7 +63,8 @@ public:
 
     explicit TaskManager(QObject* parent = nullptr);
 
-    ItemModel* dataModel();
+    DockItemModel *dataModel() const;
+    HoverPreviewProxyModel *hoverPreviewModel() const;
 
     virtual bool init() override;
     virtual bool load() override;
@@ -89,9 +90,7 @@ public:
     Q_INVOKABLE bool IsDocked(QString appID);
     Q_INVOKABLE bool RequestUndock(QString appID);
 
-    Q_INVOKABLE void clickItem(const QString& itemid, const QString& menuId);
-    Q_INVOKABLE void dropFilesOnItem(const QString& itemId, const QStringList& urls);
-    Q_INVOKABLE void showItemPreview(const QString& itemId, QObject* relativePositionItem, int32_t previewXoffset, int32_t previewYoffset, uint32_t direction);
+    Q_INVOKABLE void dropFilesOnItem(const QString &itemId, const QStringList &urls);
     Q_INVOKABLE void hideItemPreview();
 
     Q_INVOKABLE void setAppItemWindowIconGeometry(const QString& appid, QObject* relativePositionItem, const int& x1, const int& y1, const int& x2, const int& y2);
@@ -109,14 +108,12 @@ private Q_SLOTS:
     void modifyOpacityChanged();
 
 private:
-    void loadDockedAppItems();
-
-private:
     QScopedPointer<AbstractWindowMonitor> m_windowMonitor;
     bool m_windowFullscreen;
     DockCombineModel *m_activeAppModel = nullptr;
     DockGlobalElementModel *m_dockGlobalElementModel = nullptr;
     DockItemModel *m_itemModel = nullptr;
+    HoverPreviewProxyModel *m_hoverPreviewModel = nullptr;
 };
 
 }

--- a/panels/dock/taskmanager/treelandwindowmonitor.h
+++ b/panels/dock/taskmanager/treelandwindowmonitor.h
@@ -45,6 +45,7 @@ public:
 Q_SIGNALS:
     void entered();
     void exited();
+    void closed();
 
 protected:
     virtual void treeland_dock_preview_context_v1_enter() override;
@@ -70,8 +71,10 @@ public:
     virtual QPointer<AbstractWindow> getWindowByWindowId(ulong windowId) override;
 
     virtual void presentWindows(QList<uint32_t> windows) override;
-    virtual void showItemPreview(const QPointer<AppItem> &item, QObject* relativePositionItem, int32_t previewXoffset, int32_t previewYoffset, uint32_t direction) override;
     virtual void hideItemPreview() override;
+
+    void
+    requestPreview(QAbstractItemModel *sourceModel, QWindow *relativePositionItem, int32_t previewXoffset, int32_t previewYoffset, uint32_t direction) override;
 
 private Q_SLOTS:
     friend class ForeignToplevelManager;

--- a/panels/dock/taskmanager/x11preview.h
+++ b/panels/dock/taskmanager/x11preview.h
@@ -4,25 +4,24 @@
 
 #pragma once
 
-#include "appitem.h"
-#include "dsglobal.h"
-
 #include <cstdint>
 
-#include <DLabel>
-#include <QWidget>
-#include <QListView>
-#include <DToolButton>
-#include <QVBoxLayout>
 #include <DBlurEffectWidget>
 #include <DGuiApplicationHelper>
 #include <DIconButton>
+#include <DLabel>
+#include <DToolButton>
+#include <QListView>
+#include <QPointer>
+#include <QVBoxLayout>
+#include <QWidget>
+#include <QWindow>
 
 DWIDGET_USE_NAMESPACE
 
 namespace dock {
 class X11WindowMonitor;
-class AppItemWindowModel;
+class DockItemWindowModel;
 class AppItemWindowDeletegate;
 class PreviewsListView;
 
@@ -66,7 +65,10 @@ class X11WindowPreviewContainer: public DBlurEffectWidget
 
 public:
     explicit X11WindowPreviewContainer(X11WindowMonitor* monitor, QWidget *parent = nullptr);
-    void showPreview(const QPointer<AppItem> &item, const QPointer<QWindow> &window, int32_t previewXoffset, int32_t previewYoffset, uint32_t direction);
+
+    void
+    showPreviewWithModel(QAbstractItemModel *sourceModel, const QPointer<QWindow> &window, int32_t previewXoffset, int32_t previewYoffset, uint32_t direction);
+
     void hidePreView();
 
 protected:
@@ -80,7 +82,7 @@ protected:
 private:
     inline void updatePreviewTitle(const QString& title);
     inline void initUI();
-    inline void updateSize();
+    inline void updateSize(int windowCount = -1);
     void updatePreviewIconFromBase64(const QString &base64Data);
 
 public Q_SLOTS:
@@ -94,9 +96,8 @@ private:
     bool m_isPreviewEntered;
     int32_t m_isDockPreviewCount;
 
-    X11WindowMonitor* m_monitor;
-
-    AppItemWindowModel* m_model;
+    QPointer<X11WindowMonitor> m_monitor;
+    QAbstractItemModel *m_sourceModel;
     PreviewsListView* m_view;
     QWidget *m_titleWidget;
 
@@ -111,7 +112,6 @@ private:
     uint32_t m_direction;
 
     QPointer<QWindow> m_baseWindow;
-    QPointer<AppItem> m_previewItem;
 
     QString m_previewTitleStr;
 };

--- a/panels/dock/taskmanager/x11windowmonitor.h
+++ b/panels/dock/taskmanager/x11windowmonitor.h
@@ -5,10 +5,9 @@
 #pragma once
 
 #include "abstractwindow.h"
-#include "appitem.h"
-#include "x11window.h"
-#include "x11preview.h"
 #include "abstractwindowmonitor.h"
+#include "x11preview.h"
+#include "x11window.h"
 
 #include <cstdint>
 #include <xcb/xcb.h>
@@ -37,11 +36,14 @@ public:
 
     virtual QPointer<AbstractWindow> getWindowByWindowId(ulong windowId) override;
     virtual void presentWindows(QList<uint32_t> windows) override;
-    virtual void showItemPreview(const QPointer<AppItem> &item, QObject* relativePositionItem, int32_t previewXoffset, int32_t previewYoffset, uint32_t direction) override;
     virtual void hideItemPreview() override;
     void previewWindow(uint32_t winId);
     void cancelPreviewWindow();
     void setPreviewOpacity(double opacity);
+    void clearPreviewState();
+
+    void
+    requestPreview(QAbstractItemModel *sourceModel, QWindow *relativePositionItem, int32_t previewXoffset, int32_t previewYoffset, uint32_t direction) override;
 
 Q_SIGNALS:
     void windowMapped(xcb_window_t window);


### PR DESCRIPTION
PR 当前状态说明：

1. 相比 https://github.com/linuxdeepin/dde-shell/pull/1148 ，此 PR 状态仅负责 model 切换以及切换后基础功能的相应变更/重新实现
2. 原有代码关于“终端启动的应用的子进程”识别问题可以通过移除通过 AM 进行 cgroup 识别的调用来解决，但观察到有 360zip 这种不太对劲的 app 会在特定操作步骤后导致任务栏显示成齿轮。重构分支无此问题，在旧分支解决的意义可能不大。
3. 原有代码关于非子进程识别问题的图标错误合并情况大概率是应用列表刷新时机的问题，旧的结构上只能绕过，不太方便根治。
4. 此 PR 【目前】状态有一些功能未补全，包括关闭窗口时的预览状态等。这也是当前标记为 draft 的原因，挂一个 PR 旨在方便看 diff，不用在 worktree 之间切来切去。

---

切换 taskmanager 区域的 model 为新的 DockItemModel,以解决一系列问题:

1. 部分场景下企业微信和微信图标合并/钉钉和微信合并等问题
2. 终端执行 gitk/dde-dconfig-editor 时不会单独显示任务栏图标
3. 没有 desktop-id 的带界面的可执行程序不会单独显示任务栏图标
4. 开机后部分场景（AM启动晚于任务栏时）可能导致任务栏驻留全部消失

---

进展跟进：

- ✅ DockItemModel 相关 Model 和 ProxyModel 并入主线
- ✅ https://github.com/linuxdeepin/dde-shell/pull/1212 任务栏图标能够拖拽调整顺序
- ✅ https://github.com/linuxdeepin/dde-shell/pull/1213 记住拖拽调整后的图标顺序
- ✅ https://github.com/linuxdeepin/dde-shell/pull/1233 图标显示正确预览图，并跟随窗口状态增加、减少预览中的窗口数量
- ✅ https://github.com/linuxdeepin/dde-shell/pull/1229 图标右键菜单工作正常
- 🚧 主干切换为 DockItemModel （即此 PR）

状态说明：

- 🚧 施工中
- ✅ 相关修改已并入主线，并 rebase 当前分支至主干合入相关修改后的commit之上
- 无 emoji 则必定提供 PR 链接，表示相关 PR 已就绪，待 review 或已合入但还未 rebase 此分支

## Summary by Sourcery

Migrate the TaskManager from the old AppItem/ItemModel architecture to the new DockItemModel, refactor preview and activation APIs, and update QML bindings and tests accordingly.

New Features:
- Replace AppItemWindowModel with DockItemWindowModel that drives window previews from QModelIndexList.
- Implement AbstractTaskManagerInterface methods (requestActivate, requestClose, requestPreview, etc.) in window monitors.
- Add fetchWindowPreview using KWin ScreenShot2 D-Bus interface for accurate window preview snapshots.

Bug Fixes:
- Eliminate icon-merging problems (e.g. WeChat, Enterprise WeChat) by switching to the new dock model.

Enhancements:
- Simplify QML by replacing legacy clickItem/drop signals with TaskManager.requestActivate and requestNewInstance using modelIndex.
- Remove outdated docking drop-area hacks and delay window monitor startup for proper initialization.

Tests:
- Include QAbstractItemModelTester in combine/group model tests to strengthen model validation.