### PR TITLE
fix: improve task manager layout calculation

### DIFF
--- a/panels/dock/package/main.qml
+++ b/panels/dock/package/main.qml
@@ -22,6 +22,9 @@ Window {
     property int dockLeftSpaceForCenter: useColumnLayout ?
         (Screen.height - dockLeftPart.implicitHeight - dockRightPart.implicitHeight) :
         (Screen.width - dockLeftPart.implicitWidth - dockRightPart.implicitWidth)
+    property int dockRemainingSpaceForCenter: useColumnLayout ?
+        (Screen.height / 1.8 - dockRightPart.implicitHeight)  :
+        (Screen.width / 1.8 - dockRightPart.implicitWidth) 
     // TODO
     signal dockCenterPartPosChanged()
     signal pressedAndDragging(bool isDragging)
@@ -419,10 +422,20 @@ Window {
                 }
             }
 
-            Item {
+            Item {  
                 id: dockCenterPart
-                implicitWidth: centerLoader.implicitWidth
-                implicitHeight: centerLoader.implicitHeight
+                property var taskmanagerRootObject: {
+                    let applet = DS.applet("org.deepin.ds.dock.taskmanager")
+                    return applet ? applet.rootObject : null
+                }
+                
+                readonly property real taskmanagerImplicitWidth: taskmanagerRootObject ? taskmanagerRootObject.implicitWidth : 0
+                readonly property real taskmanagerImplicitHeight: taskmanagerRootObject ? taskmanagerRootObject.implicitHeight : 0
+                readonly property real taskmanagerAppContainerWidth: taskmanagerRootObject ? taskmanagerRootObject.appContainerWidth : 0
+                readonly property real taskmanagerAppContainerHeight: taskmanagerRootObject ? taskmanagerRootObject.appContainerHeight : 0
+                
+                implicitWidth: centerLoader.implicitWidth - taskmanagerImplicitWidth + taskmanagerAppContainerWidth
+                implicitHeight: centerLoader.implicitHeight - taskmanagerImplicitHeight + taskmanagerAppContainerHeight
                 onXChanged: dockCenterPartPosChanged()
                 onYChanged: dockCenterPartPosChanged()
                 Layout.leftMargin: !useColumnLayout && Panel.itemAlignment === Dock.CenterAlignment ?

--- a/panels/dock/taskmanager/package/TaskManager.qml
+++ b/panels/dock/taskmanager/package/TaskManager.qml
@@ -13,8 +13,12 @@ ContainmentItem {
     id: taskmanager
     property bool useColumnLayout: Panel.position % 2
     property int dockOrder: 16
-    property int remainingSpacesForTaskManager: Panel.rootObject.dockLeftSpaceForCenter - Panel.rootObject.dockItemMaxSize * 1.2
+    property int remainingSpacesForTaskManager: Panel.itemAlignment === Dock.LeftAlignment ? Panel.rootObject.dockLeftSpaceForCenter : Panel.rootObject.dockRemainingSpaceForCenter
     property int forceRelayoutWorkaround: 0
+
+    // 用于居中计算的实际应用区域尺寸
+    property int appContainerWidth: useColumnLayout ? Panel.rootObject.dockSize : (appContainer.implicitWidth + forceRelayoutWorkaround)
+    property int appContainerHeight: useColumnLayout ? (appContainer.implicitHeight + forceRelayoutWorkaround) : Panel.rootObject.dockSize
 
     Timer {
         // FIXME: dockItemMaxSize(visualModel.cellWidth,actually its implicitWidth/Height) change will cause all delegate item's position change, but
@@ -30,8 +34,8 @@ ContainmentItem {
         }
     }
 
-    implicitWidth: useColumnLayout ? Panel.rootObject.dockSize : (Math.min(remainingSpacesForTaskManager, appContainer.implicitWidth) + forceRelayoutWorkaround)
-    implicitHeight: useColumnLayout ? (Math.min(remainingSpacesForTaskManager, appContainer.implicitHeight) + forceRelayoutWorkaround) : Panel.rootObject.dockSize
+    implicitWidth: useColumnLayout ? Panel.rootObject.dockSize : (Math.max(remainingSpacesForTaskManager, appContainer.implicitWidth) + forceRelayoutWorkaround)
+    implicitHeight: useColumnLayout ? (Math.max(remainingSpacesForTaskManager, appContainer.implicitHeight) + forceRelayoutWorkaround) : Panel.rootObject.dockSize
 
     // Helper function to find the current index of an app by its appId in the visualModel
     function findAppIndex(appId) {


### PR DESCRIPTION
Changed dock layout calculation to use new dockRemainingSpaceForCenter property instead of dockLeftSpaceForCenter
Modified implicitWidth/Height calculations in dockCenterPart to account for task manager's center dimensions
Replaced Math.min with Math.max in task manager size calculations to ensure proper space allocation
Added centerWidth and centerHeight properties in task manager for accurate centering calculations
These changes fix layout issues where task manager was not properly utilizing available space and improve centering behavior

fix: 改进任务管理器布局计算

使用新的 dockRemainingSpaceForCenter 属性替代 dockLeftSpaceForCenter 进 行停靠栏布局计算
修改 dockCenterPart 中的隐式宽度/高度计算以考虑任务管理器的居中尺寸
将任务管理器尺寸计算中的 Math.min 替换为 Math.max 以确保正确分配空间
在任务管理器中添加 centerWidth 和 centerHeight 属性以实现精确的居中计算
这些更改解决了任务管理器未正确利用可用空间的布局问题，并改进了居中行为

Pms: BUG-327583

## Summary by Sourcery

Improve the task manager and dock center layout calculations by introducing a new remaining-space property, updating size calculations to use maximum values, and adding explicit center dimensions to ensure proper space utilization and centering.

Bug Fixes:
- Fix layout issues where the task manager and dock center were not properly utilizing available space and centering

Enhancements:
- Replace dockLeftSpaceForCenter with dockRemainingSpaceForCenter for more accurate space calculations
- Switch from Math.min to Math.max in implicit width/height calculations to ensure the task manager uses the correct dimension
- Add centerWidth and centerHeight properties in the task manager for precise centering
- Adjust dockCenterPart implicit dimensions to account for the task manager’s center dimensions