### PR TITLE
fix: crash when click close on preview window in some cases

### DIFF
--- a/panels/dock/taskmanager/dockglobalelementmodel.cpp
+++ b/panels/dock/taskmanager/dockglobalelementmodel.cpp
@@ -245,7 +245,7 @@ void DockGlobalElementModel::loadDockedElements()
 
 QString DockGlobalElementModel::getMenus(const QModelIndex &index) const
 {
-    auto data = m_data.value(index.row());
+    auto data = m_data.at(index.row());
     auto id = std::get<0>(data);
     auto model = std::get<1>(data);
     auto row = std::get<2>(data);
@@ -278,10 +278,10 @@ int DockGlobalElementModel::rowCount(const QModelIndex &parent) const
 
 QVariant DockGlobalElementModel::data(const QModelIndex &index, int role) const
 {
-    if (index.row() > m_data.size())
+    if (index.row() >= m_data.size())
         return {};
 
-    auto data = m_data.value(index.row());
+    auto data = m_data.at(index.row());
     auto id = std::get<0>(data);
     auto model = std::get<1>(data);
     auto row = std::get<2>(data);


### PR DESCRIPTION
修正在存在多个预览窗口时,点击中间的某个窗口的关闭按钮时,预览可能崩溃的问题.

## Summary by Sourcery

Prevent crashes when closing preview windows in multi-window scenarios by tightening index bounds checks and switching to at() for data retrieval.

Bug Fixes:
- Prevent out-of-range access to m_data when retrieving items by replacing m_data.value with m_data.at
- Fix incorrect bounds check in data() by changing the condition from '>' to '>=' to avoid invalid index access