### PR TITLE
fix: pluginVisibleChanged signal needs to be sent when dragging the p…

### DIFF
--- a/panels/dock/tray/traysortordermodel.h
+++ b/panels/dock/tray/traysortordermodel.h
@@ -102,6 +102,7 @@ private:
     QString registerSurfaceId(const QVariantMap &surfaceData);
     void loadDataFromDConfig();
     void saveDataToDConfig();
+    void handlePluginVisibleChanged(const QString &surfaceId, bool visible);
 
 private slots:
     void onAvailableSurfacesChanged();


### PR DESCRIPTION
…lugin docked to tray

as title

Log: as title
Pms: BUG-299881

## Summary by Sourcery

Trigger the pluginVisibleChanged signal over D-Bus whenever a tray plugin’s visibility changes (e.g., when dragging into or out of the tray)

Bug Fixes:
- Ensure pluginVisibleChanged is sent when a tray plugin is shown via drop
- Send pluginVisibleChanged when setting surface visibility
- Send pluginVisibleChanged when hiding a plugin section

Enhancements:
- Add handlePluginVisibleChanged method to send setItemOnDock calls over D-Bus
- Include QDBus includes and error handling for the D-Bus call