### PR TITLE
fix: ensure preview icon will use icon from theme as fallback

### DIFF
--- a/panels/dock/taskmanager/x11preview.h
+++ b/panels/dock/taskmanager/x11preview.h
@@ -83,7 +83,7 @@ private:
     inline void updatePreviewTitle(const QString& title);
     inline void initUI();
     inline void updateSize(int windowCount = -1);
-    void updatePreviewIconFromBase64(const QString &base64Data);
+    void updatePreviewIconFromString(const QString &stringData);
 
 public Q_SLOTS:
     void updatePosition();


### PR DESCRIPTION
确保窗口预览图会使用来自图标主题的名称作为 fallback

## Summary by Sourcery

Improve the window preview icon loader to handle both base64 image data and named icons by theme, renaming the method and adding fallback behavior and logging

Enhancements:
- Rename updatePreviewIconFromBase64 to updatePreviewIconFromString and update its usage sites accordingly
- Extend icon loading to fall back to theme icons when input string is not base64 image data
- Log failures when icon loading fails and use a transparent placeholder as fallback