### PR TITLE
fix: handle NoDisplay apps in notification settings

### DIFF
--- a/panels/notification/server/notificationmanager.cpp
+++ b/panels/notification/server/notificationmanager.cpp
@@ -207,6 +207,8 @@ uint NotificationManager::Notify(const QString &appName, uint replacesId, const 
     auto tsAppName = m_setting->appValue(appId, NotificationSetting::AppName).toString();
     if (tsAppName.isEmpty()) {
         tsAppName = appName;
+    } else {
+        qCDebug(notifyLog) << "AppName is translated from AM, which appId is:" << appId;
     }
 
     QString strBody = body;

--- a/panels/notification/server/notificationsetting.cpp
+++ b/panels/notification/server/notificationsetting.cpp
@@ -247,9 +247,6 @@ QList<NotificationSetting::AppItem> NotificationSetting::appItemsImpl() const
     apps.reserve(m_appAccessor->rowCount());
     for (int i = 0; i < m_appAccessor->rowCount(); i++) {
         const auto index = m_appAccessor->index(i, 0);
-        const auto nodisplay = m_appAccessor->data(index, NoDisplayRole).toBool();
-        if (nodisplay)
-            continue;
 
         const auto desktopId = m_appAccessor->data(index, DesktopIdRole).toString();
         const auto icon = m_appAccessor->data(index, IconNameRole).toString();


### PR DESCRIPTION
1. Removed NoDisplay app filtering in
NotificationSetting::appItemsImpl() to ensure all apps are processed
2. Added debug log in NotificationManager::Notify() to track when app
names are translated from AM
3. This fixes an issue where applications marked as NoDisplay were not
being translated in the notification system

The change ensures that translation works for all applications
regardless of their NoDisplay status, while maintaining debug visibility
into translation operations.

fix: 处理通知设置中的NoDisplay应用

1. 移除了NotificationSetting::appItemsImpl()中对NoDisplay应用的过滤，确
保所有应用都被处理
2. 在NotificationManager::Notify()中添加了调试日志，用于跟踪何时从AM翻译
应用名称
3. 修复了标记为NoDisplay的应用在通知系统中未被翻译的问题

此更改确保无论应用的NoDisplay状态如何，翻译都能正常工作，同时保持对翻译
操作的调试可见性。
