### PR TITLE
fix: prevent duplicate dock requests

### DIFF
--- a/panels/dock/taskmanager/taskmanager.cpp
+++ b/panels/dock/taskmanager/taskmanager.cpp
@@ -344,7 +344,12 @@ QString TaskManager::desktopIdToAppId(const QString& desktopId)
 bool TaskManager::requestDockByDesktopId(const QString& desktopID)
 {
     if (desktopID.startsWith("internal/")) return false;
-    return RequestDock(desktopIdToAppId(desktopID));
+    QString appId = desktopIdToAppId(desktopID);
+    // 检查应用是否已经在任务栏中，如果是则返回 false
+    if (IsDocked(appId)) 
+        return false;
+    
+    return RequestDock(appId);
 }
 
 bool TaskManager::requestUndockByDesktopId(const QString& desktopID)


### PR DESCRIPTION
1. Added check for existing docked applications in requestDockByDesktopId
2. Return false if application is already docked to avoid duplicate entries
3. Improves user experience by preventing redundant dock requests
4. Maintains cleaner taskbar state by avoiding duplicate icons

fix: 防止重复的dock请求

1. 在requestDockByDesktopId中添加对已dock应用的检查
2. 如果应用已经dock则返回false避免重复条目
3. 通过防止冗余的dock请求提升用户体验
4. 避免重复图标保持任务栏状态更整洁

Pms: BUG-315721