### PR TITLE
feat: add i18n support for notification clear button

### DIFF
--- a/panels/notification/CMakeLists.txt
+++ b/panels/notification/CMakeLists.txt
@@ -42,6 +42,7 @@ target_link_libraries(ds-notification-shared PUBLIC
 
 install(TARGETS ds-notification-shared DESTINATION "${LIB_INSTALL_DIR}")
 ds_install_package(PACKAGE org.deepin.ds.notification TARGET ds-notification)
+ds_handle_package_translation(PACKAGE org.deepin.ds.notification QML_FILES ${CMAKE_CURRENT_SOURCE_DIR}/plugin/NotifyItemContent.qml)
 
 add_subdirectory(plugin)
 add_subdirectory(bubble)

--- a/panels/notification/plugin/NotifyItemContent.qml
+++ b/panels/notification/plugin/NotifyItemContent.qml
@@ -8,6 +8,7 @@ import QtQuick.Layouts
 import org.deepin.dtk 1.0
 import org.deepin.dtk.style 1.0 as DStyle
 import org.deepin.ds.notification
+import org.deepin.ds.notificationcenter
 
 NotifyItem {
     id: root
@@ -60,11 +61,13 @@ NotifyItem {
 
             Loader {
                 focus: true
+                anchors.right: parent.right
                 active: !(root.strongInteractive && root.actions.length > 0) && (root.closeVisible || closePlaceHolder.hovered || activeFocus)
-                sourceComponent: SettingActionButton {
+                sourceComponent: AnimationSettingButton {
                     id: closeBtn
                     objectName: "closeNotify-" + root.appName
                     icon.name: "clean-alone"
+                    text: qsTr("Clear alone")
                     padding: 2
                     forcusBorderVisible: visualFocus
                     onClicked: function () {

--- a/panels/notification/translations/org.deepin.ds.notification.ts
+++ b/panels/notification/translations/org.deepin.ds.notification.ts
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1">
+<context>
+    <name>NotifyItemContent</name>
+    <message>
+        <source>Clear alone</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/panels/notification/translations/org.deepin.ds.notification_ar.ts
+++ b/panels/notification/translations/org.deepin.ds.notification_ar.ts
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1">
+<context>
+    <name>NotifyItemContent</name>
+    <message>
+        <source>Clear alone</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/panels/notification/translations/org.deepin.ds.notification_az.ts
+++ b/panels/notification/translations/org.deepin.ds.notification_az.ts
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1">
+<context>
+    <name>NotifyItemContent</name>
+    <message>
+        <source>Clear alone</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/panels/notification/translations/org.deepin.ds.notification_bo.ts
+++ b/panels/notification/translations/org.deepin.ds.notification_bo.ts
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1">
+<context>
+    <name>NotifyItemContent</name>
+    <message>
+        <source>Clear alone</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/panels/notification/translations/org.deepin.ds.notification_ca.ts
+++ b/panels/notification/translations/org.deepin.ds.notification_ca.ts
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1">
+<context>
+    <name>NotifyItemContent</name>
+    <message>
+        <source>Clear alone</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/panels/notification/translations/org.deepin.ds.notification_de.ts
+++ b/panels/notification/translations/org.deepin.ds.notification_de.ts
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1">
+<context>
+    <name>NotifyItemContent</name>
+    <message>
+        <source>Clear alone</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/panels/notification/translations/org.deepin.ds.notification_es.ts
+++ b/panels/notification/translations/org.deepin.ds.notification_es.ts
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1">
+<context>
+    <name>NotifyItemContent</name>
+    <message>
+        <source>Clear alone</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/panels/notification/translations/org.deepin.ds.notification_fi.ts
+++ b/panels/notification/translations/org.deepin.ds.notification_fi.ts
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1">
+<context>
+    <name>NotifyItemContent</name>
+    <message>
+        <source>Clear alone</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/panels/notification/translations/org.deepin.ds.notification_fr.ts
+++ b/panels/notification/translations/org.deepin.ds.notification_fr.ts
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1">
+<context>
+    <name>NotifyItemContent</name>
+    <message>
+        <source>Clear alone</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/panels/notification/translations/org.deepin.ds.notification_hu.ts
+++ b/panels/notification/translations/org.deepin.ds.notification_hu.ts
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1">
+<context>
+    <name>NotifyItemContent</name>
+    <message>
+        <source>Clear alone</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/panels/notification/translations/org.deepin.ds.notification_it.ts
+++ b/panels/notification/translations/org.deepin.ds.notification_it.ts
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1">
+<context>
+    <name>NotifyItemContent</name>
+    <message>
+        <source>Clear alone</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/panels/notification/translations/org.deepin.ds.notification_ja.ts
+++ b/panels/notification/translations/org.deepin.ds.notification_ja.ts
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1">
+<context>
+    <name>NotifyItemContent</name>
+    <message>
+        <source>Clear alone</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/panels/notification/translations/org.deepin.ds.notification_ko.ts
+++ b/panels/notification/translations/org.deepin.ds.notification_ko.ts
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1">
+<context>
+    <name>NotifyItemContent</name>
+    <message>
+        <source>Clear alone</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/panels/notification/translations/org.deepin.ds.notification_lo.ts
+++ b/panels/notification/translations/org.deepin.ds.notification_lo.ts
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1">
+<context>
+    <name>NotifyItemContent</name>
+    <message>
+        <source>Clear alone</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/panels/notification/translations/org.deepin.ds.notification_nb_NO.ts
+++ b/panels/notification/translations/org.deepin.ds.notification_nb_NO.ts
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1">
+<context>
+    <name>NotifyItemContent</name>
+    <message>
+        <source>Clear alone</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/panels/notification/translations/org.deepin.ds.notification_pl.ts
+++ b/panels/notification/translations/org.deepin.ds.notification_pl.ts
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1">
+<context>
+    <name>NotifyItemContent</name>
+    <message>
+        <source>Clear alone</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/panels/notification/translations/org.deepin.ds.notification_pt_BR.ts
+++ b/panels/notification/translations/org.deepin.ds.notification_pt_BR.ts
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1">
+<context>
+    <name>NotifyItemContent</name>
+    <message>
+        <source>Clear alone</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/panels/notification/translations/org.deepin.ds.notification_ru.ts
+++ b/panels/notification/translations/org.deepin.ds.notification_ru.ts
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1">
+<context>
+    <name>NotifyItemContent</name>
+    <message>
+        <source>Clear alone</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/panels/notification/translations/org.deepin.ds.notification_sq.ts
+++ b/panels/notification/translations/org.deepin.ds.notification_sq.ts
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1">
+<context>
+    <name>NotifyItemContent</name>
+    <message>
+        <source>Clear alone</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/panels/notification/translations/org.deepin.ds.notification_uk.ts
+++ b/panels/notification/translations/org.deepin.ds.notification_uk.ts
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1">
+<context>
+    <name>NotifyItemContent</name>
+    <message>
+        <source>Clear alone</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/panels/notification/translations/org.deepin.ds.notification_zh_CN.ts
+++ b/panels/notification/translations/org.deepin.ds.notification_zh_CN.ts
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_CN">
+<context>
+    <name>NotifyItemContent</name>
+    <message>
+        <source>Clear alone</source>
+        <translation>清除单个</translation>
+    </message>
+</context>
+</TS>

--- a/panels/notification/translations/org.deepin.ds.notification_zh_HK.ts
+++ b/panels/notification/translations/org.deepin.ds.notification_zh_HK.ts
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_HK">
+<context>
+    <name>NotifyItemContent</name>
+    <message>
+        <source>Clear alone</source>
+        <translation>清除單個</translation>
+    </message>
+</context>
+</TS>

--- a/panels/notification/translations/org.deepin.ds.notification_zh_TW.ts
+++ b/panels/notification/translations/org.deepin.ds.notification_zh_TW.ts
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_TW">
+<context>
+    <name>NotifyItemContent</name>
+    <message>
+        <source>Clear alone</source>
+        <translation>清除單個</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
1. Added translation handling for NotifyItemContent.qml in CMakeLists.txt
2. Replaced SettingActionButton with AnimationSettingButton for better UX
3. Added text label "Clear alone" to the close button for accessibility
4. Anchored close button to the right side for proper layout
5. Created translation files for 20+ languages including Chinese variants
6. Pre-filled Chinese translations (zh_CN, zh_HK, zh_TW) while leaving others unfinished

This change enables internationalization support for the notification clear button, making the interface more user-friendly for global users. The button now has proper text labeling and improved positioning.

feat: 为通知清除按钮添加国际化支持

1. 在 CMakeLists.txt 中添加对 NotifyItemContent.qml 的翻译处理
2. 将 SettingActionButton 替换为 AnimationSettingButton 以提升用户体验
3. 为关闭按钮添加"清除单个"文本标签以提高可访问性
4. 将关闭按钮锚定到右侧以实现正确布局
5. 创建包含中文变体在内的20多种语言翻译文件
6. 预填充中文翻译（简体、香港、台湾），其他语言留空待翻译

此更改使通知清除按钮支持国际化，为全球用户提供更友好的界面。按钮现在具有
适当的文本标签和改善的定位。

Pms: BUG-283587