### PR TITLE
fix: Fixed tab key navigation issue in notification center

### DIFF
--- a/panels/notification/center/GroupNotify.qml
+++ b/panels/notification/center/GroupNotify.qml
@@ -11,45 +11,52 @@ import org.deepin.ds.notificationcenter
 
 NotifyItem {
     id: root
+    implicitWidth: impl.implicitWidth
+    implicitHeight: impl.implicitHeight
 
     signal collapse()
 
-    contentItem: RowLayout {
-        NotifyHeaderTitleText {
-            text: root.appName
-            Layout.alignment: Qt.AlignLeft
-            Layout.leftMargin: 18
-            tFont: DTK.fontManager.t5
-        }
+    Control {
+        id: impl
+        anchors.fill: parent
 
-        Item {
-            Layout.fillWidth: true
-            Layout.preferredHeight: 1
-        }
+        contentItem: RowLayout {
+            NotifyHeaderTitleText {
+                text: root.appName
+                Layout.alignment: Qt.AlignLeft
+                Layout.leftMargin: 18
+                tFont: DTK.fontManager.t5
+            }
 
-        SettingActionButton {
-            Layout.alignment: Qt.AlignRight
-            icon.name: "fold"
-            onClicked: {
-                console.log("collapse")
-                root.collapse()
+            Item {
+                Layout.fillWidth: true
+                Layout.preferredHeight: 1
             }
-        }
-        SettingActionButton {
-            Layout.alignment: Qt.AlignRight
-            icon.name: "more"
-            onClicked: function () {
-                console.log("group setting", appName)
-                let pos = mapToItem(root, Qt.point(width / 2, height))
-                root.setting(pos)
+
+            SettingActionButton {
+                Layout.alignment: Qt.AlignRight
+                icon.name: "fold"
+                onClicked: {
+                    console.log("collapse")
+                    root.collapse()
+                }
             }
-        }
-        AnimationSettingButton {
-            Layout.alignment: Qt.AlignRight
-            icon.name: "clean-group"
-            text: qsTr("Clear All")
-            onClicked: function () {
-                root.remove()
+            SettingActionButton {
+                Layout.alignment: Qt.AlignRight
+                icon.name: "more"
+                onClicked: function () {
+                    console.log("group setting", root.appName)
+                    let pos = mapToItem(root, Qt.point(width / 2, height))
+                    root.setting(pos)
+                }
+            }
+            AnimationSettingButton {
+                Layout.alignment: Qt.AlignRight
+                icon.name: "clean-group"
+                text: qsTr("Clear All")
+                onClicked: function () {
+                    root.remove()
+                }
             }
         }
     }

--- a/panels/notification/center/NormalNotify.qml
+++ b/panels/notification/center/NormalNotify.qml
@@ -11,6 +11,8 @@ import org.deepin.ds.notificationcenter
 
 NotifyItem {
     id: root
+    implicitWidth: impl.implicitWidth
+    implicitHeight: impl.implicitHeight
 
     property var removedCallback
 
@@ -35,34 +37,39 @@ NotifyItem {
         }
     }
 
-    contentItem: NotifyItemContent {
-        width: parent.width
-        appName: root.appName
-        iconName: root.iconName
-        content: root.content
-        title: root.title
-        date: root.date
-        actions: root.actions
-        defaultAction: root.defaultAction
-        closeVisible: root.hovered || root.activeFocus
-        strongInteractive: root.strongInteractive
-        contentIcon: root.contentIcon
-        contentRowCount: root.contentRowCount
+    Control {
+        id: impl
+        anchors.fill: parent
 
-        onRemove: function () {
-            root.removedCallback = function () {
-                root.remove()
+        contentItem: NotifyItemContent {
+            width: parent.width
+            appName: root.appName
+            iconName: root.iconName
+            content: root.content
+            title: root.title
+            date: root.date
+            actions: root.actions
+            defaultAction: root.defaultAction
+            closeVisible: impl.hovered || root.activeFocus
+            strongInteractive: root.strongInteractive
+            contentIcon: root.contentIcon
+            contentRowCount: root.contentRowCount
+
+            onRemove: function () {
+                root.removedCallback = function () {
+                    root.remove()
+                }
+                root.state = "removing"
             }
-            root.state = "removing"
-        }
-        onDismiss: function () {
-            root.removedCallback = function () {
-                root.dismiss()
+            onDismiss: function () {
+                root.removedCallback = function () {
+                    root.dismiss()
+                }
+                root.state = "removing"
             }
-            root.state = "removing"
-        }
-        onActionInvoked: function (actionId) {
-            root.actionInvoked(actionId)
+            onActionInvoked: function (actionId) {
+                root.actionInvoked(actionId)
+            }
         }
     }
 }

--- a/panels/notification/center/NotifyViewDelegate.qml
+++ b/panels/notification/center/NotifyViewDelegate.qml
@@ -140,7 +140,7 @@ DelegateChooser {
                 active: overlapNotify.activeFocus && NotifyAccessor.debugging
 
                 sourceComponent: FocusBoxBorder {
-                    radius: overlapNotify.radius
+                    radius: overlapNotify.overlapItemRadius
                     color: overlapNotify.palette.highlight
                 }
             }

--- a/panels/notification/center/OverlapNotify.qml
+++ b/panels/notification/center/OverlapNotify.qml
@@ -11,6 +11,8 @@ import org.deepin.ds.notificationcenter
 
 NotifyItem {
     id: root
+    implicitWidth: impl.implicitWidth
+    implicitHeight: impl.implicitHeight
 
     property int count: 1
     readonly property int overlapItemRadius: 12
@@ -40,62 +42,67 @@ NotifyItem {
         }
     }
 
-    contentItem: Item {
-        width: parent.width
-        implicitHeight: notifyContent.height + indicator.height
-        NotifyItemContent {
-            id: notifyContent
+    Control {
+        id: impl
+        anchors.fill: parent
+
+        contentItem: Item {
             width: parent.width
-            appName: root.appName
-            iconName: root.iconName
-            content: root.content
-            title: root.title
-            date: root.date
-            actions: root.actions
-            defaultAction: root.defaultAction
-            closeVisible: root.hovered || root.activeFocus
-            strongInteractive: root.strongInteractive
-            contentIcon: root.contentIcon
-            contentRowCount: root.contentRowCount
-            enableDismissed: root.enableDismissed
+            implicitHeight: notifyContent.height + indicator.height
+            NotifyItemContent {
+                id: notifyContent
+                width: parent.width
+                appName: root.appName
+                iconName: root.iconName
+                content: root.content
+                title: root.title
+                date: root.date
+                actions: root.actions
+                defaultAction: root.defaultAction
+                closeVisible: impl.hovered || root.activeFocus
+                strongInteractive: root.strongInteractive
+                contentIcon: root.contentIcon
+                contentRowCount: root.contentRowCount
+                enableDismissed: root.enableDismissed
 
-            onRemove: function () {
-                root.removedCallback = function () {
-                    root.remove()
+                onRemove: function () {
+                    root.removedCallback = function () {
+                        root.remove()
+                    }
+                    root.state = "removing"
                 }
-                root.state = "removing"
-            }
-            onDismiss: function () {
-                root.removedCallback = function () {
-                    root.dismiss()
+                onDismiss: function () {
+                    root.removedCallback = function () {
+                        root.dismiss()
+                    }
+                    root.state = "removing"
                 }
-                root.state = "removing"
+                onActionInvoked: function (actionId) {
+                    root.actionInvoked(actionId)
+                }
             }
-            onActionInvoked: function (actionId) {
-                root.actionInvoked(actionId)
+
+            OverlapIndicator {
+                id: indicator
+                anchors {
+                    bottom: parent.bottom
+                    left: parent.left
+                    leftMargin: overlapItemRadius
+                    right: parent.right
+                    rightMargin: overlapItemRadius
+                }
+                z: -1
+                count: root.count
             }
         }
 
-        OverlapIndicator {
-            id: indicator
-            anchors {
-                bottom: parent.bottom
-                left: parent.left
-                leftMargin: overlapItemRadius
-                right: parent.right
-                rightMargin: overlapItemRadius
-            }
-            z: -1
-            count: root.count
+        // expand
+        TapHandler {
+            enabled: !root.enableDismissed
+            acceptedButtons: Qt.LeftButton
+            onTapped: root.expand()
         }
+        Keys.onEnterPressed: root.expand()
+        Keys.onReturnPressed: root.expand()
     }
-
-    // expand
-    TapHandler {
-        enabled: !root.enableDismissed
-        acceptedButtons: Qt.LeftButton
-        onTapped: root.expand()
-    }
-    Keys.onEnterPressed: root.expand()
-    Keys.onReturnPressed: root.expand()
 }

--- a/panels/notification/plugin/NotifyItem.qml
+++ b/panels/notification/plugin/NotifyItem.qml
@@ -8,7 +8,7 @@ import QtQuick.Layouts
 import org.deepin.dtk 1.0
 import org.deepin.ds.notification
 
-Control {
+FocusScope {
     id: root
 
     enum CloseReason {

--- a/panels/notification/plugin/NotifyItemContent.qml
+++ b/panels/notification/plugin/NotifyItemContent.qml
@@ -11,243 +11,250 @@ import org.deepin.ds.notification
 
 NotifyItem {
     id: root
-
-    property bool closeVisible: root.hovered || root.activeFocus
+    implicitWidth: impl.implicitWidth
+    implicitHeight: impl.implicitHeight
+    property bool closeVisible: activeFocus
     property int miniContentHeight: NotifyStyle.contentItem.miniHeight
     property bool enableDismissed: true
 
-    Item {
+    Control {
+        id: impl
         anchors.fill: parent
-        z: -1
-        enabled: root.enableDismissed
-        TapHandler {
-            property bool isLongPressed
-            gesturePolicy: TapHandler.ReleaseWithinBounds
-            onCanceled: function () {
-                if (isLongPressed) {
-                    console.log("Dissmiss notify", root.appName, isLongPressed)
-                    root.dismiss()
+
+        Item {
+            anchors.fill: parent
+            z: -1
+            enabled: root.enableDismissed
+            TapHandler {
+                property bool isLongPressed
+                gesturePolicy: TapHandler.ReleaseWithinBounds
+                onCanceled: function () {
+                    if (isLongPressed) {
+                        console.log("Dissmiss notify", root.appName, isLongPressed)
+                        root.dismiss()
+                    }
+                    isLongPressed = false
                 }
-                isLongPressed = false
-            }
-            onLongPressed: isLongPressed = true
-            onTapped: function () {
-                if (!root.defaultAction)
-                    return
+                onLongPressed: isLongPressed = true
+                onTapped: function () {
+                    if (!root.defaultAction)
+                        return
 
-                console.log("Click default action notify", root.appName, root.defaultAction)
-                root.actionInvoked(root.defaultAction)
-            }
-        }
-    }
-
-    // placeHolder to receive MouseEvent
-    FocusScope {
-        focus: true
-        anchors {
-            top: parent.top
-            topMargin: -height / 2
-            right: parent.right
-            rightMargin: -width / 2
-        }
-        width: 20
-        height: 20
-
-        Loader {
-            active: !(root.strongInteractive && root.actions.length > 0) && (root.closeVisible || activeFocus)
-            sourceComponent: SettingActionButton {
-                id: closeBtn
-                objectName: "closeNotify-" + root.appName
-                icon.name: "clean-alone"
-                padding: 2
-                forcusBorderVisible: visualFocus
-                onClicked: function () {
-                    root.remove()
-                }
-                background: BoxPanel {
-                    radius: closeBtn.radius
-                    enableBoxShadow: true
-                    boxShadowBlur: 4
-                    boxShadowOffsetY: 1
-                    color1: Palette {
-                        normal {
-                            common: ("transparent")
-                            // TODO crystal: Qt.rgba(240 / 255.0, 240 / 255.0, 240 / 255.0, 0.5)
-                            crystal: Qt.rgba(240 / 255.0, 240 / 255.0, 240 / 255.0, 1.0)
-                        }
-                        normalDark {
-                            // TODO crystal: Qt.rgba(240 / 255.0, 240 / 255.0, 240 / 255.0, 0.5)
-                            crystal: Qt.rgba(24 / 255.0, 24 / 255.0, 24 / 255.0, 1.0)
-                        }
-                    }
-                    color2: color1
-                    insideBorderColor: Palette {
-                        normal {
-                            common: ("transparent")
-                            crystal: Qt.rgba(255 / 255.0, 255 / 255.0, 255 / 255.0, 0.2)
-                        }
-                        normalDark {
-                            crystal: Qt.rgba(255 / 255.0, 255 / 255.0, 255 / 255.0, 0.1)
-                        }
-                    }
-                    outsideBorderColor: Palette {
-                        normal {
-                            common: ("transparent")
-                            crystal: Qt.rgba(0, 0, 0, 0.08)
-                        }
-                        normalDark {
-                            crystal: Qt.rgba(0, 0, 0, 0.4)
-                        }
-                    }
-                    dropShadowColor: Palette {
-                        normal {
-                            common: ("transparent")
-                            crystal: Qt.rgba(0, 0, 0, 0.15)
-                        }
-                        normalDark {
-                            crystal: Qt.rgba(0, 0, 0, 0.4)
-                        }
-                    }
-                    innerShadowColor1: null
-                    innerShadowColor2: innerShadowColor1
+                    console.log("Click default action notify", root.appName, root.defaultAction)
+                    root.actionInvoked(root.defaultAction)
                 }
             }
         }
-    }
 
-    contentItem: RowLayout {
-        spacing: 0
-        Binding {
-            target: root
-            property: "miniContentHeight"
-            value: 26 + NotifyStyle.contentItem.topMargin + NotifyStyle.contentItem.bottomMargin
+        // placeHolder to receive MouseEvent
+        FocusScope {
+            focus: true
+            anchors {
+                top: parent.top
+                topMargin: -height / 2
+                right: parent.right
+                rightMargin: -width / 2
+            }
+            width: 20
+            height: 20
+
+            Loader {
+                focus: true
+                active: !(root.strongInteractive && root.actions.length > 0) && (root.closeVisible || activeFocus)
+                sourceComponent: SettingActionButton {
+                    id: closeBtn
+                    objectName: "closeNotify-" + root.appName
+                    icon.name: "clean-alone"
+                    padding: 2
+                    forcusBorderVisible: visualFocus
+                    onClicked: function () {
+                        root.remove()
+                    }
+                    background: BoxPanel {
+                        radius: closeBtn.radius
+                        enableBoxShadow: true
+                        boxShadowBlur: 4
+                        boxShadowOffsetY: 1
+                        color1: Palette {
+                            normal {
+                                common: ("transparent")
+                                // TODO crystal: Qt.rgba(240 / 255.0, 240 / 255.0, 240 / 255.0, 0.5)
+                                crystal: Qt.rgba(240 / 255.0, 240 / 255.0, 240 / 255.0, 1.0)
+                            }
+                            normalDark {
+                                // TODO crystal: Qt.rgba(240 / 255.0, 240 / 255.0, 240 / 255.0, 0.5)
+                                crystal: Qt.rgba(24 / 255.0, 24 / 255.0, 24 / 255.0, 1.0)
+                            }
+                        }
+                        color2: color1
+                        insideBorderColor: Palette {
+                            normal {
+                                common: ("transparent")
+                                crystal: Qt.rgba(255 / 255.0, 255 / 255.0, 255 / 255.0, 0.2)
+                            }
+                            normalDark {
+                                crystal: Qt.rgba(255 / 255.0, 255 / 255.0, 255 / 255.0, 0.1)
+                            }
+                        }
+                        outsideBorderColor: Palette {
+                            normal {
+                                common: ("transparent")
+                                crystal: Qt.rgba(0, 0, 0, 0.08)
+                            }
+                            normalDark {
+                                crystal: Qt.rgba(0, 0, 0, 0.4)
+                            }
+                        }
+                        dropShadowColor: Palette {
+                            normal {
+                                common: ("transparent")
+                                crystal: Qt.rgba(0, 0, 0, 0.15)
+                            }
+                            normalDark {
+                                crystal: Qt.rgba(0, 0, 0, 0.4)
+                            }
+                        }
+                        innerShadowColor1: null
+                        innerShadowColor2: innerShadowColor1
+                    }
+                }
+            }
         }
 
-        DciIcon {
-            name: root.iconName !== "" ? root.iconName : "application-x-desktop"
-            sourceSize: Qt.size(24, 24)
-            Layout.alignment: Qt.AlignLeft | Qt.AlignTop
-            Layout.topMargin: 8
-            Layout.leftMargin: 10
-            palette: DTK.makeIconPalette(root.palette)
-            theme: root.ColorSelector.controlTheme
-        }
-
-        ColumnLayout {
+        contentItem: RowLayout {
             spacing: 0
-            Layout.alignment: Qt.AlignLeft | Qt.AlignTop
-            Layout.rightMargin: 10
-            Layout.leftMargin: 10
-            Layout.topMargin: NotifyStyle.contentItem.topMargin
-            Layout.bottomMargin: NotifyStyle.contentItem.bottomMargin
-            Layout.fillWidth: true
-            Layout.fillHeight: true
-            Layout.minimumHeight: NotifyStyle.contentItem.miniHeight
-            Layout.maximumHeight: 240
-            RowLayout {
-                id: firstLine
+            Binding {
+                target: root
+                property: "miniContentHeight"
+                value: 26 + NotifyStyle.contentItem.topMargin + NotifyStyle.contentItem.bottomMargin
+            }
+
+            DciIcon {
+                name: root.iconName !== "" ? root.iconName : "application-x-desktop"
+                sourceSize: Qt.size(24, 24)
+                Layout.alignment: Qt.AlignLeft | Qt.AlignTop
+                Layout.topMargin: 8
+                Layout.leftMargin: 10
+                palette: DTK.makeIconPalette(impl.palette)
+                theme: impl.ColorSelector.controlTheme
+            }
+
+            ColumnLayout {
                 spacing: 0
+                Layout.alignment: Qt.AlignLeft | Qt.AlignTop
+                Layout.rightMargin: 10
+                Layout.leftMargin: 10
+                Layout.topMargin: NotifyStyle.contentItem.topMargin
+                Layout.bottomMargin: NotifyStyle.contentItem.bottomMargin
                 Layout.fillWidth: true
-                Layout.preferredHeight: 24
-                Layout.alignment: Qt.AlignTop | Qt.AlignLeft
-                Text {
-                    text: root.appName
-                    font: DTK.fontManager.t10
-                    color: palette.windowText
-                }
-
-                Item {
-                    Layout.preferredHeight: 1
+                Layout.fillHeight: true
+                Layout.minimumHeight: NotifyStyle.contentItem.miniHeight
+                Layout.maximumHeight: 240
+                RowLayout {
+                    id: firstLine
+                    spacing: 0
                     Layout.fillWidth: true
-                }
-
-                Loader {
-                    id: time
-                    active: !root.closeVisible
-                    visible: active
-                    Layout.alignment: Qt.AlignRight
-                    sourceComponent: Text {
-                        text: root.date
+                    Layout.preferredHeight: 24
+                    Layout.alignment: Qt.AlignTop | Qt.AlignLeft
+                    Text {
+                        text: root.appName
                         font: DTK.fontManager.t10
                         color: palette.windowText
                     }
-                }
-            }
 
-            Text {
-                text: root.title
-                visible: text !== ""
-                maximumLineCount: 1
-                font {
-                    pixelSize: DTK.fontManager.t8.pixelSize
-                    family: DTK.fontManager.t8.family
-                    bold: true
-                }
-                color: palette.windowText
-                wrapMode: Text.NoWrap
-                elide: Text.ElideMiddle
-                Layout.fillWidth: true
-                Layout.alignment: Qt.AlignLeft | Qt.AlignTop
-            }
+                    Item {
+                        Layout.preferredHeight: 1
+                        Layout.fillWidth: true
+                    }
 
-            RowLayout {
-                Layout.fillWidth: true
-                Layout.alignment: Qt.AlignLeft | Qt.AlignTop
+                    Loader {
+                        id: time
+                        active: !root.closeVisible
+                        visible: active
+                        Layout.alignment: Qt.AlignRight
+                        sourceComponent: Text {
+                            text: root.date
+                            font: DTK.fontManager.t10
+                            color: palette.windowText
+                        }
+                    }
+                }
+
                 Text {
-                    id: bodyText
-                    Layout.alignment: Qt.AlignLeft
-                    Layout.fillWidth: true
+                    text: root.title
                     visible: text !== ""
-                    text: root.content
-                    maximumLineCount: root.contentRowCount
-                    font: DTK.fontManager.t8
+                    maximumLineCount: 1
+                    font {
+                        pixelSize: DTK.fontManager.t8.pixelSize
+                        family: DTK.fontManager.t8.family
+                        bold: true
+                    }
                     color: palette.windowText
-                    wrapMode: Text.WordWrap
-                    elide: Text.ElideRight
-                    linkColor: palette.highlight
-                    onLinkActivated: function (link) {
-                        root.linkActivated(link)
-                    }
-                    HoverHandler {
-                        enabled: bodyText.hoveredLink !== ""
-                        cursorShape: Qt.PointingHandCursor
-                    }
-                }
-                Item {
-                    Layout.preferredHeight: 1
+                    wrapMode: Text.NoWrap
+                    elide: Text.ElideMiddle
                     Layout.fillWidth: true
+                    Layout.alignment: Qt.AlignLeft | Qt.AlignTop
+                }
+
+                RowLayout {
+                    Layout.fillWidth: true
+                    Layout.alignment: Qt.AlignLeft | Qt.AlignTop
+                    Text {
+                        id: bodyText
+                        Layout.alignment: Qt.AlignLeft
+                        Layout.fillWidth: true
+                        visible: text !== ""
+                        text: root.content
+                        maximumLineCount: root.contentRowCount
+                        font: DTK.fontManager.t8
+                        color: palette.windowText
+                        wrapMode: Text.WordWrap
+                        elide: Text.ElideRight
+                        linkColor: palette.highlight
+                        onLinkActivated: function (link) {
+                            root.linkActivated(link)
+                        }
+                        HoverHandler {
+                            enabled: bodyText.hoveredLink !== ""
+                            cursorShape: Qt.PointingHandCursor
+                        }
+                    }
+                    Item {
+                        Layout.preferredHeight: 1
+                        Layout.fillWidth: true
+                    }
+
+                    Loader {
+                        Layout.maximumWidth: 106
+                        Layout.maximumHeight: 106
+                        Layout.minimumWidth: 16
+                        Layout.minimumHeight: 16
+                        Layout.alignment: Qt.AlignRight
+                        active: root.contentIcon !== ""
+                        visible: active
+                        // TODO DciIcon's bounding can't be limit by maximumWidth.
+                        sourceComponent: Image {
+                            anchors.fill: parent
+                            fillMode: Image.PreserveAspectFit
+                            source: root.contentIcon
+                        }
+                    }
                 }
 
                 Loader {
-                    Layout.maximumWidth: 106
-                    Layout.maximumHeight: 106
-                    Layout.minimumWidth: 16
-                    Layout.minimumHeight: 16
-                    Layout.alignment: Qt.AlignRight
-                    active: root.contentIcon !== ""
+                    active: root.actions.length > 0
                     visible: active
-                    // TODO DciIcon's bounding can't be limit by maximumWidth.
-                    sourceComponent: Image {
-                        anchors.fill: parent
-                        fillMode: Image.PreserveAspectFit
-                        source: root.contentIcon
-                    }
-                }
-            }
-
-            Loader {
-                active: root.actions.length > 0
-                visible: active
-                Layout.alignment: Qt.AlignRight | Qt.AlignBottom
-                sourceComponent: NotifyAction {
-                    actions: root.actions
-                    onActionInvoked: function (actionId) {
-                        root.actionInvoked(actionId)
+                    Layout.alignment: Qt.AlignRight | Qt.AlignBottom
+                    sourceComponent: NotifyAction {
+                        actions: root.actions
+                        onActionInvoked: function (actionId) {
+                            root.actionInvoked(actionId)
+                        }
                     }
                 }
             }
         }
-    }
 
-    background: NotifyItemBackground { }
+        background: NotifyItemBackground { }
+    }
 }


### PR DESCRIPTION
The changes address the tab key navigation issue in the notification
center where pressing tab couldn't close notifications. The main fix
involves converting NotifyItem from Control to FocusScope to properly
handle focus management. Additionally, all notification components
(GroupNotify, NormalNotify, OverlapNotify, NotifyItemContent) were
wrapped in Control containers with proper implicit size properties to
ensure consistent focus behavior. The close button visibility logic was
updated to use activeFocus instead of hovered state for better keyboard
navigation support.

Log: Fixed tab key navigation issue in notification center

Influence:
1. Test tab navigation through notification items
2. Verify close button appears with keyboard focus
3. Test Enter/Return key functionality on notifications
4. Verify mouse interactions still work correctly
5. Test notification dismissal with keyboard shortcuts

fix: 修复通知中心Tab键焦点问题

此次修改解决了通知中心中按Tab键无法关闭通知的问题。主要修复包括将
NotifyItem从Control转换为FocusScope以正确处理焦点管理。此外，所有通知组
件（GroupNotify、NormalNotify、OverlapNotify、NotifyItemContent）都被包
装在Control容器中，并设置了适当的隐式大小属性以确保一致的焦点行为。关闭
按钮的可见性逻辑更新为使用activeFocus而不是hovered状态，以提供更好的键盘
导航支持。

Log: 修复通知中心Tab键导航问题

Influence:
1. 测试通过通知项的Tab导航
2. 验证关闭按钮是否随键盘焦点出现
3. 测试Enter/Return键在通知上的功能
4. 验证鼠标交互是否仍然正常工作
5. 测试使用键盘快捷键关闭通知

PMS: BUG-311333

## Summary by Sourcery

Improve keyboard navigation in the notification center by refactoring focus management, wrapping components for consistent sizing, and updating close button visibility logic to support Tab and Enter/Return key interactions

New Features:
- Support expanding overlapping notifications via Enter/Return keys

Enhancements:
- Convert NotifyItem root element from Control to FocusScope for improved focus management
- Wrap all notification components in Control containers with implicit size properties for consistent focus behavior
- Update close button visibility logic to depend on activeFocus instead of hovered for keyboard navigation