### PR TITLE
feat: add keyboard focus management for plugin surfaces

### DIFF
--- a/panels/dock/pluginmanagerextension_p.h
+++ b/panels/dock/pluginmanagerextension_p.h
@@ -9,6 +9,8 @@
 #include <QtWaylandCompositor/QWaylandCompositor>
 #include <QtWaylandCompositor/QWaylandSurface>
 #include <QtWaylandCompositor/QWaylandResource>
+#include <QtWaylandCompositor/QWaylandSeat>
+
 #include <cstdint>
 
 #include "qwayland-server-fractional-scale-v1.h"
@@ -75,6 +77,9 @@ public:
     void setDockSize(const QSize &newDockSize);
 
     void removePluginSurface(PluginSurface *plugin);
+
+    //处理鼠标焦点给到相应插件
+    void setupMouseFocusListener();
 
 Q_SIGNALS:
     void pluginPopupCreated(PluginPopup*);


### PR DESCRIPTION
1. Added setKeyboardFocus method to PluginSurface class to handle keyboard focus via Wayland seat
2. Exposed the method as Q_INVOKABLE for QML access
3. Implemented focus handling in ShellSurfaceItemProxy when hovered
4. Includes necessary QWaylandSeat header for keyboard focus management
5. This ensures proper keyboard input handling when interacting with plugin surfaces

feat: 为插件表面添加键盘焦点管理

1. 在 PluginSurface 类中添加 setKeyboardFocus 方法，通过 Wayland seat 处 理键盘焦点
2. 将方法暴露为 Q_INVOKABLE 以便 QML 访问
3. 在 ShellSurfaceItemProxy 中实现悬停时的焦点处理
4. 包含必要的 QWaylandSeat 头文件用于键盘焦点管理
5. 确保与插件表面交互时能正确处理键盘输入

Pms: BUG-312795

## Summary by Sourcery

Introduce keyboard focus management for plugin surfaces in the compositor and QML layer

New Features:
- Add setKeyboardFocus method to PluginSurface to assign keyboard focus via the Wayland seat
- Expose setKeyboardFocus as Q_INVOKABLE for QML access
- Invoke setKeyboardFocus in ShellSurfaceItemProxy on hover to enable keyboard input

Enhancements:
- Include QWaylandSeat header to support keyboard focus operations