### PR TITLE
fix: update building warning.

### DIFF
--- a/applets/dde-am/amapplet.cpp
+++ b/applets/dde-am/amapplet.cpp
@@ -57,6 +57,7 @@ static QString unescapeAppIdFromObjectPath(const QString &path)
 
 void AMApplet::onInterfacesRemoved(const QDBusObjectPath &objPath, const QStringList &interfaces)
 {
+    Q_UNUSED(interfaces)
     const QString &path(objPath.path());
     qDebug() << "InterfacesRemoved by AM, path:" << path;
 

--- a/applets/dde-appearance/appearanceapplet.cpp
+++ b/applets/dde-appearance/appearanceapplet.cpp
@@ -21,6 +21,7 @@ AppearanceApplet::AppearanceApplet(QObject *parent)
     watcher->addWatchedService("org.deepin.dde.Appearance1");
     watcher->setConnection(QDBusConnection::sessionBus());
     connect(watcher, &QDBusServiceWatcher::serviceRegistered, this, [this] (const QString & service) {
+        Q_UNUSED(service)
         initDBusProxy();
     });
 }

--- a/applets/dde-apps/amappitem.cpp
+++ b/applets/dde-apps/amappitem.cpp
@@ -19,8 +19,8 @@ static const QString DEFAULT_KEY = "default";
 static QString locale = QLocale::system().name();
 
 AMAppItem::AMAppItem(const QDBusObjectPath &path, QObject *parent)
-    : AppItem(DUtil::unescapeFromObjectPath(path.path().split('/').last()), AppItemModel::AppItemType)
-    , Application(AM_DBUS_SERVICE, path.path(), QDBusConnection::sessionBus(), parent)
+    : Application(AM_DBUS_SERVICE, path.path(), QDBusConnection::sessionBus(), parent)
+    , AppItem(DUtil::unescapeFromObjectPath(path.path().split('/').last()), AppItemModel::AppItemType)
 {
 }
 

--- a/applets/dde-apps/amappitemmodel.cpp
+++ b/applets/dde-apps/amappitemmodel.cpp
@@ -39,6 +39,7 @@ AMAppItemModel::AMAppItemModel(QObject *parent)
     });
 
     connect(m_manager, &ObjectManager::InterfacesRemoved, this, [this](const QDBusObjectPath &objPath, const QStringList &interfaces) {
+        Q_UNUSED(interfaces)
         auto desktopId = DUtil::unescapeFromObjectPath(objPath.path().split('/').last());
         auto res = match(index(0, 0), AppItemModel::DesktopIdRole, desktopId);
         if (res.isEmpty()) {

--- a/applets/dde-apps/appgroupmanager.cpp
+++ b/applets/dde-apps/appgroupmanager.cpp
@@ -15,8 +15,8 @@ namespace apps {
 AppGroupManager::AppGroupManager(AMAppItemModel * referenceModel, QObject *parent)
     : QStandardItemModel(parent)
     , m_referenceModel(referenceModel)
-    , m_config(Dtk::Core::DConfig::create("org.deepin.dde.shell", "org.deepin.ds.dde-apps", "", this))
     , m_dumpTimer(new QTimer(this))
+    , m_config(Dtk::Core::DConfig::create("org.deepin.dde.shell", "org.deepin.ds.dde-apps", "", this))
 {
     m_dumpTimer->setSingleShot(true);
     m_dumpTimer->setInterval(1000);
@@ -295,7 +295,6 @@ void AppGroupManager::launchpadArrangementConfigMigration()
         itemArrangementSettings.beginGroup(groupName);
         QString folderName = itemArrangementSettings.value("name", QString()).toString();
         int pageCount = itemArrangementSettings.value("pageCount", 0).toInt();
-        bool isTopLevel = groupName == "toplevel";
 
         QVariantMap valueMap;
         valueMap.insert("name", folderName);
@@ -344,7 +343,7 @@ void AppGroupManager::loadAppGroupInfo()
         if (groupId.isEmpty()) {
             groupId = assignGroupId();
         }
-        auto p = appendGroup(groupId, name, items);
+        appendGroup(groupId, name, items);
     }
 
     // always ensure top-level group exists

--- a/applets/dde-apps/appsdockedhelper.cpp
+++ b/applets/dde-apps/appsdockedhelper.cpp
@@ -34,7 +34,7 @@ AppsDockedHelper::AppsDockedHelper(QObject *parent)
             YAML::Node node;
             try {
                 node = YAML::Load("{" + dcokedDesktopFilesStr.toStdString() + "}");
-            } catch (YAML::Exception) {
+            } catch (const YAML::Exception&) {
                 qWarning() << "unable to parse docked desktopfiles";
             }
 
@@ -66,6 +66,8 @@ bool AppsDockedHelper::isDocked(const QString &appItemId) const
 
 void AppsDockedHelper::setDocked(const QString &appId, bool docked)
 {
+    Q_UNUSED(appId)
+    Q_UNUSED(docked)
     // TODO
 }
 }

--- a/frame/appletdata.cpp
+++ b/frame/appletdata.cpp
@@ -29,7 +29,8 @@ DAppletData::DAppletData(const QVariantMap &data)
 }
 
 DAppletData::DAppletData(const DAppletData &other)
-    : d(other.d)
+    : QObject()
+    , d(other.d)
 {
 }
 

--- a/frame/layershell/dlayershellwindow.cpp
+++ b/frame/layershell/dlayershellwindow.cpp
@@ -212,7 +212,7 @@ DLayerShellWindow::DLayerShellWindow(QWindow* window)
         waylandWindow->setShellIntegration(shellIntegration);
     }
 #ifdef BUILD_WITH_X11
-    else if (auto xcbWindow = dynamic_cast<QNativeInterface::Private::QXcbWindow*>(window->handle())) {
+    else if (dynamic_cast<QNativeInterface::Private::QXcbWindow*>(window->handle())) {
         new LayerShellEmulation(window, this);
         qCInfo(layershellwindow) << "not a wayland window, try to emulate on x11";
     }

--- a/frame/layershell/x11dlayershellemulation.cpp
+++ b/frame/layershell/x11dlayershellemulation.cpp
@@ -59,6 +59,7 @@ LayerShellEmulation::LayerShellEmulation(QWindow* window, QObject *parent)
     });
     connect(qApp, &QGuiApplication::primaryScreenChanged, &m_exclusionZoneChangedTimer, static_cast<void (QTimer::*)()>(&QTimer::start));
     connect(m_window, &QWindow::screenChanged, this, [this](QScreen *nowScreen){
+        Q_UNUSED(nowScreen)
         onPositionChanged();
         m_exclusionZoneChangedTimer.start();
     });

--- a/frame/models/listtotableproxymodel.cpp
+++ b/frame/models/listtotableproxymodel.cpp
@@ -25,8 +25,8 @@ ListToTableProxyModel::ListToTableProxyModel(QObject *parent)
     });
 
     connect(this, &ListToTableProxyModel::dataChanged, this,
-            [this](const QModelIndex &topLeft, const QModelIndex &bottomRight,
-                   const QList<int> &roles = QList<int>()){
+            [this](const QModelIndex &, const QModelIndex &,
+                   const QList<int> &){
         // TODO: lazy solution, we should use dataChanged() to notify extra column changed;
         beginResetModel();
         endResetModel();
@@ -35,6 +35,7 @@ ListToTableProxyModel::ListToTableProxyModel(QObject *parent)
 
 QVariant ListToTableProxyModel::extraColumnData(const QModelIndex &parent, int row, int extraColumn, int role) const
 {
+    Q_UNUSED(role)
     QVariant result(data(index(row, m_sourceColumn, parent), m_roles[extraColumn]));
     if (!result.isValid()) return QStringLiteral("<invalid>");
     return result.userType() == QMetaType::QVariantList ? result.toStringList().join(',') : result;

--- a/frame/pluginmetadata.cpp
+++ b/frame/pluginmetadata.cpp
@@ -34,7 +34,8 @@ DPluginMetaData::DPluginMetaData()
 }
 
 DPluginMetaData::DPluginMetaData(const DPluginMetaData &other)
-    : d(other.d)
+    : QObject()
+    , d(other.d)
 {
 }
 

--- a/panels/dock/dockpanel.cpp
+++ b/panels/dock/dockpanel.cpp
@@ -55,12 +55,14 @@ bool DockPanel::load()
 bool DockPanel::init()
 {
     DockAdaptor* adaptor = new DockAdaptor(this);
+    Q_UNUSED(adaptor)
     QDBusConnection::sessionBus().registerService("org.deepin.ds.Dock");
     QDBusConnection::sessionBus().registerObject("/org/deepin/ds/Dock", "org.deepin.ds.Dock", this);
 
     // for old api compatible
     DockDBusProxy* proxy = new DockDBusProxy(this);
     DockFrontAdaptor* dockFrontAdaptor = new DockFrontAdaptor(proxy);
+    Q_UNUSED(dockFrontAdaptor)
     QDBusConnection::sessionBus().registerService("org.deepin.dde.Dock1");
     QDBusConnection::sessionBus().registerObject("/org/deepin/dde/Dock1", "org.deepin.dde.Dock1", proxy);
 

--- a/panels/dock/pluginmanagerextension.cpp
+++ b/panels/dock/pluginmanagerextension.cpp
@@ -202,12 +202,14 @@ void PluginSurface::updatePluginGeometry(const QRect &geometry)
 
 void PluginSurface::plugin_mouse_event(QtWaylandServer::plugin::Resource *resource, int32_t type)
 {
+    Q_UNUSED(resource)
     qInfo() << "server plugin surface receive mouse event:" << type;
     Q_EMIT recvMouseEvent((QEvent::Type)type);
 }
 
 void PluginSurface::plugin_dcc_icon(Resource *resource, const QString &icon)
 {
+    Q_UNUSED(resource)
     qInfo() << "dcc_icon:" << icon;
     m_dccIcon = icon;
 }
@@ -219,6 +221,7 @@ void PluginSurface::plugin_request_shutdown(Resource *resource, const QString &t
 }
 
 void PluginSurface::plugin_close_quick_panel(Resource *resource) {
+    Q_UNUSED(resource)
     qInfo() << "close_quick_panel";
     Q_EMIT m_manager->pluginCloseQuickPanelPopup();
 }
@@ -280,12 +283,14 @@ PluginPopup::PluginPopup(PluginManager *manager,
                          const QWaylandResource &resource)
     : m_manager(manager)
     , m_surface(surface)
-    , m_pluginId(pluginId)
     , m_itemKey(itemKey)
+    , m_pluginId(pluginId)
     , m_popupType(popupType)
     , m_height(1)
     , m_width(1)
 {
+    Q_UNUSED(x)
+    Q_UNUSED(y)
     init(resource.resource());
     setExtensionContainer(surface);
     QWaylandCompositorExtension::initialize();
@@ -360,6 +365,7 @@ int32_t PluginPopup::popupType() const
 
 void PluginPopup::plugin_popup_set_position(Resource *resource, int32_t x, int32_t y)
 {
+    Q_UNUSED(resource)
     setX(x);
     setY(y);
 }
@@ -500,6 +506,7 @@ void PluginManager::setEmbedPanelMinHeight(int height)
 
 void PluginManager::plugin_manager_v1_request_message(Resource *resource, const QString &plugin_id, const QString &item_key, const QString &msg)
 {
+    Q_UNUSED(resource)
     qInfo() << "server pluginManager receive client:" << plugin_id << item_key << " msg:" << msg;
     PluginSurface *dstPlugin = nullptr;
     for (PluginSurface *plugin : m_pluginSurfaces) {

--- a/panels/dock/taskmanager/abstractwindowmonitor.cpp
+++ b/panels/dock/taskmanager/abstractwindowmonitor.cpp
@@ -26,6 +26,7 @@ QHash<int, QByteArray> AbstractWindowMonitor::roleNames() const
 
 int AbstractWindowMonitor::rowCount(const QModelIndex &parent) const
 {
+    Q_UNUSED(parent)
     return m_trackedWindows.size();
 }
 

--- a/panels/dock/taskmanager/appitem.cpp
+++ b/panels/dock/taskmanager/appitem.cpp
@@ -163,7 +163,7 @@ void AppItem::active() const
 bool AppItem::isAttention() const
 {
     bool res = false;
-    for (const auto window : m_windows) {
+    for (const auto &window : m_windows) {
         if (window->isAttention()) {
             res = true;
             break;

--- a/panels/dock/taskmanager/desktopfileabstractparser.cpp
+++ b/panels/dock/taskmanager/desktopfileabstractparser.cpp
@@ -34,11 +34,12 @@ void DesktopfileAbstractParser::launch()
 
 void DesktopfileAbstractParser::launchWithAction(const QString& action)
 {
-
+    Q_UNUSED(action)
 }
 
 void DesktopfileAbstractParser::launchWithUrls(const QStringList & urls)
 {
+    Q_UNUSED(urls)
 }
 
 void DesktopfileAbstractParser::requestQuit()

--- a/panels/dock/taskmanager/desktopfileamparser.cpp
+++ b/panels/dock/taskmanager/desktopfileamparser.cpp
@@ -41,6 +41,7 @@ DesktopFileAMParser::DesktopFileAMParser(QString id, QObject* parent)
         interface()->isServiceRegistered(AM_DBUS_PATH);
 
     connect(&desktopobjectManager, &ObjectManager::InterfacesRemoved, this, [this] (const QDBusObjectPath& path, const QStringList& interfaces) {
+        Q_UNUSED(interfaces)
         if (m_applicationInterface->path() == path.path()) {
             getAppItem()->setDocked(false);
             return;
@@ -203,6 +204,8 @@ void DesktopFileAMParser::requestQuit()
 
 void DesktopFileAMParser::connectToAmDBusSignal(const QString& signalName, const char *slot)
 {
+    Q_UNUSED(signalName)
+    Q_UNUSED(slot)
     QDBusConnection::sessionBus().connect(
         m_applicationInterface->service(),
         m_applicationInterface->path(),

--- a/panels/dock/taskmanager/dockglobalelementmodel.cpp
+++ b/panels/dock/taskmanager/dockglobalelementmodel.cpp
@@ -25,6 +25,7 @@ DockGlobalElementModel::DockGlobalElementModel(QAbstractItemModel *appsModel, Do
 {
     connect(TaskManagerSettings::instance(), &TaskManagerSettings::dockedElementsChanged, this, &DockGlobalElementModel::loadDockedElements);
     connect(m_appsModel, &QAbstractItemModel::rowsRemoved, this, [this](const QModelIndex &parent, int first, int last) {
+        Q_UNUSED(parent)
         for (int i = first; i <= last; ++i) {
             auto it = std::find_if(m_data.begin(), m_data.end(), [this, &i](auto data) {
                 return std::get<1>(data) == m_appsModel && std::get<2>(data) == i;
@@ -44,6 +45,7 @@ DockGlobalElementModel::DockGlobalElementModel(QAbstractItemModel *appsModel, Do
     });
 
     connect(m_activeAppModel, &QAbstractItemModel::rowsInserted, this, [this](const QModelIndex &parent, int first, int last) {
+        Q_UNUSED(parent)
         for (int i = first; i <= last; ++i) {
             auto index = m_activeAppModel->index(i, 0);
             auto desktopId = index.data(TaskManager::DesktopIdRole).toString();
@@ -72,6 +74,7 @@ DockGlobalElementModel::DockGlobalElementModel(QAbstractItemModel *appsModel, Do
     });
 
     connect(m_activeAppModel, &QAbstractItemModel::rowsRemoved, this, [this](const QModelIndex &parent, int first, int last) {
+        Q_UNUSED(parent)
         for (int i = first; i <= last; ++i) {
             auto it = std::find_if(m_data.begin(), m_data.end(), [this, i](auto data) {
                 return std::get<1>(data) == m_activeAppModel && std::get<2>(data) == i;
@@ -160,16 +163,19 @@ QHash<int, QByteArray> DockGlobalElementModel::roleNames() const
 
 QModelIndex DockGlobalElementModel::index(int row, int column, const QModelIndex &parent) const
 {
+    Q_UNUSED(parent)
     return createIndex(row, column);
 }
 
 QModelIndex DockGlobalElementModel::parent(const QModelIndex &child) const
 {
+    Q_UNUSED(child)
     return QModelIndex();
 }
 
 int DockGlobalElementModel::columnCount(const QModelIndex &parent) const
 {
+    Q_UNUSED(parent)
     return 1;
 }
 
@@ -312,6 +318,8 @@ void DockGlobalElementModel::requestActivate(const QModelIndex &index) const
 
 void DockGlobalElementModel::requestOpenUrls(const QModelIndex &index, const QList<QUrl> &urls) const
 {
+    Q_UNUSED(index)
+    Q_UNUSED(urls)
 }
 
 void DockGlobalElementModel::requestNewInstance(const QModelIndex &index, const QString &action) const
@@ -346,6 +354,9 @@ void DockGlobalElementModel::requestClose(const QModelIndex &index, bool force) 
 }
 void DockGlobalElementModel::requestUpdateWindowGeometry(const QModelIndex &index, const QRect &geometry, QObject *delegate) const
 {
+    Q_UNUSED(index)
+    Q_UNUSED(geometry)
+    Q_UNUSED(delegate)
 }
 
 void DockGlobalElementModel::requestPreview(const QModelIndexList &indexes,
@@ -369,5 +380,6 @@ void DockGlobalElementModel::requestPreview(const QModelIndexList &indexes,
 
 void DockGlobalElementModel::requestWindowsView(const QModelIndexList &indexes) const
 {
+    Q_UNUSED(indexes)
 }
 }

--- a/panels/dock/taskmanager/dockgroupmodel.cpp
+++ b/panels/dock/taskmanager/dockgroupmodel.cpp
@@ -15,17 +15,22 @@ DockGroupModel::DockGroupModel(QAbstractItemModel *sourceModel, int role, QObjec
     , m_roleForDeduplication(role)
 {
     connect(this, &QAbstractItemModel::rowsInserted, this, [this](const QModelIndex &parent, int first, int last) {
+        Q_UNUSED(first)
+        Q_UNUSED(last)
         if (!parent.isValid())
             return;
         Q_EMIT dataChanged(index(parent.row(), 0), index(parent.row(), 0), {TaskManager::WindowsRole});
     });
     connect(this, &QAbstractItemModel::rowsRemoved, this, [this](const QModelIndex &parent, int first, int last) {
+        Q_UNUSED(first)
+        Q_UNUSED(last)
         if (!parent.isValid())
             return;
         Q_EMIT dataChanged(index(parent.row(), 0), index(parent.row(), 0), {TaskManager::WindowsRole});
     });
 
     connect(this, &QAbstractItemModel::dataChanged, this, [this](const QModelIndex &topLeft, const QModelIndex &bottomRight, const QList<int> &roles) {
+        Q_UNUSED(bottomRight)
         if (!topLeft.parent().isValid())
             return;
         auto parentRow = topLeft.parent().row();
@@ -86,7 +91,6 @@ QVariantList DockGroupModel::all(const QModelIndex &index, int role) const
     QVariantList res;
     auto rowCount = RoleGroupModel::rowCount(index);
     for (int i = 0; i < rowCount; i++) {
-        auto cIndex = RoleGroupModel::index(i, 0, index);
         auto window = RoleGroupModel::data(index, role);
         if (window.isValid())
             res.append(window);
@@ -115,6 +119,8 @@ void DockGroupModel::requestActivate(const QModelIndex &index) const
 
 void DockGroupModel::requestOpenUrls(const QModelIndex &index, const QList<QUrl> &urls) const
 {
+    Q_UNUSED(index)
+    Q_UNUSED(urls)
 }
 
 void DockGroupModel::requestClose(const QModelIndex &index, bool force) const
@@ -132,6 +138,9 @@ void DockGroupModel::requestClose(const QModelIndex &index, bool force) const
 
 void DockGroupModel::requestUpdateWindowGeometry(const QModelIndex &index, const QRect &geometry, QObject *delegate) const
 {
+    Q_UNUSED(index)
+    Q_UNUSED(geometry)
+    Q_UNUSED(delegate)
 }
 
 void DockGroupModel::requestPreview(const QModelIndexList &indexes,

--- a/panels/dock/taskmanager/dockitemmodel.cpp
+++ b/panels/dock/taskmanager/dockitemmodel.cpp
@@ -104,21 +104,25 @@ QHash<int, QByteArray> DockItemModel::roleNames() const
 
 QModelIndex DockItemModel::index(int row, int column, const QModelIndex &parent) const
 {
+    Q_UNUSED(parent)
     return createIndex(row, column);
 }
 
 QModelIndex DockItemModel::parent(const QModelIndex &child) const
 {
+    Q_UNUSED(child)
     return QModelIndex();
 }
 
 int DockItemModel::columnCount(const QModelIndex &parent) const
 {
+    Q_UNUSED(parent)
     return 1;
 }
 
 int DockItemModel::rowCount(const QModelIndex &parent) const
 {
+    Q_UNUSED(parent)
     auto sourceModel = this->sourceModel();
     return sourceModel == nullptr ? 0 : sourceModel->rowCount();
 }

--- a/panels/dock/taskmanager/rolecombinemodel.cpp
+++ b/panels/dock/taskmanager/rolecombinemodel.cpp
@@ -24,6 +24,7 @@ RoleCombineModel::RoleCombineModel(QAbstractItemModel* major, QAbstractItemModel
     }
 
     connect(sourceModel(), &QAbstractItemModel::rowsInserted, this, [this, majorRoles, func](const QModelIndex &parent, int first, int last) {
+        Q_UNUSED(parent)
         // 对于QAbstractListModel，parent通常是无效的，我们直接使用QModelIndex()
         beginInsertRows(QModelIndex(), first, last);
 
@@ -58,6 +59,7 @@ RoleCombineModel::RoleCombineModel(QAbstractItemModel* major, QAbstractItemModel
     });
 
     connect(sourceModel(), &QAbstractItemModel::columnsInserted, this, [this, majorRoles, func](const QModelIndex &parent, int first, int last) {
+        Q_UNUSED(parent)
         beginInsertColumns(QModelIndex(), first, last);
 
         // 先调整现有映射中后续列的索引
@@ -91,6 +93,7 @@ RoleCombineModel::RoleCombineModel(QAbstractItemModel* major, QAbstractItemModel
     });
 
     connect(sourceModel(), &QAbstractItemModel::rowsRemoved, this, [this](const QModelIndex &parent, int first, int last) {
+        Q_UNUSED(parent)
         beginRemoveRows(QModelIndex(), first, last);
 
         // 删除被移除行的映射
@@ -123,6 +126,7 @@ RoleCombineModel::RoleCombineModel(QAbstractItemModel* major, QAbstractItemModel
     });
 
     connect(sourceModel(), &QAbstractItemModel::columnsRemoved, this, [this](const QModelIndex &parent, int first, int last) {
+        Q_UNUSED(parent)
         beginRemoveColumns(QModelIndex(), first, last);
 
         // 删除被移除列的映射
@@ -157,6 +161,7 @@ RoleCombineModel::RoleCombineModel(QAbstractItemModel* major, QAbstractItemModel
     // connect changedSignal
     connect(major, &QAbstractItemModel::dataChanged, this,
         [this, majorRoles, func](const QModelIndex &topLeft, const QModelIndex &bottomRight, const QList<int> &roles){
+            Q_UNUSED(roles)
             for (int i = topLeft.row(); i <= bottomRight.row(); i++) {
                 for (int j = topLeft.column(); j <= bottomRight.column(); j++) {
                     QModelIndex majorIndex = sourceModel()->index(i, j);
@@ -175,6 +180,7 @@ RoleCombineModel::RoleCombineModel(QAbstractItemModel* major, QAbstractItemModel
     // appended roles from minor datachanged
     connect(m_minor, &QAbstractItemModel::dataChanged, this,
         [this, majorRoles, func](const QModelIndex &topLeft, const QModelIndex &bottomRight, const QList<int> &roles){
+            Q_UNUSED(roles)
             for (int i = topLeft.row(); i <= bottomRight.row(); i++) {
                 for (int j =  topLeft.column(); j <= bottomRight.column(); j++) {
                     auto majorPos = m_indexMap.key(qMakePair(i, j), qMakePair(-1, -1));
@@ -197,13 +203,13 @@ RoleCombineModel::RoleCombineModel(QAbstractItemModel* major, QAbstractItemModel
 
     // 添加对minor模型删除操作的处理
     connect(m_minor, &QAbstractItemModel::rowsRemoved, this, [this, majorRoles, func](const QModelIndex &parent, int first, int last) {
+        Q_UNUSED(parent)
         // 当minor模型删除行时，需要更新映射并可能触发数据变化信号
         QList<QModelIndex> affectedMajorIndexes;
 
         // 找到受影响的major索引
         for (auto it = m_indexMap.begin(); it != m_indexMap.end();) {
             int minorRow = it.value().first;
-            int minorCol = it.value().second;
 
             if (minorRow >= first && minorRow <= last) {
                 // 这个映射指向的minor行被删除了，需要重新建立映射
@@ -242,9 +248,9 @@ RoleCombineModel::RoleCombineModel(QAbstractItemModel* major, QAbstractItemModel
     });
 
     connect(m_minor, &QAbstractItemModel::columnsRemoved, this, [this, majorRoles, func](const QModelIndex &parent, int first, int last) {
+        Q_UNUSED(parent)
         // 当minor模型删除列时，需要更新映射
         for (auto it = m_indexMap.begin(); it != m_indexMap.end(); ++it) {
-            int minorRow = it.value().first;
             int minorCol = it.value().second;
 
             if (minorCol > last) {
@@ -257,6 +263,9 @@ RoleCombineModel::RoleCombineModel(QAbstractItemModel* major, QAbstractItemModel
 
     connect(m_minor, &QAbstractItemModel::rowsInserted, this,
         [this, majorRoles, func](const QModelIndex &parent, int first, int last){
+            Q_UNUSED(parent)
+            Q_UNUSED(first)
+            Q_UNUSED(last)
         auto rowCount = sourceModel()->rowCount();
         auto columnCount = sourceModel()->columnCount();
         for (int i = 0; i < rowCount; i++) {
@@ -373,6 +382,7 @@ QModelIndex RoleCombineModel::index(int row, int column, const QModelIndex &pare
 
 QModelIndex RoleCombineModel::parent(const QModelIndex &child) const
 {
+    Q_UNUSED(child)
     return QModelIndex();
 }
 

--- a/panels/dock/taskmanager/rolegroupmodel.cpp
+++ b/panels/dock/taskmanager/rolegroupmodel.cpp
@@ -39,6 +39,7 @@ void RoleGroupModel::setSourceModel(QAbstractItemModel *model)
         return;
 
     connect(sourceModel(), &QAbstractItemModel::rowsInserted, this, [this](const QModelIndex &parent, int first, int last) {
+        Q_UNUSED(parent)
         adjustMap(first, (last - first) + 1);
 
         for (int i = first; i <= last; i++) {
@@ -65,6 +66,7 @@ void RoleGroupModel::setSourceModel(QAbstractItemModel *model)
     });
 
     connect(sourceModel(), &QAbstractItemModel::rowsRemoved, this, [this](const QModelIndex &parent, int first, int last) {
+        Q_UNUSED(parent)
         for (int i = 0; i < m_rowMap.count(); ++i) {
             auto sourceRows = m_rowMap.value(i);
             for (int j = 0; j < sourceRows->size(); ++j) {

--- a/panels/dock/taskmanager/taskmanager.cpp
+++ b/panels/dock/taskmanager/taskmanager.cpp
@@ -107,6 +107,7 @@ bool TaskManager::load()
 bool TaskManager::init()
 {
     auto adaptor = new TaskManagerAdaptor(this);
+    Q_UNUSED(adaptor)
     QDBusConnection::sessionBus().registerService("org.deepin.ds.Dock.TaskManager");
     QDBusConnection::sessionBus().registerObject("/org/deepin/ds/Dock/TaskManager", "org.deepin.ds.Dock.TaskManager", this);
 

--- a/panels/dock/taskmanager/taskmanagersettings.cpp
+++ b/panels/dock/taskmanager/taskmanagersettings.cpp
@@ -105,7 +105,7 @@ void TaskManagerSettings::migrateFromDockedItems()
         YAML::Node node;
         try {
             node = YAML::Load("{" + dcokedDesktopFilesStr.toStdString() + "}");
-        } catch (YAML::Exception) {
+        } catch (const YAML::Exception&) {
             qWarning() << "unable to parse docked desktopfiles";
         }
 

--- a/panels/dock/taskmanager/treelandwindowmonitor.cpp
+++ b/panels/dock/taskmanager/treelandwindowmonitor.cpp
@@ -33,9 +33,9 @@ void ForeignToplevelManager::treeland_foreign_toplevel_manager_v1_toplevel(struc
 
 TreeLandDockPreviewContext::TreeLandDockPreviewContext(struct ::treeland_dock_preview_context_v1 *context)
     : QWaylandClientExtensionTemplate<TreeLandDockPreviewContext>(1)
-    , m_hideTimer(new QTimer(this))
     , m_isPreviewEntered(false)
     , m_isDockMouseAreaEnter(false)
+    , m_hideTimer(new QTimer(this))
 {
     init(context);
 
@@ -113,7 +113,7 @@ QPointer<AbstractWindow> TreeLandWindowMonitor::getWindowByWindowId(ulong window
 
 void TreeLandWindowMonitor::presentWindows(QList<uint32_t> windows)
 {
-
+    Q_UNUSED(windows)
 }
 
 void TreeLandWindowMonitor::showItemPreview(const QPointer<AppItem> &item, QObject* relativePositionItem, int32_t previewXoffset, int32_t previewYoffset, uint32_t direction)

--- a/panels/dock/taskmanager/x11preview.cpp
+++ b/panels/dock/taskmanager/x11preview.cpp
@@ -107,6 +107,7 @@ public:
 
     int rowCount(const QModelIndex& parent = QModelIndex()) const override
     {
+        Q_UNUSED(parent)
         return m_item.isNull() ? 0 : m_item->getAppendWindows().size();
     }
 
@@ -337,6 +338,7 @@ public:
 
     virtual QSize sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const override
     {
+        Q_UNUSED(option)
         if (!WM_HELPER->hasComposite() || !WM_HELPER->hasBlurWindow()) {
             return QSize(PREVIEW_CONTENT_MAX_WIDTH + PREVIEW_HOVER_BORDER * 2, PREVIEW_TITLE_HEIGHT + PREVIEW_HOVER_BORDER * 2);
         }
@@ -396,12 +398,13 @@ private:
 
 X11WindowPreviewContainer::X11WindowPreviewContainer(X11WindowMonitor* monitor, QWidget *parent)
     : DBlurEffectWidget(parent)
-    , m_direction(0)
     , m_isPreviewEntered(false)
     , m_isDockPreviewCount(0)
     , m_model(new AppItemWindowModel(this))
     , m_titleWidget(new QWidget())
+    , m_direction(0)
 {
+    Q_UNUSED(monitor)
     m_hideTimer = new QTimer(this);
     m_hideTimer->setSingleShot(true);
     m_hideTimer->setInterval(500);
@@ -515,6 +518,7 @@ void X11WindowPreviewContainer::hideEvent(QHideEvent*)
 
 void X11WindowPreviewContainer::resizeEvent(QResizeEvent *event)
 {
+    Q_UNUSED(event)
     updatePosition();
 }
 

--- a/panels/dock/taskmanager/x11utils.cpp
+++ b/panels/dock/taskmanager/x11utils.cpp
@@ -112,6 +112,7 @@ QString X11Utils::getNameByAtom(const xcb_atom_t &atom)
 }
 QList<xcb_window_t> X11Utils::getWindowClientList(const xcb_window_t &window)
 {
+    Q_UNUSED(window)
     QList<xcb_window_t> ret;
     xcb_get_property_cookie_t cookie = xcb_ewmh_get_client_list(&m_ewmh, 0);
     xcb_ewmh_get_windows_reply_t reply;
@@ -183,7 +184,7 @@ QString X11Utils::getWindowIcon(const xcb_window_t &window)
         });
     
         xcb_ewmh_wm_icon_iterator_t iter = xcb_ewmh_get_wm_icon_iterator(replyPtr.get());
-        xcb_ewmh_wm_icon_iterator_t wmIconIt{0, 0, nullptr};
+        xcb_ewmh_wm_icon_iterator_t wmIconIt{0, 0, nullptr, 0, 0};
         for (; iter.rem; xcb_ewmh_get_wm_icon_next(&iter)) {
             const uint32_t size = iter.width * iter.height;
             if (size > 0 && size > wmIconIt.width * wmIconIt.height) {

--- a/panels/dock/tray/quickpanel/quickpanelproxymodel.cpp
+++ b/panels/dock/tray/quickpanel/quickpanelproxymodel.cpp
@@ -19,7 +19,7 @@ enum {
     QuickSurfaceItemKey,
     TraySurface,
     TraySurfaceItemKey
-} ProxyRole;
+};
 }
 QuickPanelProxyModel::QuickPanelProxyModel(QObject *parent)
     : QSortFilterProxyModel(parent)

--- a/panels/dock/tray/traysortordermodel.cpp
+++ b/panels/dock/tray/traysortordermodel.cpp
@@ -68,6 +68,8 @@ TraySortOrderModel::~TraySortOrderModel()
 
 bool TraySortOrderModel::dropToStashTray(const QString &draggedSurfaceId, int dropVisualIndex, bool isBefore)
 {
+    Q_UNUSED(dropVisualIndex)
+    Q_UNUSED(isBefore)
     // Check if the dragged tray surfaceId exists. Reject if not the case
     QList<QStandardItem *> draggedItems = findItems(draggedSurfaceId);
     if (draggedItems.isEmpty()) return false;

--- a/panels/dock/waylanddockhelper.cpp
+++ b/panels/dock/waylanddockhelper.cpp
@@ -18,9 +18,9 @@
 namespace dock {
 WaylandDockHelper::WaylandDockHelper(DockPanel *panel)
     : DockHelper(panel)
-    , m_panel(panel)
     , m_isWindowOverlap(false)
     , m_isCurrentActiveWindowFullscreened(false)
+    , m_panel(panel)
 {
     m_wallpaperColorManager.reset(new WallpaperColorManager(this));
     m_ddeShellManager.reset(new TreeLandDDEShellManager());
@@ -250,11 +250,13 @@ void TreeLandDockWakeUpArea::updateDockWakeArea(Position pos)
 
 void TreeLandDockWakeUpArea::enterEvent(QEnterEvent *event)
 {
+    Q_UNUSED(event)
     m_helper->enterScreen(QWidget::screen());
 }
 
 void TreeLandDockWakeUpArea::leaveEvent(QEvent *event)
 {
+    Q_UNUSED(event)
     m_helper->leaveScreen();
 }
 

--- a/panels/dock/x11dockhelper.cpp
+++ b/panels/dock/x11dockhelper.cpp
@@ -381,7 +381,7 @@ void X11DockHelper::onHideModeChanged(HideMode mode)
             updating = true;
             int currentWorkspace = m_xcbHelper->getCurrentWorkspace();
             for (auto &&data : m_windows) {
-                if (data->overlap && (data->workspace == currentWorkspace || data->workspace == allWorkspace)) {
+                if (data->overlap && (static_cast<int>(data->workspace) == currentWorkspace || data->workspace == static_cast<uint32_t>(allWorkspace))) {
                     Q_EMIT isWindowOverlapChanged(isWindowOverlap());
                     updating = false;
                     return;
@@ -486,13 +486,13 @@ void X11DockHelper::updateDockArea()
         rect.setHeight(size);
         break;
     case Bottom:
-        if (rect.height() != size) {
+        if (rect.height() != static_cast<int>(size)) {
             rect.setTop(rect.top() + rect.height() - size);
             rect.setHeight(size);
         }
         break;
     case Right:
-        if (rect.width() != size) {
+        if (rect.width() != static_cast<int>(size)) {
             rect.setLeft(rect.left() + rect.width() - size);
             rect.setWidth(size);
         }

--- a/panels/notification/bubble/bubbleitem.cpp
+++ b/panels/notification/bubble/bubbleitem.cpp
@@ -103,7 +103,7 @@ static QString decodeImageToBase64(const QImage &image, const char *format = "PN
     return QString("data:image/%1;base64,%2").arg(QString::fromLatin1(format).toLower()).arg(QString::fromLatin1(ba.toBase64()));
 }
 
-static QIcon decodeIconFromPath(const QString &arg, const QString &fallback)
+[[maybe_unused]] static QIcon decodeIconFromPath(const QString &arg, const QString &fallback)
 {
     DGUI_USE_NAMESPACE;
     const QUrl url(arg);
@@ -117,6 +117,7 @@ static QIcon decodeIconFromPath(const QString &arg, const QString &fallback)
 
 static QString imagePathOfNotification(const QVariantMap &hints, const QString &appIcon, const QString &appName)
 {
+    Q_UNUSED(appName)
     static const QStringList HintsOrder {
             "desktop-entry",
             "image-data",

--- a/panels/notification/center/notificationcenterpanel.cpp
+++ b/panels/notification/center/notificationcenterpanel.cpp
@@ -32,11 +32,6 @@ static const QString DDENotifyDBusServer = "org.deepin.dde.Notification1";
 static const QString DDENotifyDBusInterface = "org.deepin.dde.Notification1";
 static const QString DDENotifyDBusPath = "/org/deepin/dde/Notification1";
 
-static QDBusInterface notifyCenterInterface()
-{
-    return QDBusInterface(DDENotifyDBusServer, DDENotifyDBusPath, DDENotifyDBusInterface);
-}
-
 NotificationCenterPanel::NotificationCenterPanel(QObject *parent)
     : DPanel(parent)
     , m_proxy(new NotificationCenterProxy(this))

--- a/panels/notification/center/notifyaccessor.cpp
+++ b/panels/notification/center/notifyaccessor.cpp
@@ -51,6 +51,7 @@ public:
 NotifyAccessor::NotifyAccessor(QObject *parent)
     : m_pinnedApps(InvalidPinnedApps)
 {
+    Q_UNUSED(parent)
     if (!qEnvironmentVariableIsEmpty("DS_NOTIFICATION_DEBUG")) {
         const int value = qEnvironmentVariableIntValue("DS_NOTIFICATION_DEBUG");
         m_debugging = value;

--- a/panels/notification/center/notifyitem.cpp
+++ b/panels/notification/center/notifyitem.cpp
@@ -81,10 +81,11 @@ QString toQString(const icu::UnicodeString &icuString)
     return QString(reinterpret_cast<const QChar *>(ucharData), length);
 }
 
-icu::UnicodeString fromQString(const QString &qstr)
+[[maybe_unused]] icu::UnicodeString fromQString(const QString &qstr)
 {
     return icu::UnicodeString(qstr.utf16(), qstr.length());
 }
+
 } // anonymous namespace
 
 void AppNotifyItem::updateTime()

--- a/panels/notification/center/notifymodel.cpp
+++ b/panels/notification/center/notifymodel.cpp
@@ -572,7 +572,6 @@ void NotifyModel::removeByApp(const QString &appName)
     beginRemoveRows(QModelIndex(), start, start + notifies.size() - 1);
     for (int i = 0; i < notifies.size(); i++) {
         auto item = notifies[i];
-        const auto id = item->id();
         m_appNotifies.removeOne(item);
         item->deleteLater();
     }
@@ -674,6 +673,7 @@ void NotifyModel::pinApplication(const QString &appName, bool pin)
 
 int NotifyModel::rowCount(const QModelIndex &parent) const
 {
+    Q_UNUSED(parent)
     return m_appNotifies.size();
 }
 
@@ -827,6 +827,8 @@ void NotifyModel::timerEvent(QTimerEvent *event)
 
 void NotifyModel::sort(int column, Qt::SortOrder order)
 {
+    Q_UNUSED(column)
+    Q_UNUSED(order)
     auto notifies = m_appNotifies;
     // emit layoutAboutToBeChanged(QList<QPersistentModelIndex>(), QAbstractItemModel::VerticalSortHint);
     beginResetModel();

--- a/panels/notification/center/notifystagingmodel.cpp
+++ b/panels/notification/center/notifystagingmodel.cpp
@@ -126,7 +126,6 @@ void NotifyStagingModel::remove(qint64 id)
 
             for (int i = 0; i < m_appNotifies.size(); i++) {
                 auto item = m_appNotifies[i];
-                const auto id = item->id();
                 const auto time = item->entity().cTime();
 
                 for (auto entity : newEntities) {
@@ -180,6 +179,7 @@ void NotifyStagingModel::open()
 
 int NotifyStagingModel::rowCount(const QModelIndex &parent) const
 {
+    Q_UNUSED(parent)
     return m_appNotifies.size();
 }
 

--- a/panels/notification/server/dbusadaptor.cpp
+++ b/panels/notification/server/dbusadaptor.cpp
@@ -130,7 +130,7 @@ QString DDENotificationDbusAdaptor::GetAppSetting(const QString &appName)
 
 void DDENotificationDbusAdaptor::SetAppSetting(const QString &settings)
 {
-
+    Q_UNUSED(settings)
 }
 
 void DDENotificationDbusAdaptor::SetSystemInfo(uint configItem, const QDBusVariant &value)

--- a/shell/main.cpp
+++ b/shell/main.cpp
@@ -140,7 +140,7 @@ int main(int argc, char *argv[])
 
     auto dirs = QStandardPaths::standardLocations(QStandardPaths::GenericDataLocation);
     QStringList fallbacks = QIcon::fallbackSearchPaths();
-    for (const auto fb : dirs) {
+    for (const auto &fb : dirs) {
         fallbacks << fb + QLatin1String("/icons");
     }
     // To Fix (developer-center#8413) Qt6 find icons will ignore ${GenericDataLocation}/icons/xxx.png

--- a/tests/panels/dock/taskmanager/combinemodela.cpp
+++ b/tests/panels/dock/taskmanager/combinemodela.cpp
@@ -7,6 +7,7 @@
 DataA::DataA(int id, TestModelA* parent)
     : m_id(id)
 {
+    Q_UNUSED(parent)
 }
 
 DataA::DataA(int id, const QString &data, TestModelA* model)
@@ -52,6 +53,7 @@ QHash<int, QByteArray> TestModelA::roleNames() const
 
 int TestModelA::rowCount(const QModelIndex &parent) const
 {
+    Q_UNUSED(parent)
     return m_list.size();
 }
 

--- a/tests/panels/dock/taskmanager/combinemodelb.cpp
+++ b/tests/panels/dock/taskmanager/combinemodelb.cpp
@@ -7,6 +7,7 @@
 DataB::DataB(int id, TestModelB* parent)
     : m_id(id)
 {
+    Q_UNUSED(parent)
 }
 
 DataB::DataB(int id, const QString &data, TestModelB* model)
@@ -52,6 +53,7 @@ QHash<int, QByteArray> TestModelB::roleNames() const
 
 int TestModelB::rowCount(const QModelIndex &parent) const
 {
+    Q_UNUSED(parent)
     return m_list.size();
 }
 

--- a/tests/panels/dock/taskmanager/rolecombinemodeltests.cpp
+++ b/tests/panels/dock/taskmanager/rolecombinemodeltests.cpp
@@ -17,7 +17,11 @@
 TEST(RoleCombineModel, RoleNamesTest) {
     TestModelA modelA;
     TestModelB modelB;
-    RoleCombineModel model(&modelA, &modelB, 1, [](QVariant data, QAbstractItemModel* model) -> QModelIndex{ return QModelIndex();});
+    RoleCombineModel model(&modelA, &modelB, 1, [](QVariant data, QAbstractItemModel* model) -> QModelIndex{ 
+        Q_UNUSED(data)
+        Q_UNUSED(model)
+        return QModelIndex();
+    });
     QHash<int, QByteArray> res(modelA.roleNames());
     auto keys = modelA.roleNames().keys();
     auto maxKey = *(std::max_element(keys.begin(), keys.end())) + 1;
@@ -38,6 +42,8 @@ TEST(RoleCombineModel, RowCountTest) {
     modelB.addData(new DataB(1, &modelB));
     modelB.addData(new DataB(2, &modelB));
     RoleCombineModel model(&modelA, &modelB, TestModelA::idRole, [](QVariant data, QAbstractItemModel *model) -> QModelIndex {
+        Q_UNUSED(data)
+        Q_UNUSED(model)
         return QModelIndex();
     });
 
@@ -57,10 +63,12 @@ TEST(RoleGroupModel, ModelTest)
     modelB.addData(new DataB(1, &modelB));
     modelB.addData(new DataB(2, &modelB));
     RoleCombineModel model(&modelA, &modelB, TestModelA::idRole, [](QVariant data, QAbstractItemModel *model) -> QModelIndex {
+        Q_UNUSED(data)
+        Q_UNUSED(model)
         return QModelIndex();
     });
 
-    auto tester = new QAbstractItemModelTester(&model, QAbstractItemModelTester::FailureReportingMode::Fatal);
+    [[maybe_unused]] auto tester = new QAbstractItemModelTester(&model, QAbstractItemModelTester::FailureReportingMode::Fatal);
 }
 
 TEST(RoleCombineModel, dataTest) {
@@ -183,6 +191,8 @@ TEST(RoleCombineModel, InvalidParentHandlingBug)
     TestModelB modelB;
 
     RoleCombineModel model(&modelA, &modelB, TestModelA::idRole, [](QVariant data, QAbstractItemModel *model) -> QModelIndex {
+        Q_UNUSED(data)
+        Q_UNUSED(model)
         return QModelIndex();
     });
 


### PR DESCRIPTION
as title.

Log:

## Summary by Sourcery

Silence compiler warnings and update build configuration

Enhancements:
- Mark many unused function parameters and variables with Q_UNUSED to suppress warnings
- Remove or comment out unused variables and code snippets across models, views, and utilities
- Add missing qtpreprocessorsupport.h include

Build:
- Comment out strict warning flags in CMakeLists.txt

Tests:
- Apply Q_UNUSED in test lambdas and remove unused local variables in test files