### PR TITLE
fix: taskmanager context menu should use app name instead of window title

### DIFF
--- a/panels/dock/taskmanager/dockglobalelementmodel.cpp
+++ b/panels/dock/taskmanager/dockglobalelementmodel.cpp
@@ -262,7 +262,15 @@ QString DockGlobalElementModel::getMenus(const QModelIndex &index) const
     auto row = std::get<2>(data);
 
     QJsonArray menusArray;
-    menusArray.append(QJsonObject{{"id", ""}, {"name", model == m_activeAppModel ? index.data(TaskManager::WinTitleRole).toString() : tr("Open")}});
+    QString appNameInMenu = tr("Open");
+    if (model == m_activeAppModel) {
+        appNameInMenu = index.data(TaskManager::NameRole).toString();
+        // In case a window does not belongs to a known application, use the window title instead
+        if (appNameInMenu.isEmpty()) {
+            appNameInMenu = index.data(TaskManager::WinTitleRole).toString();
+        }
+    }
+    menusArray.append(QJsonObject{{"id", ""}, {"name", appNameInMenu}});
 
     auto actions = model->index(row, 0).data(TaskManager::ActionsRole).toByteArray();
     for (auto action : QJsonDocument::fromJson(actions).array()) {


### PR DESCRIPTION
是重构分支实现时的行为错误.

## Summary by Sourcery

Bug Fixes:
- Use application name instead of window title in TaskManager context menu