### PR TITLE
fix: close tooltip before show desktop action

### DIFF
--- a/panels/dock/showdesktop/package/showdesktop.qml
+++ b/panels/dock/showdesktop/package/showdesktop.qml
@@ -38,6 +38,7 @@ AppletItem {
         }
 
         onClicked: {
+            toolTip.close()
             Applet.toggleShowDesktop()
         }
         onHoveredChanged: {


### PR DESCRIPTION
1. Added toolTip.close() before toggling show desktop
2. Prevents tooltip from remaining visible after clicking
3. Improves visual consistency when interacting with the dock

fix: 在显示桌面操作前关闭工具提示

1. 在切换显示桌面之前添加了toolTip.close()
2. 防止点击后工具提示仍然可见
3. 提高了与dock交互时的视觉一致性

Pms: BUG-324009