### PR TITLE
fix: prevent duplicate taskbar entries during drag

### DIFF
--- a/panels/dock/taskmanager/package/TaskManager.qml
+++ b/panels/dock/taskmanager/package/TaskManager.qml
@@ -149,7 +149,7 @@ ContainmentItem {
                 let desktopId = drag.getDataAsString("text/x-dde-dock-dnd-appid")
                 launcherDndDragSource = drag.getDataAsString("text/x-dde-dock-dnd-source")
                 launcherDndDesktopId = desktopId
-                if (taskmanager.Applet.requestDockByDesktopId(desktopId) === false) {
+                if (launcherDndDragSource !== "taskbar" && taskmanager.Applet.requestDockByDesktopId(desktopId) === false) {
                     resetDndState()
                 }
             }


### PR DESCRIPTION
1. Added check for drag source before processing dock request
2. Prevents duplicate entries when dragging between taskbars
3. Only processes dock request if source is not another taskbar
4. Maintains clean taskbar state during drag operations

fix: 防止拖拽时任务栏出现重复条目

1. 在处理停靠请求前添加了对拖动源的检查
2. 防止在任务栏之间拖拽时出现重复条目
3. 仅当来源不是其他任务栏时才处理停靠请求
4. 在拖拽操作期间保持任务栏状态整洁

## Summary by Sourcery

Bug Fixes:
- Add drag source check to gate dock requests to non-taskbar origins and avoid duplicate entries when dragging between taskbars