### PR TITLE
fix: adjust notification center width calculation

### DIFF
--- a/panels/notification/center/NotifyCenter.qml
+++ b/panels/notification/center/NotifyCenter.qml
@@ -6,6 +6,7 @@ import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
 import org.deepin.dtk 1.0
+import org.deepin.dtk.style 1.0 as DS
 import org.deepin.ds.notification
 import org.deepin.ds.notificationcenter
 
@@ -32,7 +33,7 @@ FocusScope {
                 left: parent.left
             }
             height: 40
-            width: parent.width
+            width: NotifyStyle.contentItem.width
             notifyModel: notifyModel
             z: 1
         }
@@ -46,7 +47,7 @@ FocusScope {
                 bottom: parent.bottom
             }
 
-            width: parent.width
+            width: NotifyStyle.contentItem.width + DS.Style.scrollBar.padding + DS.Style.scrollBar.width + NotifyStyle.scrollBarPadding
             height: Math.min(maxViewHeight, viewHeight)
             notifyModel: notifyModel
         }

--- a/panels/notification/center/NotifyViewDelegate.qml
+++ b/panels/notification/center/NotifyViewDelegate.qml
@@ -23,7 +23,7 @@ DelegateChooser {
         GroupNotify {
             id: groupNotify
             objectName: "group-" + model.appName
-            width: 360
+            width: NotifyStyle.contentItem.width
             appName: model.appName
             activeFocusOnTab: true
 
@@ -61,7 +61,7 @@ DelegateChooser {
         NormalNotify {
             id: normalNotify
             objectName: "normal-" + model.appName
-            width: 360
+            width: NotifyStyle.contentItem.width
             activeFocusOnTab: true
 
             appName: model.appName
@@ -120,7 +120,7 @@ DelegateChooser {
         OverlapNotify {
             id: overlapNotify
             objectName: "overlap-" + model.appName
-            width: 360
+            width: NotifyStyle.contentItem.width
             activeFocusOnTab: true
 
             count: model.overlapCount

--- a/panels/notification/center/package/main.qml
+++ b/panels/notification/center/package/main.qml
@@ -7,6 +7,7 @@ import QtQuick.Controls
 import QtQuick.Layouts
 import org.deepin.dtk 1.0
 import org.deepin.ds 1.0
+import org.deepin.ds.notification
 import org.deepin.ds.notificationcenter
 
 Window {
@@ -33,7 +34,8 @@ Window {
     visible: Panel.visible
     flags: Qt.Tool
 
-    width: 360 + view.anchors.leftMargin + view.anchors.rightMargin
+    property int contentPadding: 20
+    width: NotifyStyle.contentItem.width + contentPadding * 2
     // height: 800
     DLayerShellWindow.layer: DLayerShellWindow.LayerOverlay
     DLayerShellWindow.anchors: DLayerShellWindow.AnchorRight | DLayerShellWindow.AnchorTop | DLayerShellWindow.AnchorBottom
@@ -80,13 +82,13 @@ Window {
 
     Item {
         id: view
-        width: parent.width
         // clear focus when NotificationCenter is closed.
         focus: root.visible
         anchors {
             top: parent.top
             left: parent.left
-            margins: 20
+            leftMargin: contentPadding
+            right: parent.right
             bottom: parent.bottom
         }
 
@@ -95,8 +97,9 @@ Window {
             anchors {
                 top: parent.top
                 left: parent.left
+                right: parent.right
+                rightMargin: contentPadding
             }
-            implicitWidth: 360
             Connections {
                 target: Panel
                 function onVisibleChanged() {
@@ -114,6 +117,7 @@ Window {
             anchors {
                 top: notifyStaging.bottom
                 left: parent.left
+                right: parent.right
                 bottom: parent.bottom
             }
 
@@ -128,7 +132,6 @@ Window {
                 }
             }
 
-            implicitWidth: 360
             maxViewHeight: root.height
             stagingViewCount: notifyStaging.viewCount
         }

--- a/panels/notification/plugin/NotifyStyle.qml
+++ b/panels/notification/plugin/NotifyStyle.qml
@@ -12,5 +12,7 @@ QtObject {
         property int topMargin: 4
         property int bottomMargin: 8
         property int miniHeight: 40
+        property int width: 360
     }
+    property int scrollBarPadding: 2
 }


### PR DESCRIPTION
Changed width calculation from hardcoded values to use
NotifyStyle.contentItem.width for consistent styling
Added proper scrollbar width calculation in NotifyCenter to account for
scrollbar presence
Updated main window width calculation to include proper padding handling
Fixed anchor margins and right constraints to ensure proper layout with
dynamic width
Added contentPadding property for better maintainability of spacing
values

Log: Fixed notification center layout issues with dynamic width
calculation

Influence:
1. Test notification center display with different content widths
2. Verify scrollbar appears correctly and doesn't cause layout issues
3. Check that all notification items maintain consistent width
4. Test window resizing behavior and content alignment
5. Verify margins and padding are applied correctly on all sides

fix: 调整通知中心宽度计算方式

将硬编码的宽度值改为使用 NotifyStyle.contentItem.width 以确保样式一致性
在 NotifyCenter 中添加了正确的滚动条宽度计算以考虑滚动条的存在
更新了主窗口宽度计算以包含正确的内边距处理
修复了锚点边距和右侧约束以确保动态宽度下的正确布局
添加了 contentPadding 属性以便更好地维护间距值

Log: 修复了通知中心动态宽度计算导致的布局问题

Influence:
1. 测试不同内容宽度下通知中心的显示效果
2. 验证滚动条正确显示且不会导致布局问题
3. 检查所有通知项是否保持一致的宽度
4. 测试窗口调整大小行为和内容对齐
5. 验证边距和内边距在所有边上是否正确应用

PMS: BUG-325871
