### PR TITLE
fix: adjust notification center window positioning

### DIFF
--- a/panels/notification/center/package/main.qml
+++ b/panels/notification/center/package/main.qml
@@ -86,6 +86,7 @@ Window {
         focus: root.visible
         anchors {
             top: parent.top
+            topMargin: contentPadding
             left: parent.left
             leftMargin: contentPadding
             right: parent.right


### PR DESCRIPTION
Fixed notification center window positioning by adding top margin to
match the left/right margins. Previously the window was flush with
the top edge while having side margins, creating inconsistent spacing.
Now the top margin uses the same contentPadding value as the sides for
consistent visual alignment.

Influence:
1. Verify notification center appears with equal spacing on all sides
2. Test that window positioning remains correct when contentPadding
changes
3. Check that notifications display properly within the adjusted bounds

fix: 调整通知中心窗口位置

修复通知中心窗口位置问题，通过添加顶部边距使其与左右边距保持一致。之前窗
口顶部边缘没有边距而两侧有边距，导致间距不一致。现在顶部边距使用与两侧相
同的contentPadding值，实现一致的视觉对齐。

Influence:
1. 验证通知中心在所有边距上显示相等的间距
2. 测试当contentPadding变化时窗口位置保持正确
3. 检查通知在调整后的边界内正确显示

PMS: BUG-335225

## Summary by Sourcery

Bug Fixes:
- Apply contentPadding as the topMargin on the notification center window to prevent it from being flush with the top edge