### PR TITLE
fix: When system has no blur effect, the Multitasking View plugin is …

### DIFF
--- a/panels/dock/dockdbusproxy.cpp
+++ b/panels/dock/dockdbusproxy.cpp
@@ -222,7 +222,7 @@ DockItemInfos DockDBusProxy::plugins()
         QMetaObject::invokeMethod(m_trayApplet, "dockItemInfos", Qt::DirectConnection, qReturnArg(iteminfos));
     }
 
-    if (m_multitaskviewApplet && DWindowManagerHelper::instance()->hasComposite()) {
+    if (m_multitaskviewApplet && DWindowManagerHelper::instance()->hasBlurWindow()) {
         DockItemInfo info;
         if (QMetaObject::invokeMethod(m_multitaskviewApplet, "dockItemInfo", Qt::DirectConnection, qReturnArg(info))) {
             iteminfos.append(info);


### PR DESCRIPTION
…also displayed in the Control Center

has no blur effect, multitasking view plugin can not display in dcc.

Log: as title
Pms: BUG-286917

## Summary by Sourcery

Bug Fixes:
- Use DWindowManagerHelper::hasBlurWindow() instead of hasComposite() to determine when to include the Multitasking View plugin, preventing it from appearing when blur effect is unavailable