### PR TITLE
refactor: migrated docked items config to TASKMANAGER_DOCKEDELEMENTS_KEY

### DIFF
--- a/panels/dock/taskmanager/dconfig/org.deepin.ds.dock.taskmanager.json
+++ b/panels/dock/taskmanager/dconfig/org.deepin.ds.dock.taskmanager.json
@@ -38,8 +38,8 @@
 			"serial": 0,
 			"flags": [],
 			"name": "Docked_Items",
-			"name[zh_CN]": "已固定项目",
-			"description": "The default apps which is docked when dock is started.",
+			"name[zh_CN]": "已固定项目(已弃用)",
+			"description": "`Docked_Items` is deprecated, please use `dockedElements` instead",
 			"permissions": "readwrite",
 			"visibility": "private"
 		},

--- a/panels/dock/taskmanager/desktopfileabstractparser.cpp
+++ b/panels/dock/taskmanager/desktopfileabstractparser.cpp
@@ -134,10 +134,7 @@ bool DesktopfileAbstractParser::isDocked()
         return false;
     }
 
-    QJsonObject desktopfile;
-    desktopfile["type"] = type();
-    desktopfile["id"] = id();
-    return TaskManagerSettings::instance()->dockedDesktopFiles().contains(desktopfile);
+    return TaskManagerSettings::instance()->isDocked(QStringLiteral("desktop/%1").arg(id()));
 }
 
 void DesktopfileAbstractParser::setDocked(bool docked)
@@ -147,14 +144,12 @@ void DesktopfileAbstractParser::setDocked(bool docked)
         return;
     }
 
-    QJsonObject desktopfile;
-    desktopfile["type"] = type();
-    desktopfile["id"] = id();
+    auto desktopElement = QStringLiteral("desktop/%1").arg(id());
 
     if (docked) {
-        TaskManagerSettings::instance()->appnedDockedDesktopfiles(desktopfile);
+        TaskManagerSettings::instance()->appendDockedElements(desktopElement);
     } else {
-        TaskManagerSettings::instance()->removeDockedDesktopfile(desktopfile);
+        TaskManagerSettings::instance()->removeDockedElements(desktopElement);
     }
 
     Q_EMIT dockedChanged();

--- a/panels/dock/taskmanager/itemmodel.cpp
+++ b/panels/dock/taskmanager/itemmodel.cpp
@@ -72,29 +72,6 @@ QVariant ItemModel::data(const QModelIndex &index, int role) const
     return QVariant();
 }
 
-void ItemModel::moveTo(const QString &id, int dIndex)
-{
-    // simply do nothing if dIndex is invalid
-    if (dIndex >= m_items.size() || dIndex < 0) {
-        return;
-    }
-
-    auto sItem = getItemById(id);
-    auto dItem = m_items.at(dIndex);
-
-    int sIndex = m_items.indexOf(sItem);
-    if (sIndex == dIndex) {
-        return;
-    }
-    beginMoveRows(QModelIndex(), sIndex, sIndex, QModelIndex(), dIndex > sIndex ? (dIndex + 1) : dIndex);
-    m_items.move(sIndex, dIndex);
-    endMoveRows();
-
-    if (sItem->isDocked() || dItem->isDocked()) {
-        TaskManagerSettings::instance()->setDockedDesktopFiles(dumpDockedItems());
-    }
-}
-
 QJsonArray ItemModel::dumpDockedItems() const
 {
     QJsonArray result;

--- a/panels/dock/taskmanager/itemmodel.h
+++ b/panels/dock/taskmanager/itemmodel.h
@@ -31,7 +31,6 @@ public:
     static ItemModel* instance();
     Q_INVOKABLE int rowCount(const QModelIndex &parent = QModelIndex()) const Q_DECL_OVERRIDE;
     Q_INVOKABLE QVariant data(const QModelIndex &index, int role = ItemIdRole) const Q_DECL_OVERRIDE;
-    Q_INVOKABLE void moveTo(const QString &id, int index);
 
     QHash<int, QByteArray> roleNames() const Q_DECL_OVERRIDE;
 

--- a/panels/dock/taskmanager/taskmanager.h
+++ b/panels/dock/taskmanager/taskmanager.h
@@ -99,6 +99,7 @@ public:
 
     Q_INVOKABLE void setAppItemWindowIconGeometry(const QString& appid, QObject* relativePositionItem, const int& x1, const int& y1, const int& x2, const int& y2);
     Q_INVOKABLE void activateWindow(uint32_t windowID);
+    Q_INVOKABLE void saveDockElementsOrder(const QStringList &appIds);
 
 Q_SIGNALS:
     void dataModelChanged();

--- a/panels/dock/taskmanager/taskmanagersettings.h
+++ b/panels/dock/taskmanager/taskmanagersettings.h
@@ -29,16 +29,16 @@ public:
     bool isWindowSplit();
     void setWindowSplit(bool split);
 
-    void setDockedDesktopFiles(QJsonArray desktopfiles);
-    void appnedDockedDesktopfiles(QJsonObject desktopfile);
-    void removeDockedDesktopfile(QJsonObject desktopfile);
-    QJsonArray dockedDesktopFiles();
-    QStringList dockedElements();
+    void setDockedElements(const QStringList &elements);
+    void appendDockedElements(const QString &element);
+    void removeDockedElements(const QString &element);
+    QStringList dockedElements() const;
+    bool isDocked(const QString &elementId) const;
 
 private:
     explicit TaskManagerSettings(QObject *parent = nullptr);
-    inline void dockedItemsPersisted();
-    inline void loadDockedItems();
+    inline void migrateFromDockedItems();
+    inline void saveDockedElements();
 
 Q_SIGNALS:
     void allowedForceQuitChanged();
@@ -51,7 +51,6 @@ private:
 
     bool m_allowForceQuit;
     bool m_windowSplit;
-    QJsonArray m_dockedItems;
     QStringList m_dockedElements;
 };
 }


### PR DESCRIPTION
使 ItemModel 使用新的任务栏驻留配置,并确保任务栏驻留顺序的保存位置也使用
新的任务栏驻留配置.

此提交旨在进一步与 ItemModel 解耦,便于后续模型切换重构分支的合入.

## Summary by Sourcery

Refactor TaskManager to migrate docked items configuration from the deprecated TASKMANAGER_DOCKEDITEMS_KEY to the new TASKMANAGER_DOCKEDELEMENTS_KEY, unify docking APIs around element ID strings, and update drag-and-drop reordering logic accordingly.

New Features:
- Introduce saveDockElementsOrder invokable in TaskManager to persist user reordering of docked elements.

Enhancements:
- Migrate legacy docked items from YAML-based config to a string list under TASKMANAGER_DOCKEDELEMENTS_KEY with automatic data migration and deprecation warning for the old key.
- Replace TaskManagerSettings’ dockedDesktopFiles API with set/append/remove methods and an isDocked query using element ID strings.
- Remove ItemModel.moveTo and shift item reordering logic into TaskManager and QML, adjusting drag-and-drop to operate on element IDs.
- Update DesktopfileAbstractParser to use the new string-based docking API instead of JSON objects.