### PR TITLE
fix: ensure panel tooltips are capitalized

### DIFF
--- a/frame/qml/PanelToolTip.qml
+++ b/frame/qml/PanelToolTip.qml
@@ -92,7 +92,11 @@ Item {
         visible: readyBinding
         anchors.centerIn: parent
         parent: toolTipWindow ? toolTipWindow.contentItem : undefined
-        font: DTK.fontManager.t6
+        font {
+            family: DTK.fontManager.t6.family
+            pixelSize: DTK.fontManager.t6.pixelSize
+            capitalization: Font.Capitalize
+        }
         contentItem: Text {
             topPadding: 4
             bottomPadding: 4


### PR DESCRIPTION
确保面板的 tooltip 提示逐词首字母大写.

潜在影响：所有 panel tooltip 的文本都会遵循首字母大写的显示方式。目前检查没发现例外，如果有的话就得把这个选项导出成属性，允许各个组件主动设置了。

## Summary by Sourcery

Bug Fixes:
- Ensure panel tooltips display with word-initial capitalization by configuring the font capitalization property