### PR TITLE
chore: change item delegate for taskmanager from DropArea to Item

### DIFF
--- a/panels/dock/taskmanager/package/TaskManager.qml
+++ b/panels/dock/taskmanager/package/TaskManager.qml
@@ -80,7 +80,7 @@ ContainmentItem {
             onCountChanged: function() {
                 relayoutWorkaroundTimer.start()
             }
-            delegate: DropArea {
+            delegate: Item {
                 id: delegateRoot
                 required property bool active
                 required property bool attention
@@ -89,7 +89,6 @@ ContainmentItem {
                 required property string iconName
                 required property string menus
                 required property list<string> windows
-                keys: ["text/x-dde-dock-dnd-appid"]
                 z: attention ? -1 : 0
                 property bool visibility: itemId !== taskmanager.Applet.desktopIdToAppId(launcherDndDropArea.launcherDndDesktopId)
 
@@ -112,11 +111,6 @@ ContainmentItem {
                 // TODO: 临时溢出逻辑，待后面修改
                 implicitWidth: useColumnLayout ? taskmanager.implicitWidth : visualModel.cellWidth
                 implicitHeight: useColumnLayout ? visualModel.cellWidth : taskmanager.implicitHeight
-
-                onEntered: function(drag) {
-                    // TODO: this is actually unused, should change the delegateRoot type from DropArea to Item later.
-                    visualModel.items.move(drag.source.DelegateModel.itemsIndex, delegateRoot.DelegateModel.itemsIndex)
-                }
 
                 property int visualIndex: DelegateModel.itemsIndex
 


### PR DESCRIPTION
将 taskmanager 组件的 item delegate 调整为 Item

这里应该是引入 `launcherDndDropArea` 之前的逻辑，由每个 item 自己处理被拖拽到图标上后的移动行为。现在应该没有实际再被使用了（拖拽事件会被 `launcherDndDropArea` 接受并处理，不会到 Item 自己的 DropArea 上），所以直接将其调整回 Item。

## Summary by Sourcery

Revert the TaskManager item delegate from DropArea to Item and remove its unused drag-and-drop code.

Chores:
- Change TaskManager item delegate type from DropArea to Item.
- Remove unused keys property and onEntered handler now handled by launcherDndDropArea.