### PR TITLE
fix: adjust notification center scrollbar position

### DIFF
--- a/panels/notification/center/NotifyCenter.qml
+++ b/panels/notification/center/NotifyCenter.qml
@@ -6,7 +6,6 @@ import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
 import org.deepin.dtk 1.0
-import org.deepin.dtk.style 1.0 as DS
 import org.deepin.ds.notification
 import org.deepin.ds.notificationcenter
 
@@ -43,11 +42,12 @@ FocusScope {
             anchors {
                 left: parent.left
                 top: header.bottom
+                right: parent.right
+                rightMargin: NotifyStyle.scrollBarPadding
                 topMargin: 10
                 bottom: parent.bottom
             }
 
-            width: NotifyStyle.contentItem.width + DS.Style.scrollBar.padding + DS.Style.scrollBar.width + NotifyStyle.scrollBarPadding
             height: Math.min(maxViewHeight, viewHeight)
             notifyModel: notifyModel
         }


### PR DESCRIPTION
Fixed scrollbar positioning issue in notification center by:
1. Removed unused DS style import that was causing conflicts
2. Added right anchor and rightMargin to properly position the content
area
3. Removed explicit width calculation that was causing misalignment
4. Maintained height calculation based on maxViewHeight and viewHeight

The scrollbar was incorrectly positioned due to hardcoded width
calculations that didn't account for proper layout constraints. By
using anchor-based layout with appropriate margins instead of explicit
width calculations, the scrollbar now positions correctly within the
notification center panel.

Log: Fixed notification center scrollbar positioning issue

Influence:
1. Open notification center and verify scrollbar appears correctly
positioned
2. Test scrolling functionality with multiple notifications
3. Check that scrollbar visibility toggles properly based on content
height
4. Verify layout consistency across different screen sizes
5. Test notification center opening/closing animations

fix: 调整通知中心滚动条位置

修复通知中心滚动条定位问题：
1. 移除导致冲突的未使用 DS 样式导入
2. 添加右侧锚点和右边距以正确定位内容区域
3. 移除导致错位的显式宽度计算
4. 保持基于最大视图高度和视图高度的高度计算

由于硬编码的宽度计算未考虑正确的布局约束，导致滚动条定位不正确。通过使用
基于锚点的布局和适当的边距代替显式宽度计算，滚动条现在可以在通知中心面板
中正确定位。

Log: 修复通知中心滚动条定位问题

Influence:
1. 打开通知中心并验证滚动条正确定位
2. 使用多个通知测试滚动功能
3. 检查滚动条可见性是否根据内容高度正确切换
4. 验证不同屏幕尺寸下的布局一致性
5. 测试通知中心打开/关闭动画

PMS: BUG-283695
