### PR TITLE
feat: add trash file drop support

### DIFF
--- a/panels/dock/taskmanager/taskmanager.h
+++ b/panels/dock/taskmanager/taskmanager.h
@@ -97,6 +97,9 @@ public:
     Q_INVOKABLE void activateWindow(uint32_t windowID);
     Q_INVOKABLE void saveDockElementsOrder(const QStringList &appIds);
 
+private:
+    void moveFilesToTrash(const QStringList& urls);
+
 Q_SIGNALS:
     void dataModelChanged();
     void windowSplitChanged();


### PR DESCRIPTION
Added functionality to handle file drops on the trash icon in the task manager
1. Implemented moveFilesToTrash method that converts URL paths to local files and moves them to system trash
2. Added file drop detection for "dde-trash" item ID with proper debug logging
3. Included necessary Qt headers for file operations (QFile, QFileInfo, QProcess, QUrl)
4. Added error handling for empty file paths with warning messages

feat: 添加回收站文件拖放支持

在任务管理器中添加了对回收站图标的文件拖放处理功能
1. 实现了moveFilesToTrash方法，将URL路径转换为本地文件并移动到系统回收站
2. 添加了对"dde-trash"项目ID的文件拖放检测，包含适当的调试日志
3. 包含了文件操作所需的Qt头文件（QFile、QFileInfo、QProcess、QUrl）
4. 为空的文件路径添加了错误处理，包含警告消息

Pms: BUG-271091

## Summary by Sourcery

Add drag-and-drop handling for files on the trash icon by implementing moveFilesToTrash, incorporating debug logging and error handling.

New Features:
- Add support for dropping files onto the trash icon in the task manager
- Implement moveFilesToTrash to convert URL paths and move files to the system trash
- Log debug messages for file drop actions and warnings for empty file paths
- Include necessary Qt headers (QFile, QUrl) for file operations