### PR TITLE
feat: add clean all button for overlap notifications

### DIFF
--- a/panels/notification/center/NotifyViewDelegate.qml
+++ b/panels/notification/center/NotifyViewDelegate.qml
@@ -166,8 +166,8 @@ DelegateChooser {
                              })
             }
             onRemove: function () {
-                console.log("remove overlap", model.id)
-                notifyModel.remove(model.id)
+                console.log("remove overlap", model.appName)
+                notifyModel.removeByApp(model.appName)
             }
             onActionInvoked: function (actionId) {
                 console.log("action overlap", model.id, actionId)

--- a/panels/notification/center/OverlapNotify.qml
+++ b/panels/notification/center/OverlapNotify.qml
@@ -64,12 +64,15 @@ NotifyItem {
                 contentIcon: root.contentIcon
                 contentRowCount: root.contentRowCount
                 enableDismissed: root.enableDismissed
-
-                onRemove: function () {
-                    root.removedCallback = function () {
-                        root.remove()
+                clearButton: AnimationSettingButton {
+                    icon.name: "clean-alone"
+                    text: qsTr("Clean All")
+                    onClicked: function () {
+                        root.removedCallback = function() {
+                            root.remove()
+                        }
+                        root.state = "removing"
                     }
-                    root.state = "removing"
                 }
                 onDismiss: function () {
                     root.removedCallback = function () {

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter.ts
@@ -58,6 +58,13 @@
     </message>
 </context>
 <context>
+    <name>OverlapNotify</name>
+    <message>
+        <source>Clean All</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>notifycenter::AppNotifyItem</name>
     <message>
         <source>Just now</source>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_ar.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_ar.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ar">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ar">
 <context>
     <name>GroupNotify</name>
     <message>
@@ -7,18 +9,18 @@
     </message>
     <message>
         <source>Fold</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>More</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>NotifyCenter</name>
     <message>
         <source>No recent notifications</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -33,11 +35,11 @@
     </message>
     <message>
         <source>Fold</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>More</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -53,6 +55,13 @@
     <message>
         <source>Notification Setting</source>
         <translation>إعداد الإخطارات</translation>
+    </message>
+</context>
+<context>
+    <name>OverlapNotify</name>
+    <message>
+        <source>Clean All</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_az.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_az.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="az">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="az">
 <context>
     <name>GroupNotify</name>
     <message>
@@ -7,18 +9,18 @@
     </message>
     <message>
         <source>Fold</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>More</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>NotifyCenter</name>
     <message>
         <source>No recent notifications</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -33,11 +35,11 @@
     </message>
     <message>
         <source>Fold</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>More</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -53,6 +55,13 @@
     <message>
         <source>Notification Setting</source>
         <translation>إعداد الإشعارات</translation>
+    </message>
+</context>
+<context>
+    <name>OverlapNotify</name>
+    <message>
+        <source>Clean All</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_bo.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_bo.ts
@@ -58,6 +58,13 @@
     </message>
 </context>
 <context>
+    <name>OverlapNotify</name>
+    <message>
+        <source>Clean All</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>notifycenter::AppNotifyItem</name>
     <message>
         <source>Just now</source>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_ca.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_ca.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ca">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ca">
 <context>
     <name>GroupNotify</name>
     <message>
@@ -53,6 +55,13 @@
     <message>
         <source>Notification Setting</source>
         <translation>Configuració de les notificacions</translation>
+    </message>
+</context>
+<context>
+    <name>OverlapNotify</name>
+    <message>
+        <source>Clean All</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_de.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_de.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="de">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="de">
 <context>
     <name>GroupNotify</name>
     <message>
@@ -7,18 +9,18 @@
     </message>
     <message>
         <source>Fold</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>More</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>NotifyCenter</name>
     <message>
         <source>No recent notifications</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -33,11 +35,11 @@
     </message>
     <message>
         <source>Fold</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>More</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -53,6 +55,13 @@
     <message>
         <source>Notification Setting</source>
         <translation>Benachrichtigungseinstellung</translation>
+    </message>
+</context>
+<context>
+    <name>OverlapNotify</name>
+    <message>
+        <source>Clean All</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_es.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_es.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="es">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="es">
 <context>
     <name>GroupNotify</name>
     <message>
@@ -7,11 +9,11 @@
     </message>
     <message>
         <source>Fold</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>More</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -33,11 +35,11 @@
     </message>
     <message>
         <source>Fold</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>More</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -53,6 +55,13 @@
     <message>
         <source>Notification Setting</source>
         <translation>Ajustes de notificaciones</translation>
+    </message>
+</context>
+<context>
+    <name>OverlapNotify</name>
+    <message>
+        <source>Clean All</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_fi.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_fi.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="fi">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fi">
 <context>
     <name>GroupNotify</name>
     <message>
@@ -7,11 +9,11 @@
     </message>
     <message>
         <source>Fold</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>More</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -33,11 +35,11 @@
     </message>
     <message>
         <source>Fold</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>More</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -53,6 +55,13 @@
     <message>
         <source>Notification Setting</source>
         <translation>Ilmoitusten asetukset</translation>
+    </message>
+</context>
+<context>
+    <name>OverlapNotify</name>
+    <message>
+        <source>Clean All</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_fr.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_fr.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="fr">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fr">
 <context>
     <name>GroupNotify</name>
     <message>
@@ -7,11 +9,11 @@
     </message>
     <message>
         <source>Fold</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>More</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -33,11 +35,11 @@
     </message>
     <message>
         <source>Fold</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>More</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -53,6 +55,13 @@
     <message>
         <source>Notification Setting</source>
         <translation>Réglages des notifications</translation>
+    </message>
+</context>
+<context>
+    <name>OverlapNotify</name>
+    <message>
+        <source>Clean All</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_hu.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_hu.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="hu">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="hu">
 <context>
     <name>GroupNotify</name>
     <message>
@@ -7,18 +9,18 @@
     </message>
     <message>
         <source>Fold</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>More</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>NotifyCenter</name>
     <message>
         <source>No recent notifications</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -33,11 +35,11 @@
     </message>
     <message>
         <source>Fold</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>More</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -53,6 +55,13 @@
     <message>
         <source>Notification Setting</source>
         <translation>Értesítési Beállítások</translation>
+    </message>
+</context>
+<context>
+    <name>OverlapNotify</name>
+    <message>
+        <source>Clean All</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_it.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_it.ts
@@ -58,6 +58,13 @@
     </message>
 </context>
 <context>
+    <name>OverlapNotify</name>
+    <message>
+        <source>Clean All</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>notifycenter::AppNotifyItem</name>
     <message>
         <source>Just now</source>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_ja.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_ja.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ja">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ja">
 <context>
     <name>GroupNotify</name>
     <message>
@@ -7,11 +9,11 @@
     </message>
     <message>
         <source>Fold</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>More</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -33,11 +35,11 @@
     </message>
     <message>
         <source>Fold</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>More</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -53,6 +55,13 @@
     <message>
         <source>Notification Setting</source>
         <translation>通知の設定</translation>
+    </message>
+</context>
+<context>
+    <name>OverlapNotify</name>
+    <message>
+        <source>Clean All</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_ko.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_ko.ts
@@ -58,6 +58,13 @@
     </message>
 </context>
 <context>
+    <name>OverlapNotify</name>
+    <message>
+        <source>Clean All</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>notifycenter::AppNotifyItem</name>
     <message>
         <source>Just now</source>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_lo.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_lo.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="lo">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="lo">
 <context>
     <name>GroupNotify</name>
     <message>
@@ -7,11 +9,11 @@
     </message>
     <message>
         <source>Fold</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>More</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -33,11 +35,11 @@
     </message>
     <message>
         <source>Fold</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>More</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -53,6 +55,13 @@
     <message>
         <source>Notification Setting</source>
         <translation>ການຕັ້ງຄ່າການແຈ້ງເຕືອນ</translation>
+    </message>
+</context>
+<context>
+    <name>OverlapNotify</name>
+    <message>
+        <source>Clean All</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_nb_NO.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_nb_NO.ts
@@ -58,6 +58,13 @@
     </message>
 </context>
 <context>
+    <name>OverlapNotify</name>
+    <message>
+        <source>Clean All</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>notifycenter::AppNotifyItem</name>
     <message>
         <source>Just now</source>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_pl.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_pl.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pl">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pl">
 <context>
     <name>GroupNotify</name>
     <message>
@@ -7,11 +9,11 @@
     </message>
     <message>
         <source>Fold</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>More</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -33,11 +35,11 @@
     </message>
     <message>
         <source>Fold</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>More</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -53,6 +55,13 @@
     <message>
         <source>Notification Setting</source>
         <translation>Ustawienia powiadomień</translation>
+    </message>
+</context>
+<context>
+    <name>OverlapNotify</name>
+    <message>
+        <source>Clean All</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_pt_BR.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_pt_BR.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pt_BR">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pt_BR">
 <context>
     <name>GroupNotify</name>
     <message>
@@ -7,11 +9,11 @@
     </message>
     <message>
         <source>Fold</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>More</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -33,11 +35,11 @@
     </message>
     <message>
         <source>Fold</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>More</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -53,6 +55,13 @@
     <message>
         <source>Notification Setting</source>
         <translation>Configurações de Notificações</translation>
+    </message>
+</context>
+<context>
+    <name>OverlapNotify</name>
+    <message>
+        <source>Clean All</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_ru.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_ru.ts
@@ -58,6 +58,13 @@
     </message>
 </context>
 <context>
+    <name>OverlapNotify</name>
+    <message>
+        <source>Clean All</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>notifycenter::AppNotifyItem</name>
     <message>
         <source>Just now</source>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_sq.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_sq.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="sq">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sq">
 <context>
     <name>GroupNotify</name>
     <message>
@@ -7,18 +9,18 @@
     </message>
     <message>
         <source>Fold</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>More</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>NotifyCenter</name>
     <message>
         <source>No recent notifications</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -33,11 +35,11 @@
     </message>
     <message>
         <source>Fold</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>More</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -53,6 +55,13 @@
     <message>
         <source>Notification Setting</source>
         <translation>Rregullime Njoftimesh</translation>
+    </message>
+</context>
+<context>
+    <name>OverlapNotify</name>
+    <message>
+        <source>Clean All</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_uk.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_uk.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="uk">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="uk">
 <context>
     <name>GroupNotify</name>
     <message>
@@ -7,11 +9,11 @@
     </message>
     <message>
         <source>Fold</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>More</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -33,11 +35,11 @@
     </message>
     <message>
         <source>Fold</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>More</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -53,6 +55,13 @@
     <message>
         <source>Notification Setting</source>
         <translation>Параметри сповіщень</translation>
+    </message>
+</context>
+<context>
+    <name>OverlapNotify</name>
+    <message>
+        <source>Clean All</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_zh_CN.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_zh_CN.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_CN">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_CN">
 <context>
     <name>GroupNotify</name>
     <message>
@@ -53,6 +55,13 @@
     <message>
         <source>Notification Setting</source>
         <translation>通知设置</translation>
+    </message>
+</context>
+<context>
+    <name>OverlapNotify</name>
+    <message>
+        <source>Clean All</source>
+        <translation>清除全部</translation>
     </message>
 </context>
 <context>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_zh_HK.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_zh_HK.ts
@@ -1,9 +1,11 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_HK">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_HK">
 <context>
     <name>GroupNotify</name>
     <message>
         <source>Clear All</source>
-        <translation>全部清除</translation>
+        <translation>清除全部</translation>
     </message>
     <message>
         <source>Fold</source>
@@ -53,6 +55,13 @@
     <message>
         <source>Notification Setting</source>
         <translation>通知設置</translation>
+    </message>
+</context>
+<context>
+    <name>OverlapNotify</name>
+    <message>
+        <source>Clean All</source>
+        <translation>清除全部</translation>
     </message>
 </context>
 <context>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_zh_TW.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_zh_TW.ts
@@ -1,9 +1,11 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_TW">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_TW">
 <context>
     <name>GroupNotify</name>
     <message>
         <source>Clear All</source>
-        <translation>全部清除</translation>
+        <translation>清除全部</translation>
     </message>
     <message>
         <source>Fold</source>
@@ -53,6 +55,13 @@
     <message>
         <source>Notification Setting</source>
         <translation>通知設定</translation>
+    </message>
+</context>
+<context>
+    <name>OverlapNotify</name>
+    <message>
+        <source>Clean All</source>
+        <translation>清除全部</translation>
     </message>
 </context>
 <context>

--- a/panels/notification/plugin/NotifyItemContent.qml
+++ b/panels/notification/plugin/NotifyItemContent.qml
@@ -16,6 +16,7 @@ NotifyItem {
     property bool closeVisible: activeFocus || impl.hovered
     property int miniContentHeight: NotifyStyle.contentItem.miniHeight
     property bool enableDismissed: true
+    property alias clearButton: clearLoader.sourceComponent
 
     Control {
         id: impl
@@ -59,7 +60,9 @@ NotifyItem {
             height: 20
 
             Loader {
+                id: clearLoader
                 focus: true
+                anchors.right: parent.right
                 active: !(root.strongInteractive && root.actions.length > 0) && (root.closeVisible || closePlaceHolder.hovered || activeFocus)
                 sourceComponent: SettingActionButton {
                     id: closeBtn


### PR DESCRIPTION
Added a "Clean All" button to overlap notification items to allow users to remove all notifications from a specific app at once The button is implemented as a custom button component in OverlapNotify with proper translation support
Modified NotifyModel to handle removal of overlap type notifications and added warning logging for missing apps
Updated translation files across multiple languages to include the new "Clean All" text

feat: 为重叠通知添加清除全部按钮

在重叠通知项中添加"清除全部"按钮，允许用户一次性移除特定应用的所有通知
该按钮作为自定义按钮组件在 OverlapNotify 中实现，并支持多语言翻译
修改 NotifyModel 以处理重叠类型通知的移除，并为不存在的应用添加警告日志
更新了多个语言的翻译文件以包含新的"清除全部"文本

## Summary by Sourcery

Add a “Clean All” button to overlap notification items for batch dismissal by app; integrate a custom button component in QML, extend model logic to remove overlap-type notifications with warning logs for missing apps, and update translations to include the new label

New Features:
- Add a “Clean All” button to overlap notifications to clear all notifications for a specific app at once

Enhancements:
- Introduce customButtonComponent support in NotifyItemContent and wire it through OverlapNotify and NotifyViewDelegate for flexible action buttons
- Extend NotifyModel.removeByApp to handle overlap-type notifications and log a warning when no matching notifications are found
- Update translation files across all languages to include the new “Clean All” text and enforce proper XML encoding declarations