### PR TITLE
fix: desktop menu actions shows English instead of locale language

### DIFF
--- a/applets/dde-apps/amappitem.cpp
+++ b/applets/dde-apps/amappitem.cpp
@@ -106,11 +106,19 @@ void AMAppItem::setOnDesktop(bool on)
     AppItem::setOnDesktop(on);
 }
 
-QString AMAppItem::getLocaleOrDefaultValue(const QStringMap &value, const QString &targetKey, const QString &fallbackKey)
+QString AMAppItem::getLocaleOrDefaultValue(const QStringMap &value, const QString &localeCode, const QString &fallbackKey)
 {
-    auto targetValue = value.value(targetKey);
-    auto fallbackValue = value.value(fallbackKey);
-    return !targetValue.isEmpty() ? targetValue : fallbackValue;
+    if (value.contains(localeCode)) {
+        return value.value(localeCode);
+    } else {
+        QString fallbackValue = value.value(fallbackKey);
+        if (localeCode.contains('_')) {
+            QString prefix = localeCode.split('_')[0];
+            return value.value(prefix, fallbackValue);
+        } else {
+            return fallbackValue;
+        }
+    }
 }
 
 void AMAppItem::onPropertyChanged(const QDBusMessage &msg)
@@ -133,7 +141,7 @@ void AMAppItem::onPropertyChanged(const QDBusMessage &msg)
         AppItem::setAppName(name);
     }
 
-    auto iconName = getLocaleOrDefaultValue(Application::icons(), DESKTOP_ENTRY_ICON_KEY, "");
+    auto iconName = Application::icons().value(DESKTOP_ENTRY_ICON_KEY);
     AppItem::setAppIconName(iconName);
 
     AppItem::setNoDisPlay(Application::noDisplay());
@@ -160,7 +168,7 @@ void AMAppItem::updateActions(const QStringList &actions, const PropMap &actionN
         auto localeNames = actionName.value(action);
         QJsonObject actionObject;
         actionObject.insert(QStringLiteral("id"), action);
-        actionObject.insert(QStringLiteral("name"), getLocaleOrDefaultValue(localeNames, action, DEFAULT_KEY));
+        actionObject.insert(QStringLiteral("name"), getLocaleOrDefaultValue(localeNames, locale, DEFAULT_KEY));
         actionsArray.append(actionObject);
     }
     if (actions.size() > 0) {

--- a/applets/dde-apps/amappitem.h
+++ b/applets/dde-apps/amappitem.h
@@ -22,7 +22,7 @@ public:
     void setOnDesktop(bool on) override;
 
 private:
-    QString getLocaleOrDefaultValue(const QStringMap &value, const QString &targetKey, const QString &fallbackKey);
+    QString getLocaleOrDefaultValue(const QStringMap &value, const QString &localeCode, const QString &fallbackKey);
     void updateActions(const QStringList &actions, const PropMap &actionName);
 
 private Q_SLOTS:


### PR DESCRIPTION
任务栏右键菜单,应用自己的 action 未显示成当前用户的系统语言对应的文案

## Summary by Sourcery

Update AMAppItem localization logic to ensure desktop menu actions and icons display in the current user's locale

Bug Fixes:
- Fix desktop menu actions showing English instead of the user's locale language
- Correct action name retrieval to use the localeCode rather than the action key

Enhancements:
- Enhance getLocaleOrDefaultValue to first check full locale code, then language prefix, before falling back
- Simplify icon name lookup by using a direct map value instead of locale-based fallback