### PR TITLE
fix: add translation resources to config for multitasking view

### DIFF
--- a/.tx/transifex.yaml
+++ b/.tx/transifex.yaml
@@ -15,6 +15,11 @@ filters:
       source_language: en_US
       translation_files_expression: panels/dock/tray/translations/org.deepin.ds.dock.tray_<lang>.ts
     - filter_type: file
+      source_file: panels/dock/multitaskview/translations/org.deepin.ds.dock.multitaskview.ts
+      file_format: QT
+      source_language: en_US
+      translation_files_expression: panels/dock/multitaskview/translations/org.deepin.ds.dock.multitaskview_<lang>.ts
+    - filter_type: file
       source_file: panels/notification/bubble/translations/org.deepin.ds.notificationbubble.ts
       file_format: QT
       source_language: en_US

--- a/panels/dock/multitaskview/translations/org.deepin.ds.dock.multitaskview_zh_HK.ts
+++ b/panels/dock/multitaskview/translations/org.deepin.ds.dock.multitaskview_zh_HK.ts
@@ -1,18 +1,18 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE TS>
-<TS version="2.1">
-<context>
-    <name>dock::MultiTaskView</name>
-    <message>
-        <source>Multitasking View</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>multitaskview</name>
-    <message>
-        <source>Multitasking View</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
+<TS language="zh_HK" version="2.1">
+    <context>
+        <name>dock::MultiTaskView</name>
+        <message>
+            <source>Multitasking View</source>
+            <translation>多任務視圖</translation>
+        </message>
+    </context>
+    <context>
+        <name>multitaskview</name>
+        <message>
+            <source>Multitasking View</source>
+            <translation>多任務視圖</translation>
+        </message>
+    </context>
 </TS>

--- a/panels/dock/multitaskview/translations/org.deepin.ds.dock.multitaskview_zh_TW.ts
+++ b/panels/dock/multitaskview/translations/org.deepin.ds.dock.multitaskview_zh_TW.ts
@@ -1,18 +1,18 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE TS>
-<TS version="2.1">
-<context>
-    <name>dock::MultiTaskView</name>
-    <message>
-        <source>Multitasking View</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>multitaskview</name>
-    <message>
-        <source>Multitasking View</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
+<TS language="zh_TW" version="2.1">
+    <context>
+        <name>dock::MultiTaskView</name>
+        <message>
+            <source>Multitasking View</source>
+            <translation>多工檢視</translation>
+        </message>
+    </context>
+    <context>
+        <name>multitaskview</name>
+        <message>
+            <source>Multitasking View</source>
+            <translation>多工檢視</translation>
+        </message>
+    </context>
 </TS>


### PR DESCRIPTION
为多任务视图插件添加翻译资源文件.

## Summary by Sourcery

Add Chinese translations for the multitasking view plugin and register them in the Transifex configuration

Enhancements:
- Provide Traditional Chinese (Hong Kong) translations for the multitasking view plugin
- Provide Traditional Chinese (Taiwan) translations for the multitasking view plugin

Build:
- Add multitaskview translation resource entry to .tx/transifex.yaml