### PR TITLE
fix: missing attention role for taskmanager's base model

### DIFF
--- a/panels/dock/taskmanager/abstractwindowmonitor.cpp
+++ b/panels/dock/taskmanager/abstractwindowmonitor.cpp
@@ -22,6 +22,7 @@ QHash<int, QByteArray> AbstractWindowMonitor::roleNames() const
             {TaskManager::WinIconRole, MODEL_WINICON},
             {TaskManager::WinTitleRole, MODEL_TITLE},
             {TaskManager::ActiveRole, MODEL_ACTIVE},
+            {TaskManager::AttentionRole, MODEL_ATTENTION},
             {TaskManager::ShouldSkipRole, MODEL_SHOULDSKIP}};
 }
 
@@ -95,6 +96,8 @@ QVariant AbstractWindowMonitor::data(const QModelIndex &index, int role) const
         return window->isActive();
     case TaskManager::ShouldSkipRole:
         return window->shouldSkip();
+    case TaskManager::AttentionRole:
+        return window->isAttention();
     }
 
     return QVariant();


### PR DESCRIPTION
AbstractWindowMonitor 缺失 AttentionRole 信号,导致企业微信等应用的 消息通知动画缺失.

## Summary by Sourcery

Bug Fixes:
- Add missing AttentionRole mapping and data handling in AbstractWindowMonitor model to restore window attention notifications.