### PR TITLE
feat: new dconfig option to allow disable cgroups-based app grouping

### DIFF
--- a/panels/dock/taskmanager/dconfig/org.deepin.ds.dock.taskmanager.json
+++ b/panels/dock/taskmanager/dconfig/org.deepin.ds.dock.taskmanager.json
@@ -33,6 +33,17 @@
 			"permissions": "readwrite",
 			"visibility": "private"
 		},
+		"cgroupsBasedGrouping": {
+			"value": true,
+			"serial": 0,
+			"flags": [],
+			"name": "cgroupsBasedGrouping",
+			"name[zh_CN]": "基于 cgroups 的任务图标分组",
+			"description": "Enable cgroups-based task grouping",
+			"description[zh_CN]": "启用基于 cgroups 的任务图标分组",
+			"permissions": "readonly",
+			"visibility": "private"
+		},
 		"Docked_Items": {
 			"value": ["id: dde-file-manager,type: amAPP", "id: org.deepin.browser,type: amAPP", "id: deepin-app-store,type: amAPP", "id: org.deepin.dde.control-center, type: amAPP", "id: deepin-music,type: amAPP", "id: deepin-editor,type: amAPP", "id: deepin-mail,type: amAPP","id: deepin-terminal,type: amAPP","id: dde-calendar,type: amAPP", "id: deepin-calculator,type: amAPP"],
 			"serial": 0,

--- a/panels/dock/taskmanager/globals.h
+++ b/panels/dock/taskmanager/globals.h
@@ -19,6 +19,7 @@ static inline const QString DOCK_ACTION_DOCK = "dock-action-dock";
 // setting keys
 static inline const QString TASKMANAGER_ALLOWFOCEQUIT_KEY = "Allow_Force_Quit";
 static inline const QString TASKMANAGER_WINDOWSPLIT_KEY = "noTaskGrouping";
+static inline const QString TASKMANAGER_CGROUPS_BASED_GROUPING_KEY = "cgroupsBasedGrouping";
 static inline const QString TASKMANAGER_DOCKEDITEMS_KEY = "Docked_Items";
 constexpr auto TASKMANAGER_DOCKEDELEMENTS_KEY = "dockedElements";
 

--- a/panels/dock/taskmanager/taskmanager.cpp
+++ b/panels/dock/taskmanager/taskmanager.cpp
@@ -232,7 +232,7 @@ void TaskManager::handleWindowAdded(QPointer<AbstractWindow> window)
         qCDebug(taskManagerLog()) << "identify by AM:" << desktopId;
     }
 
-    if (desktopfile.isNull() || !desktopfile->isValied().first) {
+    if (Settings->cgroupsBasedGrouping() && (desktopfile.isNull() || !desktopfile->isValied().first)) {
         desktopfile = DESKTOPFILEFACTORY::createByWindow(window);
         qCDebug(taskManagerLog()) << "identify by Fallback:" << desktopId;
     }

--- a/panels/dock/taskmanager/taskmanagersettings.cpp
+++ b/panels/dock/taskmanager/taskmanagersettings.cpp
@@ -51,6 +51,7 @@ TaskManagerSettings::TaskManagerSettings(QObject *parent)
 
     m_allowForceQuit = enableStr2Bool(m_taskManagerDconfig->value(TASKMANAGER_ALLOWFOCEQUIT_KEY).toString());
     m_windowSplit = m_taskManagerDconfig->value(TASKMANAGER_WINDOWSPLIT_KEY).toBool();
+    m_cgroupsBasedGrouping = m_taskManagerDconfig->value(TASKMANAGER_CGROUPS_BASED_GROUPING_KEY, true).toBool();
     m_dockedElements = m_taskManagerDconfig->value(TASKMANAGER_DOCKEDELEMENTS_KEY, {}).toStringList();
     migrateFromDockedItems();
 }
@@ -75,6 +76,11 @@ void TaskManagerSettings::setWindowSplit(bool split)
 {
     m_windowSplit = split;
     m_taskManagerDconfig->setValue(TASKMANAGER_WINDOWSPLIT_KEY, m_windowSplit);
+}
+
+bool TaskManagerSettings::cgroupsBasedGrouping() const
+{
+    return m_cgroupsBasedGrouping;
 }
 
 QStringList TaskManagerSettings::dockedElements() const

--- a/panels/dock/taskmanager/taskmanagersettings.h
+++ b/panels/dock/taskmanager/taskmanagersettings.h
@@ -29,6 +29,8 @@ public:
     bool isWindowSplit();
     void setWindowSplit(bool split);
 
+    bool cgroupsBasedGrouping() const;
+
     void setDockedElements(const QStringList &elements);
     void appendDockedElements(const QString &element);
     void removeDockedElements(const QString &element);
@@ -51,6 +53,7 @@ private:
 
     bool m_allowForceQuit;
     bool m_windowSplit;
+    bool m_cgroupsBasedGrouping;
     QStringList m_dockedElements;
 };
 }


### PR DESCRIPTION
新增设置,提供形式来关闭基于 cgroups 的应用识别.

这个选项可供临时实验针对无 desktop 文件的应用程序(例如 appimage 程序)的图标识别支持,此选项不会默认禁用.

可供开发者测试的简要配置方式说明：

1. 确保包含新 dconfig 配置项的包已安装
2. 在 `/usr/share/dsg/configs/overrides/org.deepin.dde.shell/org.deepin.ds.dock.taskmanager/` 路径(不存在则主动创建)下创建 `test.json`
3. 粘贴下面的内容
4. `systemctl restart dde-dconfig-daemon.service` 刷新 dconfig 缓存
5. `systemctl --user restart dde-shell@DDE.service` 重启任务栏，使设置生效
6. 打开终端，找个 git 代码仓库目录切进去，执行 `gitk`，或者干脆执行 `dde-dconfig-editor`，观察新出现的窗口是不是在任务栏上有独立的图标

```json
{
  "magic": "dsg.config.override",
  "version": "1.0",
  "contents": {
    "cgroupsBasedGrouping": {
      "value": false,
      "serial": 0,
      "permissions": "readwrite"
    }
  }
}
```

> [!NOTE]
> 重构分支合入前，除非确实经过讨论允许，否则此项的默认值会保持为 true。手动改为 false 后存在一些已知边界情况有问题。此选项并非给最终用户提供，也因而选择了将权限设为了 `readonly`。

## Summary by Sourcery

New Features:
- Introduce a dconfig option to enable or disable cgroups-based app grouping fallback in the task manager