### PR TITLE
fix: sometimes dock might be empty after boot and login

### DIFF
--- a/applets/dde-apps/amappitemmodel.cpp
+++ b/applets/dde-apps/amappitemmodel.cpp
@@ -18,6 +18,7 @@ namespace apps
 AMAppItemModel::AMAppItemModel(QObject *parent)
     : AppItemModel(parent)
     , m_manager(new ObjectManager("org.desktopspec.ApplicationManager1", "/org/desktopspec/ApplicationManager1", QDBusConnection::sessionBus()))
+    , m_ready(false)
 {
     qRegisterMetaType<ObjectInterfaceMap>();
     qDBusRegisterMetaType<ObjectInterfaceMap>();
@@ -60,7 +61,15 @@ AMAppItemModel::AMAppItemModel(QObject *parent)
                 appendRow(c);
             }
         }
+
+        setProperty("ready", true);
+        qCDebug(appsLog) << "AMAppItemModel is now ready with apps counts:" << rowCount();
     });
+}
+
+bool AMAppItemModel::ready() const
+{
+    return m_ready;
 }
 
 AMAppItem * AMAppItemModel::appItem(const QString &id)

--- a/applets/dde-apps/amappitemmodel.h
+++ b/applets/dde-apps/amappitemmodel.h
@@ -13,13 +13,19 @@ class AMAppItem;
 class AMAppItemModel : public AppItemModel
 {
     Q_OBJECT
-
+    Q_PROPERTY(bool ready MEMBER m_ready READ ready NOTIFY readyChanged)
 public:
     explicit AMAppItemModel(QObject *parent = nullptr);
 
     AMAppItem * appItem(const QString &id);
 
+    bool ready() const;
+
+signals:
+    void readyChanged(bool);
+
 private:
+    bool m_ready;
     ObjectManager *m_manager;
 };
 }

--- a/applets/dde-apps/appsapplet.cpp
+++ b/applets/dde-apps/appsapplet.cpp
@@ -17,6 +17,7 @@ AppsApplet::AppsApplet(QObject *parent)
     , m_appModel(new AMAppItemModel(this))
     , m_groupModel(new AppGroupManager(m_appModel, this))
 {
+    connect(m_appModel, &AMAppItemModel::readyChanged, this, &AppsApplet::appModelReadyChanged);
 }
 
 AppsApplet::~AppsApplet()
@@ -37,6 +38,11 @@ QAbstractItemModel *AppsApplet::groupModel() const
 QAbstractItemModel *AppsApplet::appModel() const
 {
     return m_appModel;
+}
+
+bool AppsApplet::appModelReady() const
+{
+    return m_appModel->ready();
 }
 
 D_APPLET_CLASS(AppsApplet)

--- a/applets/dde-apps/appsapplet.h
+++ b/applets/dde-apps/appsapplet.h
@@ -18,6 +18,7 @@ class AppsApplet : public DApplet
 {
     Q_OBJECT
     Q_PROPERTY(QAbstractItemModel *appModel READ appModel CONSTANT FINAL)
+    Q_PROPERTY(bool appModelReady READ appModelReady NOTIFY appModelReadyChanged FINAL)
     Q_PROPERTY(QAbstractItemModel *appGroupModel READ groupModel CONSTANT FINAL)
 
 public:
@@ -29,7 +30,13 @@ public:
     QAbstractItemModel *appModel() const;
     QAbstractItemModel *groupModel() const;
 
+    bool appModelReady() const;
+
+signals:
+    void appModelReadyChanged(bool ready);
+
 private:
+    bool m_appModelReady;
     AMAppItemModel *m_appModel;
     QAbstractItemModel *m_groupModel;
 };

--- a/panels/dock/taskmanager/dockglobalelementmodel.cpp
+++ b/panels/dock/taskmanager/dockglobalelementmodel.cpp
@@ -12,7 +12,10 @@
 #include <QDBusConnection>
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <QLoggingCategory>
 #include <QProcess>
+
+Q_LOGGING_CATEGORY(dockGlobalElementModelLog, "dde.shell.dock.taskmanager.dockglobalelementmodel")
 
 #include <algorithm>
 #include <tuple>
@@ -181,6 +184,12 @@ int DockGlobalElementModel::columnCount(const QModelIndex &parent) const
     return 1;
 }
 
+void DockGlobalElementModel::initDockedElements(bool unused)
+{
+    Q_UNUSED(unused);
+    loadDockedElements();
+}
+
 void DockGlobalElementModel::loadDockedElements()
 {
     QList<std::tuple<QString, QString>> newDocked;
@@ -236,6 +245,8 @@ void DockGlobalElementModel::loadDockedElements()
     }
 
     m_dockedElements = newDocked;
+
+    qCDebug(dockGlobalElementModelLog) << "loaded docked elements count:" << m_dockedElements.count() << "appsModel row count:" << m_appsModel->rowCount();
 
     if (!m_data.isEmpty()) {
         // MenusRole should also be handled here due to it contains the copywriting of docked or undocked

--- a/panels/dock/taskmanager/dockglobalelementmodel.h
+++ b/panels/dock/taskmanager/dockglobalelementmodel.h
@@ -36,6 +36,9 @@ public:
 
     void requestWindowsView(const QModelIndexList &indexes) const override;
 
+public slots:
+    void initDockedElements(bool unused);
+
 private:
     void loadDockedElements();
     QString getMenus(const QModelIndex &index) const;

--- a/panels/dock/taskmanager/taskmanager.cpp
+++ b/panels/dock/taskmanager/taskmanager.cpp
@@ -140,6 +140,8 @@ bool TaskManager::init()
         // 初始化预览代理模型，基于合并后的数据
         m_hoverPreviewModel = new HoverPreviewProxyModel(this);
         m_hoverPreviewModel->setSourceModel(m_dockGlobalElementModel);
+
+        connect(applet, SIGNAL(appModelReadyChanged(bool)), m_dockGlobalElementModel, SLOT(initDockedElements(bool)));
     }
 
     connect(m_windowMonitor.data(), &AbstractWindowMonitor::windowFullscreenChanged, this, [this] (bool isFullscreen) {


### PR DESCRIPTION
部分情况下,dock驻留区域的加载早于 AM 对应的模型中的数据就绪,导致驻留加载完毕后因为有效性检查而被过滤,致使托盘区域原本驻留的应用全部未展示. 此提交新增了一个就绪信号,以供在更准确的时机通知驻留信息的加载.

## Summary by Sourcery

Delay loading of docked elements until the application model signals readiness to prevent the dock from appearing empty after boot or login.

New Features:
- Add a ready property and readyChanged signal to AMAppItemModel to indicate when the app model has finished loading
- Expose an appModelReady property and appModelReadyChanged signal on AppsApplet
- Introduce an initDockedElements slot in DockGlobalElementModel to reload docked elements upon app model readiness

Bug Fixes:
- Hold off initial dock population until the application model is ready to avoid filtering out docked apps prematurely

Enhancements:
- Add a dedicated logging category and debug messages to report docked elements load counts