### PR TITLE
chore: avoid using cell width to calculate target index for taskbar

### DIFF
--- a/panels/dock/OverflowContainer.qml
+++ b/panels/dock/OverflowContainer.qml
@@ -47,6 +47,10 @@ Item {
         }
     }
 
+    function indexAt(x, y) {
+        return listView.indexAt(x, y)
+    }
+
     implicitWidth: {
         let width = 0
         for (let child of listView.contentItem.visibleChildren) {


### PR DESCRIPTION
避免使用固定的任务栏图标宽度来计算当前拖拽的目标项的索引.

这个修改旨在下面两点:

1. 为后续任务栏图标不固定长度做准备(图标+标题)
2. 为后续ItemModel解耦做准备,便于重构分支合入(重构分支使用DelegateModel 的 items 属性维护的顺序表示任务栏上的图标顺序,因而无法直接使用此处 原本的下标计算方式)

(下一步是规避使用 ItemModel::moveTo() 接口)

## Summary by Sourcery

Remove reliance on fixed cell widths for taskbar item reordering by using ListView.indexAt and DelegateModel indices

Enhancements:
- Introduce findTargetIndexByPosition using ListView.indexAt and expose indexAt in OverflowContainer
- Update drag and drop handlers to use the new target index method for dataModel.moveTo
- Switch visualModel.items.move calls to use DelegateModel.itemsIndex instead of fixed visualIndex