### PR TITLE
fix: Fix the storage notification that says there is no signal

### DIFF
--- a/panels/notification/center/notifymodel.cpp
+++ b/panels/notification/center/notifymodel.cpp
@@ -643,7 +643,8 @@ void NotifyModel::invokeAction(qint64 id, const QString &actionId)
     if (!entity.isValid())
         return;
 
-    m_accessor->invokeAction(entity, actionId);
+    // The storage notification needs to emit signal.
+    m_accessor->invokeNotify(entity, actionId);
 
     remove(id);
 }


### PR DESCRIPTION
Fix the storage notification that says there is no signal

Log: Fix the storage notification that says there is no signal
pms: BUG-333027

## Summary by Sourcery

Bug Fixes:
- Replace m_accessor->invokeAction with invokeNotify in NotifyModel to ensure storage notifications emit their signal