### PR TITLE
chore: bump CMake minimum required version to 3.16

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: CC0-1.0
 
-CMAKE_MINIMUM_REQUIRED(VERSION 3.10)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.16)
 
 set(DS_VERSION "1.99.0" CACHE STRING "Define project version")
 project(DDEShell


### PR DESCRIPTION
这是 Qt 6 所要求的最低 CMake 版本(尽管低于此版本不会导致无法构建).

## Summary by Sourcery

Chores:
- Increase CMake minimum required version from 3.10 to 3.16