### PR TITLE
fix: correct Chinese translation for "Clear All"

### DIFF
--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_zh_CN.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_zh_CN.ts
@@ -3,7 +3,7 @@
     <name>GroupNotify</name>
     <message>
         <source>Clear All</source>
-        <translation>全部清除</translation>
+        <translation>清除全部</translation>
     </message>
 </context>
 <context>
@@ -21,7 +21,7 @@
     </message>
     <message>
         <source>Clear All</source>
-        <translation>全部清除</translation>
+        <translation>清除全部</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
Changed the Chinese translation of "Clear All" from "全部清除" to "清除
全部" in notification center translations. The new translation "清除全
部" is more natural and commonly used in Chinese UI contexts, providing
better linguistic accuracy and user experience.

Log: Improved Chinese translation for "Clear All" button in notification
center

Influence:
1. Verify the "Clear All" button text appears as "清除全部" in Chinese
locale
2. Test notification clearing functionality remains unchanged
3. Check UI layout to ensure text fits properly with new translation
4. Verify consistency across all instances of "Clear All" in
notification center

fix: 修正"Clear All"的中文翻译

将通知中心中"Clear All"的中文翻译从"全部清除"改为"清除全部"。新的翻译"清
除全部"在中文UI环境中更加自然和常用，提供了更好的语言准确性和用户体验。

Log: 改进了通知中心"Clear All"按钮的中文翻译

Influence:
1. 验证中文环境下"Clear All"按钮显示为"清除全部"
2. 测试通知清除功能保持不变
3. 检查UI布局确保新翻译文本适配良好
4. 验证通知中心所有"Clear All"实例的翻译一致性

PMS: BUG-283617

## Summary by Sourcery

Bug Fixes:
- Correct Chinese translation of "Clear All" to "清除全部" in notification center