### PR TITLE
fix: prevent duplicate QML import paths

### DIFF
--- a/frame/qmlengine.cpp
+++ b/frame/qmlengine.cpp
@@ -39,11 +39,13 @@ public:
             QObject::connect(s_engine, &QQmlEngine::quit, qApp, &QCoreApplication::quit);
             auto paths = s_engine->importPathList();
             // high priority for builtin plugin.
-            paths.prepend(DDE_SHELL_QML_INSTALL_DIR);
+            if (!paths.contains(DDE_SHELL_QML_INSTALL_DIR))
+                paths.prepend(DDE_SHELL_QML_INSTALL_DIR);
             const QString rootDir = QCoreApplication::applicationDirPath();
             QDir pluginDir(rootDir);
             if (pluginDir.cd("../plugins")) {
-                paths.prepend(pluginDir.absolutePath());
+                if (!paths.contains(pluginDir.absolutePath()))
+                    paths.prepend(pluginDir.absolutePath());
             }
             s_engine->setImportPathList(paths);
             qCDebug(dsLog()) << "Engine importPaths" << s_engine->importPathList();


### PR DESCRIPTION
1. Added check to avoid prepending DDE_SHELL_QML_INSTALL_DIR if it
already exists in import path list
2. This prevents duplicate paths and maintains correct search order for
QML imports
3. The change ensures consistent behavior when environment variables add
the same path
4. Fixes issue where duplicate paths could cause import resolution
problems

fix: 防止 QML 导入路径重复

1. 添加检查避免在导入路径列表中已存在 DDE_SHELL_QML_INSTALL_DIR 时重复
添加
2. 防止路径重复并保持 QML 导入的正确搜索顺序
3. 确保当环境变量添加相同路径时行为一致
4. 修复重复路径可能导致导入解析问题的情况

## Summary by Sourcery

Bug Fixes:
- Avoid duplicate DDE_SHELL_QML_INSTALL_DIR and plugin directory paths in the QML import path list by verifying their presence before prepending.