### PR TITLE
fix: click area keep same with app on dock

### DIFF
--- a/panels/dock/multitaskview/package/multitaskview.qml
+++ b/panels/dock/multitaskview/package/multitaskview.qml
@@ -32,33 +32,38 @@ AppletItem {
         scale: Panel.rootObject.dockItemMaxSize * 9 / 14 / Dock.MAX_DOCK_TASKMANAGER_ICON_SIZE
         // 9:14 (iconSize/dockHeight)
         sourceSize: Qt.size(Dock.MAX_DOCK_TASKMANAGER_ICON_SIZE, Dock.MAX_DOCK_TASKMANAGER_ICON_SIZE)
-        Timer {
-            id: toolTipShowTimer
-            interval: 50
-            onTriggered: {
-                var point = Applet.rootObject.mapToItem(null, Applet.rootObject.width / 2, Applet.rootObject.height / 2)
-                toolTip.DockPanelPositioner.bounding = Qt.rect(point.x, point.y, toolTip.width, toolTip.height)
-                toolTip.open()
-            }
+    }
+
+    Timer {
+        id: toolTipShowTimer
+        interval: 50
+        onTriggered: {
+            var point = toggleworkspace.mapToItem(null, toggleworkspace.width / 2, toggleworkspace.height / 2)
+            toolTip.DockPanelPositioner.bounding = Qt.rect(point.x, point.y, toolTip.width, toolTip.height)
+            toolTip.open()
         }
-        TapHandler {
-            acceptedButtons: Qt.LeftButton
-            onTapped: {
+    }
+
+    MouseArea {
+        id: mouseHandler
+        anchors.fill: parent
+        onClicked: function (mouse) {
+            if (mouse.button === Qt.LeftButton) {
                 Applet.openWorkspace()
                 toolTip.close()
             }
         }
-        HoverHandler {
-            onHoveredChanged: {
-                if (hovered) {
-                    toolTipShowTimer.start()
-                } else {
-                    if (toolTipShowTimer.running) {
-                        toolTipShowTimer.stop()
-                    }
-
-                    toolTip.close()
+    }
+    HoverHandler {
+        onHoveredChanged: {
+            if (hovered) {
+                toolTipShowTimer.start()
+            } else {
+                if (toolTipShowTimer.running) {
+                    toolTipShowTimer.stop()
                 }
+
+                toolTip.close()
             }
         }
     }


### PR DESCRIPTION
1. Restructured tooltip timer and positioning logic outside the Image component
2. Replaced TapHandler with MouseArea for better click handling consistency
3. Fixed tooltip positioning by using toggleworkspace coordinates instead of Applet.rootObject
4. Maintained hover behavior but with cleaner separation of concerns

The changes improve the reliability of the workspace switching functionality and tooltip display in the dock's multitask view. The new MouseArea provides more consistent click handling compared to the previous TapHandler implementation. The tooltip positioning is now more accurate as it uses the correct coordinate space.

fix: 修复点击范围保持跟应用一致.

1. 将工具提示计时器和定位逻辑从Image组件中移出并重构
2. 用MouseArea替换TapHandler以获得更一致的点击处理
3. 通过使用toggleworkspace坐标而非Applet.rootObject修复工具提示定位
4. 保持悬停行为但实现了更清晰的关注点分离

这些改动提高了dock中多任务视图的工作区切换功能和工具提示显示的可靠性。新
的MouseArea相比之前的TapHandler提供了更一致的点击处理。工具提示定位现在
更加准确，因为它使用了正确的坐标空间。

Pms: BUG-323763