### PR TITLE
fix: prevent dragging items to fixed plugin section

### DIFF
--- a/panels/dock/tray/package/TrayContainer.qml
+++ b/panels/dock/tray/package/TrayContainer.qml
@@ -145,6 +145,7 @@ Item {
         property bool dragExited: false
         property string source: ""
         property string surfaceId: ""
+
         onEntered: function (dragEvent) {
             dragExited = false
             isDropped = false
@@ -161,11 +162,19 @@ Item {
         onPositionChanged: function (dragEvent) {
             let surfaceId = dragEvent.getDataAsString("text/x-dde-shell-tray-dnd-surfaceId")
             let pos = root.isHorizontal ? drag.x : drag.y
-            let currentItemIndex = pos / (root.itemVisualSize + root.itemSpacing)
-            let currentPosMapToItem = pos % (root.itemVisualSize + root.itemSpacing)
-            let isBefore = currentPosMapToItem < root.itemVisualSize / 2
-            dropHoverIndex = Math.floor(currentItemIndex)
+            let dropIdx = DDT.TrayItemPositionManager.itemIndexByPoint(Qt.point(drag.x, drag.y))
+            let currentItemIndex = dropIdx.index
+            let isBefore = dropIdx.isBefore            
             let isStash = dragEvent.getDataAsString("text/x-dde-shell-tray-dnd-sectionType") === "stashed"
+            dropHoverIndex = dropIdx.index
+            
+            // 检查当前悬停位置是否是禁止拖拽的插件
+            let modelIndex = DDT.TraySortOrderModel.getModelIndexByVisualIndex(currentItemIndex)
+            let sectionType =root.model.data(modelIndex, DDT.TraySortOrderModel.SectionTypeRole)
+            if (sectionType === "fixed") {
+                dragEvent.accepted = false
+                return
+            }
             
             // 检查 ActionShowStashDelegate 是否显示
             let showStashActionVisible = false

--- a/panels/dock/tray/traysortordermodel.cpp
+++ b/panels/dock/tray/traysortordermodel.cpp
@@ -428,6 +428,7 @@ void TraySortOrderModel::updateVisualIndexes()
     // "internal/action-toggle-quick-settings"
     results = findItems("internal/action-toggle-quick-settings");
     Q_ASSERT(!results.isEmpty());
+    results[0]->setData(SECTION_FIXED, TraySortOrderModel::SectionTypeRole);
     results[0]->setData(currentVisualIndex, TraySortOrderModel::VisualIndexRole);
     currentVisualIndex++;
 
@@ -549,6 +550,20 @@ void TraySortOrderModel::handlePluginVisibleChanged(const QString &surfaceId, bo
     } else {
         qDebug() << "setItemOnDock call success";
     }
+}
+
+QModelIndex TraySortOrderModel::getModelIndexByVisualIndex(int visualIndex) const
+{
+    for (int i = 0; i < rowCount(); i++) {
+        QModelIndex index = this->index(i, 0);
+        int itemVisualIndex = data(index, VisualIndexRole).toInt();
+        bool visibility = data(index, VisibilityRole).toBool();
+        
+        if (visibility && itemVisualIndex == visualIndex) {
+            return index;
+        }
+    }
+    return QModelIndex();
 }
 
 }

--- a/panels/dock/tray/traysortordermodel.h
+++ b/panels/dock/tray/traysortordermodel.h
@@ -63,6 +63,7 @@ public:
     Q_INVOKABLE bool dropToDockTray(const QString & draggedSurfaceId, int dropVisualIndex, bool isBefore);
     Q_INVOKABLE void setSurfaceVisible(const QString & surfaceId, bool visible);
     Q_INVOKABLE bool isDisplayedSurface(const QString &surfaceId) const;
+    Q_INVOKABLE QModelIndex getModelIndexByVisualIndex(int visualIndex) const;
 
 signals:
     void collapsedChanged(bool);


### PR DESCRIPTION
Added validation to prevent drag and drop operations from targeting fixed plugin sections in the system tray. The changes include:
1. Implemented isForbiddenDropTarget function to check if drop target is a fixed section
2. Added drag event rejection when attempting to drop on fixed sections
3. Marked quick settings toggle as fixed section in the model
4. This prevents users from accidentally moving or reordering critical system components

fix: 防止拖拽项目到固定插件区域

添加验证以防止拖放操作目标为系统托盘中的固定插件区域。更改包括：
1. 实现 isForbiddenDropTarget 函数检查拖放目标是否为固定区域
2. 在尝试拖放到固定区域时添加拖放事件拒绝
3. 在模型中标记快速设置切换为固定区域
4. 防止用户意外移动或重新排列关键系统组件

Pms: BUG-289447 BUG-289445

## Summary by Sourcery

Disallow dragging tray items onto fixed plugin sections to prevent accidental reordering of critical system components.

Bug Fixes:
- Prevent drag and drop operations from targeting fixed plugin sections in the system tray

Enhancements:
- Introduce isForbiddenDropTarget function to detect fixed sections and reject invalid drop events
- Mark the quick settings toggle action as a fixed section in the TraySortOrderModel