### PR TITLE
fix: add QML annotations to eliminate compilation warnings

### DIFF
--- a/panels/dock/pluginmanagerextension_p.h
+++ b/panels/dock/pluginmanagerextension_p.h
@@ -133,6 +133,8 @@ class PluginSurface : public QWaylandShellSurfaceTemplate<PluginSurface>, public
     Q_PROPERTY(bool isItemActive WRITE setItemActive READ isItemActive NOTIFY itemActiveChanged)
     Q_PROPERTY(QString dccIcon READ dccIcon CONSTANT)
     Q_PROPERTY(int margins READ margins WRITE setMargins NOTIFY marginsChanged FINAL)
+    QML_ELEMENT
+    QML_UNCREATABLE("PluginSurface is not creatable in QML.")
 
 public:
     PluginSurface(const PluginSurface &) = delete;
@@ -217,6 +219,8 @@ class PluginPopup : public QWaylandShellSurfaceTemplate<PluginPopup>, public QtW
     Q_PROPERTY(int32_t popupType READ popupType)
     Q_PROPERTY(int height READ height NOTIFY heightChanged)
     Q_PROPERTY(int width READ width NOTIFY widthChanged)
+    QML_ELEMENT
+    QML_UNCREATABLE("PluginPopup is not creatable in QML.")
 
 public:
     PluginPopup(PluginManager* shell, const QString &pluginId, const QString &itemKey, int x, int y, int popupType,


### PR DESCRIPTION
Added QML_ELEMENT and QML_UNCREATABLE macros to PluginSurface and
PluginPopup classes to resolve QString::arg compilation warnings. These
annotations explicitly declare the QML element registration and prevent
QML instantiation, ensuring proper type registration and eliminating the
missing argument warnings during compilation.

Log: Fixed compilation warnings related to QML type registration

Influence:
1. Verify that the dock plugin compiles without warnings
2. Test that PluginSurface and PluginPopup classes still function
correctly in C++ context
3. Confirm that QML cannot instantiate these classes as intended
4. Check that all existing dock functionality remains unaffected

fix: 添加QML注解消除编译警告

为PluginSurface和PluginPopup类添加QML_ELEMENT和QML_UNCREATABLE宏，解决
QString::arg编译警告。这些注解显式声明QML元素注册并防止QML实例化，确保正
确的类型注册并消除编译时的参数缺失警告。

Log: 修复了与QML类型注册相关的编译警告

Influence:
1. 验证dock插件编译时无警告
2. 测试PluginSurface和PluginPopup类在C++上下文中仍能正常工作
3. 确认QML无法实例化这些类（符合设计意图）
4. 检查所有现有dock功能不受影响
