### PR TITLE
fix: improve text visibility logic in AnimationSettingButton

### DIFF
--- a/panels/notification/center/AnimationSettingButton.qml
+++ b/panels/notification/center/AnimationSettingButton.qml
@@ -12,7 +12,7 @@ SettingActionButton {
     id: root
 
     property int duration: 200
-    property bool textVisible: root.hovered && text !== ""
+    property bool textVisible: (root.hovered || root.activeFocus) && text !== ""
     property bool enableAnimation: false
 
     Component.onCompleted: {


### PR DESCRIPTION
Changed the textVisible property condition to include both hovered and activeFocus states instead of just hovered. This ensures that the button text remains visible when the button has keyboard focus, improving accessibility for users navigating with keyboard or screen readers.

The previous implementation only showed text on hover, which made it difficult for keyboard-only users to see the button labels when navigating through focus.

fix: 改进 AnimationSettingButton 中的文本可见性逻辑

将 textVisible 属性的条件从仅检查悬停状态改为同时检查悬停和焦点状态。这
确保了按钮在获得键盘焦点时文本仍然可见，提高了使用键盘或屏幕阅读器用户的
可访问性。

之前的实现仅在悬停时显示文本，这使得仅使用键盘导航的用户在通过焦点浏览时
难以看到按钮标签。

Pms: BUG-284477

## Summary by Sourcery

Bug Fixes:
- Show button text when the button has active keyboard focus or hover instead of only on hover