### PR TITLE
chore: eliminate CMake configuration warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,8 @@ find_package(ICU 74.2 REQUIRED COMPONENTS uc i18n io)
 find_package(WaylandProtocols REQUIRED)
 find_package(PkgConfig REQUIRED)
 
+qt_policy(SET QTP0001 NEW)
+
 try_compile(COMPILE_RESULT
     ${CMAKE_CURRENT_BINARY_DIR}/try_compile_build
     SOURCES ${CMAKE_SOURCE_DIR}/tests/check/qt_wayland_keyextension.cpp

--- a/cmake/DDEShellPackageMacros.cmake
+++ b/cmake/DDEShellPackageMacros.cmake
@@ -13,7 +13,7 @@ macro(ds_build_package)
         SOURCES ${package_files}
     )
     set(package_dirs ${PROJECT_BINARY_DIR}/packages/${_config_PACKAGE}/)
-    add_custom_command(TARGET ${_config_PACKAGE}_package
+    add_custom_command(TARGET ${_config_PACKAGE}_package POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy_directory ${package_root_dir} ${package_dirs}
     )
 

--- a/panels/dock/CMakeLists.txt
+++ b/panels/dock/CMakeLists.txt
@@ -97,8 +97,6 @@ add_subdirectory(taskmanager)
 add_subdirectory(tray)
 add_subdirectory(multitaskview)
 
-find_package(DdeControlCenter)
-
 #add_subdirectory(appruntimeitem)
 
 # dock qml element(include Dock.xx defines and DockCompositor)
@@ -127,7 +125,6 @@ set_source_files_properties(DockPalette.qml PROPERTIES
     QT_QML_SINGLETON_TYPE TRUE
 )
 
-qt_policy(SET QTP0001 OLD)
 qt_add_qml_module(dock-plugin
     PLUGIN_TARGET dock-plugin
     URI "org.deepin.ds.dock"

--- a/panels/dock/tray/CMakeLists.txt
+++ b/panels/dock/tray/CMakeLists.txt
@@ -8,7 +8,6 @@ find_package(Qt${QT_VERSION_MAJOR} ${REQUIRED_QT_VERSION} REQUIRED COMPONENTS Gu
 find_package(Dtk6 REQUIRED COMPONENTS Core Gui)
 find_package(DdeTrayLoader REQUIRED)
 
-qt_policy(SET QTP0001 OLD)
 qt_add_qml_module(dock-tray
     PLUGIN_TARGET dock-tray
     URI "org.deepin.ds.dock.tray"


### PR DESCRIPTION
The changes address CMake configuration warnings by:
1. Setting QTP0001 policy to NEW globally in the main CMakeLists.txt
instead of setting it to OLD in individual modules
2. Adding POST_BUILD to custom command in packaging macro to ensure
proper build timing
3. Removing redundant find_package calls for DdeControlCenter that were
unnecessary
4. Removing duplicate QTP0001 policy settings from dock and tray modules

These changes eliminate build warnings while maintaining the same
functionality, making the build output cleaner and more professional.

Influence:
1. Verify that the project builds without CMake warnings
2. Test that all modules still compile correctly
3. Ensure packaging functionality works as expected
4. Confirm that QML modules are properly generated
5. Test dock and tray functionality remains unchanged

chore: 消除CMake配置警告

本次修改解决了CMake配置警告问题：
1. 在主CMakeLists.txt中全局设置QTP0001策略为NEW，而不是在各个模块中设置
为OLD
2. 在打包宏中添加POST_BUILD到自定义命令，确保正确的构建时机
3. 移除对DdeControlCenter的冗余find_package调用
4. 从dock和tray模块中移除重复的QTP0001策略设置

这些更改在保持相同功能的同时消除了构建警告，使构建输出更加清晰和专业。

Influence:
1. 验证项目构建时没有CMake警告
2. 测试所有模块仍能正确编译
3. 确保打包功能正常工作
4. 确认QML模块正确生成
5. 测试dock和tray功能保持不变
