### PR TITLE
feat: add configurable show desktop feature

### DIFF
--- a/panels/dock/dconfig/org.deepin.ds.dock.json
+++ b/panels/dock/dconfig/org.deepin.ds.dock.json
@@ -81,6 +81,16 @@
                         "description": "lock dock to prevent dragging resize",
                         "permissions": "readwrite",
                         "visibility": "private"
+		},
+		"enableShowDesktop": {
+			"value": true,
+			"serial": 0,
+			"flags": [],
+			"name": "Enable ShowDesktop",
+			"name[zh_CN]": "启用显示桌面区域",
+			"description": "Enable or disable the show desktop area on the right side of the dock",
+			"permissions": "readwrite",
+			"visibility": "private"
 		}
 	}
 }

--- a/panels/dock/showdesktop/package/showdesktop.qml
+++ b/panels/dock/showdesktop/package/showdesktop.qml
@@ -15,6 +15,7 @@ AppletItem {
     property bool useColumnLayout: Panel.position % 2
     property int dockSize: Panel.rootObject.dockItemMaxSize
     property int dockOrder: 30
+    property bool shouldVisible: Applet.visible
     implicitWidth: useColumnLayout ? Panel.rootObject.dockSize : showDesktopWidth
     implicitHeight: useColumnLayout ? showDesktopWidth : Panel.rootObject.dockSize
 

--- a/panels/dock/showdesktop/showdesktop.cpp
+++ b/panels/dock/showdesktop/showdesktop.cpp
@@ -12,6 +12,10 @@
 #include <QDBusInterface>
 #include <QLoggingCategory>
 
+#include <DConfig>
+
+DCORE_USE_NAMESPACE
+
 Q_LOGGING_CATEGORY(showDesktop, "dde.shell.dock.showdesktop")
 
 namespace dock {
@@ -19,8 +23,20 @@ namespace dock {
 ShowDesktop::ShowDesktop(QObject *parent)
     : DApplet(parent)
     , m_windowManager(nullptr)
+    , m_dockConfig(nullptr)
+    , m_visible(true)
 {
-
+    // 创建DConfig实例来读取dock配置
+    m_dockConfig = DConfig::create("org.deepin.dde.shell", "org.deepin.ds.dock", QString(), this);
+    
+    if (m_dockConfig) {
+        // 监听配置变化
+        connect(m_dockConfig, &DConfig::valueChanged, this, [this](const QString &key) {
+            if (key == "enableShowDesktop") {
+                onEnableShowDesktopChanged();
+            }
+        });
+    }
 }
 
 bool ShowDesktop::load()
@@ -33,6 +49,12 @@ bool ShowDesktop::init()
     if (QStringLiteral("wayland") == QGuiApplication::platformName()) {
         m_windowManager = new TreelandWindowManager(this);
     }
+    
+    // 从配置中读取初始的可见性状态
+    if (m_dockConfig && m_dockConfig->isValid()) {
+        m_visible = m_dockConfig->value("enableShowDesktop", true).toBool();
+    }
+    
     DApplet::init();
     return true;
 }
@@ -58,6 +80,28 @@ bool ShowDesktop::checkNeedShowDesktop()
 
     qCWarning(showDesktop) << "wm call GetIsShowDesktop fail, res:" << reply.type();
     return false;
+}
+
+bool ShowDesktop::visible() const
+{
+    return m_visible;
+}
+
+void ShowDesktop::setVisible(bool visible)
+{
+    if (m_visible != visible) {
+        m_visible = visible;
+        Q_EMIT visibleChanged();
+    }
+}
+
+void ShowDesktop::onEnableShowDesktopChanged()
+{
+    if (m_dockConfig && m_dockConfig->isValid()) {
+        bool enabled = m_dockConfig->value("enableShowDesktop", true).toBool();
+        qCDebug(showDesktop) << "onEnableShowDesktopChanged" << enabled;
+        setVisible(enabled);
+    }
 }
 
 D_APPLET_CLASS(ShowDesktop)

--- a/panels/dock/showdesktop/showdesktop.h
+++ b/panels/dock/showdesktop/showdesktop.h
@@ -8,11 +8,15 @@
 #include "dsglobal.h"
 #include "treelandwindowmanager.h"
 
+#include <DConfig>
+
 namespace dock {
 
 class ShowDesktop : public DS_NAMESPACE::DApplet
 {
     Q_OBJECT
+    Q_PROPERTY(bool visible READ visible WRITE setVisible NOTIFY visibleChanged)
+    
 public:
     explicit ShowDesktop(QObject *parent = nullptr);
     virtual bool init() override;
@@ -20,9 +24,20 @@ public:
 
     Q_INVOKABLE void toggleShowDesktop();
     Q_INVOKABLE bool checkNeedShowDesktop();
+    
+    bool visible() const;
+    void setVisible(bool visible);
+
+Q_SIGNALS:
+    void visibleChanged();
+
+private slots:
+    void onEnableShowDesktopChanged();
 
 private:
     TreelandWindowManager *m_windowManager;
+    Dtk::Core::DConfig *m_dockConfig;
+    bool m_visible;
 };
 
 }


### PR DESCRIPTION
1. Added Enable_ShowDesktop configuration in dconfig to control show desktop area visibility
2. Implemented DConfig integration to read and monitor configuration changes
3. Added visible property and related signals in ShowDesktop class
4. Connected configuration changes to UI visibility updates
5. Added shouldVisible property in QML to reflect configuration state

This change allows users to enable/disable the show desktop area through system settings while maintaining the existing functionality when enabled. The implementation uses DConfig for configuration management and properly propagates changes between backend and UI.

feat: 添加可配置的显示桌面功能

1. 在dconfig中添加Enable_ShowDesktop配置项用于控制显示桌面区域的可见性
2. 实现DConfig集成以读取和监控配置变更
3. 在ShowDesktop类中添加visible属性和相关信号
4. 将配置变更连接到UI可见性更新
5. 在QML中添加shouldVisible属性以反映配置状态

此更改允许用户通过系统设置启用/禁用显示桌面区域，同时保留启用时的现有功
能。该实现使用DConfig进行配置管理，并正确地在后端和UI之间传播变更。

Pms: BUG-312457

## Summary by Sourcery

Add a configurable Show Desktop feature by introducing a new DConfig key, wiring it into the ShowDesktop applet, and exposing its visibility state to QML.

New Features:
- Introduce Enable_ShowDesktop config option to toggle the Show Desktop area
- Expose ShowDesktop visibility through a new QML-accessible property

Enhancements:
- Integrate DConfig into ShowDesktop to load initial visibility and monitor runtime config changes

Chores:
- Add Enable_ShowDesktop entry to the dock’s DConfig JSON schema