### PR TITLE
feat: add sorting to tray items

### DIFF
--- a/panels/dock/tray/package/tray.qml
+++ b/panels/dock/tray/package/tray.qml
@@ -57,6 +57,8 @@ AppletItem {
                 color: "transparent"
                 model: DDT.SortFilterProxyModel {
                     sourceModel: DDT.TraySortOrderModel
+                    sortRoleName: "visualIndex"
+                    sortOrder: Qt.AscendingOrder
                     filterRowCallback: (sourceRow, sourceParent) => {
                         let index = sourceModel.index(sourceRow, 0, sourceParent)
                         return sourceModel.data(index, DDT.TraySortOrderModel.SectionTypeRole) === "stashed" &&


### PR DESCRIPTION
Added sortRoleName and sortOrder properties to DDT.SortFilterProxyModel to enable proper sorting of tray items by visual index in ascending order. This ensures that tray icons are displayed in a consistent and predictable sequence, improving the user experience by maintaining stable icon positions.

feat: 为托盘项添加排序功能

在 DDT.SortFilterProxyModel 中添加了 sortRoleName 和 sortOrder 属性，以 支持按视觉索引升序排列托盘项。这确保了托盘图标以一致且可预测的顺序显示，
通过保持稳定的图标位置来改善用户体验。

Pms: BUG-288745

## Summary by Sourcery

Enable proper sorting of tray items by visual index in ascending order to maintain stable icon positions and improve user experience

New Features:
- Expose sortRoleName and sortOrder properties on DDT.SortFilterProxyModel to sort tray items by visual index

Enhancements:
- Ensure tray icons display in a consistent, predictable sequence by sorting in ascending order