### PR TITLE
chore: implement dock item menus for DockGlobalElementModel

### DIFF
--- a/panels/dock/taskmanager/desktopfileabstractparser.cpp
+++ b/panels/dock/taskmanager/desktopfileabstractparser.cpp
@@ -148,9 +148,9 @@ void DesktopfileAbstractParser::setDocked(bool docked)
     auto desktopElement = QStringLiteral("desktop/%1").arg(id());
 
     if (docked) {
-        TaskManagerSettings::instance()->appendDockedElements(desktopElement);
+        TaskManagerSettings::instance()->appendDockedElement(desktopElement);
     } else {
-        TaskManagerSettings::instance()->removeDockedElements(desktopElement);
+        TaskManagerSettings::instance()->removeDockedElement(desktopElement);
     }
 
     Q_EMIT dockedChanged();

--- a/panels/dock/taskmanager/dockgroupmodel.cpp
+++ b/panels/dock/taskmanager/dockgroupmodel.cpp
@@ -117,12 +117,6 @@ void DockGroupModel::requestActivate(const QModelIndex &index) const
     interface->requestActivate(sourceIndex);
 }
 
-void DockGroupModel::requestOpenUrls(const QModelIndex &index, const QList<QUrl> &urls) const
-{
-    Q_UNUSED(index)
-    Q_UNUSED(urls)
-}
-
 void DockGroupModel::requestClose(const QModelIndex &index, bool force) const
 {
     auto interface = dynamic_cast<AbstractTaskManagerInterface *>(sourceModel());

--- a/panels/dock/taskmanager/dockgroupmodel.h
+++ b/panels/dock/taskmanager/dockgroupmodel.h
@@ -20,7 +20,6 @@ public:
     Q_INVOKABLE virtual QModelIndex index(int row, int column, const QModelIndex &parent = QModelIndex()) const override;
 
     void requestActivate(const QModelIndex &index) const override;
-    void requestOpenUrls(const QModelIndex &index, const QList<QUrl> &urls) const override;
     void requestClose(const QModelIndex &index, bool force = false) const override;
     void requestUpdateWindowGeometry(const QModelIndex &index, const QRect &geometry, QObject *delegate = nullptr) const override;
     void requestPreview(const QModelIndexList &indexes,

--- a/panels/dock/taskmanager/taskmanager.cpp
+++ b/panels/dock/taskmanager/taskmanager.cpp
@@ -271,10 +271,17 @@ void TaskManager::clickItem(const QString& itemId, const QString& menuId)
 
 void TaskManager::dropFilesOnItem(const QString& itemId, const QStringList& urls)
 {
-    auto item = ItemModel::instance()->getItemById(itemId);
-    if(!item) return;
+    auto indexes = m_itemModel->match(m_itemModel->index(0, 0), TaskManager::ItemIdRole, itemId, 1, Qt::MatchExactly);
+    if (indexes.isEmpty()) {
+        return;
+    }
 
-    item->handleFileDrop(urls);
+    QList<QUrl> urlList;
+    for (const QString &url : urls) {
+        urlList.append(QUrl::fromLocalFile(url));
+    }
+
+    m_itemModel->requestOpenUrls(indexes.first(), urlList);
 }
 
 void TaskManager::showItemPreview(const QString &itemId, QObject *relativePositionItem, int32_t previewXoffset, int32_t previewYoffset, uint32_t direction)

--- a/panels/dock/taskmanager/taskmanagersettings.cpp
+++ b/panels/dock/taskmanager/taskmanagersettings.cpp
@@ -148,14 +148,23 @@ void TaskManagerSettings::setDockedElements(const QStringList &elements)
     saveDockedElements();
 }
 
-void TaskManagerSettings::appendDockedElements(const QString &element)
+void TaskManagerSettings::toggleDockedElement(const QString &element)
+{
+    if (isDocked(element)) {
+        removeDockedElement(element);
+    } else {
+        appendDockedElement(element);
+    }
+}
+
+void TaskManagerSettings::appendDockedElement(const QString &element)
 {
     m_dockedElements.append(element);
     Q_EMIT dockedElementsChanged();
     saveDockedElements();
 }
 
-void TaskManagerSettings::removeDockedElements(const QString &element)
+void TaskManagerSettings::removeDockedElement(const QString &element)
 {
     m_dockedElements.removeAll(element);
     Q_EMIT dockedElementsChanged();

--- a/panels/dock/taskmanager/taskmanagersettings.h
+++ b/panels/dock/taskmanager/taskmanagersettings.h
@@ -32,8 +32,9 @@ public:
     bool cgroupsBasedGrouping() const;
 
     void setDockedElements(const QStringList &elements);
-    void appendDockedElements(const QString &element);
-    void removeDockedElements(const QString &element);
+    void toggleDockedElement(const QString &element);
+    void appendDockedElement(const QString &element);
+    void removeDockedElement(const QString &element);
     QStringList dockedElements() const;
     bool isDocked(const QString &elementId) const;
 


### PR DESCRIPTION
This patch is to continue prepare for linuxdeepin/dde-shell#1201, by add previously missing changed signal for Docked and Menu role when docked state is changed, and implementing actions for menu entries.

## Summary by Sourcery

Enable dock item menus by wiring up dock/undock, force quit, and close-all actions and ensure UI roles update on docking state changes

New Features:
- Introduce toggleDockedElement in TaskManagerSettings to support toggling docked state via menu actions
- Add menu actions in DockGlobalElementModel for docking/undocking, force quit, and close all

Enhancements:
- Rename appendDockedElements/removeDockedElements to singular method names and update their usages
- Emit dataChanged notifications for both DockedRole and MenusRole when the docked elements list is reloaded