### PR TITLE
fix: When clicked the application tray button, the hover background i…

### DIFF
--- a/panels/dock/tray/package/ActionShowStashDelegate.qml
+++ b/panels/dock/tray/package/ActionShowStashDelegate.qml
@@ -25,7 +25,7 @@ AppletItemButton {
 
     padding: itemPadding
 
-    D.ColorSelector.hovered: (isDropHover && DDT.TraySortOrderModel.actionsAlwaysVisible) || hoverHandler.hovered
+    D.ColorSelector.hovered: (isDropHover && DDT.TraySortOrderModel.actionsAlwaysVisible) || hoverHandler.hovered || stashedPopup.popupVisible
 
     property var itemGlobalPoint: {
         var a = root
@@ -94,8 +94,12 @@ AppletItemButton {
     }
 
     onClicked: {
-        stashedPopup.open()
-        toolTip.close()
+        if (stashedPopup.popupVisible) {
+            stashedPopup.close();
+        } else {
+            stashedPopup.open();
+        }
+        toolTip.close();
     }
 
     PanelToolTip {


### PR DESCRIPTION
…s not displayed

When you click the app tray button, the hover background is displayed normally

Log: as title
Pms: BUG-288633

## Summary by Sourcery

Fix hover background disappearance and implement toggle behavior for stash popup in the application tray button

Bug Fixes:
- Include stash popup visibility in hover state to retain hover background when popup is open
- Toggle the stash popup on click instead of always opening it