### PR TITLE
chore: bump version to 2.0.10

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,14 @@
+dde-shell (2.0.10) unstable; urgency=medium
+
+  * fix: adjust notification center scrollbar position
+  * fix: adjust notification center width calculation
+  * fix: remove redundant focus property in notification center
+  * fix: ensure panel tooltips are capitalized
+  * i18n: Updates for project Deepin Desktop Environment (#1247)
+  * chore: bump CMake minimum required version to 3.16
+
+ -- YeShanShan <yeshanshan@uniontech.com>  Thu, 18 Sep 2025 20:39:39 +0800
+
 dde-shell (2.0.9) unstable; urgency=medium
 
   * i18n: Updates for project Deepin Desktop Environment (#1244)


### PR DESCRIPTION
update changelog to 2.0.10

## Summary by Sourcery

Bump package version to 2.0.10 and update the Debian changelog accordingly.

Build:
- Update debian/changelog entry for version 2.0.10

Chores:
- Bump project version to 2.0.10