### PR TITLE
fix: Popup windows was not closed  when dock screen changed

### DIFF
--- a/panels/dock/package/main.qml
+++ b/panels/dock/package/main.qml
@@ -649,6 +649,10 @@ Window {
             if (popup && popup.visible)
                 popup.close()
         }
+        function onDockScreenChanged() {
+            // Close all popups when dock moves to another screen
+            Panel.requestClosePopup()
+        }
 
         target: Panel
     }


### PR DESCRIPTION
close all popup windows when dock screen changed

Log: as title
Pms: BUG-288701

## Summary by Sourcery

Bug Fixes:
- Add an onDockScreenChanged handler in main.qml to trigger closing of all popups via Panel.requestClosePopup()