### PR TITLE
chore: update window icon geometry via new taskmanager interface

### DIFF
--- a/panels/dock/taskmanager/abstracttaskmanagerinterface.h
+++ b/panels/dock/taskmanager/abstracttaskmanagerinterface.h
@@ -62,9 +62,9 @@ public:
     {
         callInterfaceMethod(index, &AbstractTaskManagerInterface::requestClose, force);
     }
-    virtual void requestUpdateWindowGeometry(const QModelIndex &index, const QRect &geometry, QObject *delegate = nullptr) const
+    virtual void requestUpdateWindowIconGeometry(const QModelIndex &index, const QRect &geometry, QObject *delegate = nullptr) const
     {
-        callInterfaceMethod(index, &AbstractTaskManagerInterface::requestUpdateWindowGeometry, geometry, delegate);
+        callInterfaceMethod(index, &AbstractTaskManagerInterface::requestUpdateWindowIconGeometry, geometry, delegate);
     }
     virtual void requestWindowsView(const QModelIndexList &indexes) const
     {

--- a/panels/dock/taskmanager/abstractwindowmonitor.cpp
+++ b/panels/dock/taskmanager/abstractwindowmonitor.cpp
@@ -65,7 +65,7 @@ void AbstractWindowMonitor::requestClose(const QModelIndex &index, bool force) c
     }
 }
 
-void AbstractWindowMonitor::requestUpdateWindowGeometry(const QModelIndex &index, const QRect &geometry, QObject *delegate) const
+void AbstractWindowMonitor::requestUpdateWindowIconGeometry(const QModelIndex &index, const QRect &geometry, QObject *delegate) const
 {
 }
 

--- a/panels/dock/taskmanager/abstractwindowmonitor.h
+++ b/panels/dock/taskmanager/abstractwindowmonitor.h
@@ -39,7 +39,7 @@ public:
     void requestOpenUrls(const QModelIndex &index, const QList<QUrl> &urls) const override;
     void requestNewInstance(const QModelIndex &index, const QString &action) const override;
     void requestClose(const QModelIndex &index, bool force = false) const override;
-    void requestUpdateWindowGeometry(const QModelIndex &index, const QRect &geometry, QObject *delegate = nullptr) const override;
+    void requestUpdateWindowIconGeometry(const QModelIndex &index, const QRect &geometry, QObject *delegate = nullptr) const override;
 
     virtual void
     requestPreview(QAbstractItemModel *sourceModel, QWindow *relativePositionItem, int32_t previewXoffset, int32_t previewYoffset, uint32_t direction) = 0;

--- a/panels/dock/taskmanager/dockglobalelementmodel.cpp
+++ b/panels/dock/taskmanager/dockglobalelementmodel.cpp
@@ -398,11 +398,18 @@ void DockGlobalElementModel::requestClose(const QModelIndex &index, bool force) 
 
     qWarning() << "unable to close app not running";
 }
-void DockGlobalElementModel::requestUpdateWindowGeometry(const QModelIndex &index, const QRect &geometry, QObject *delegate) const
+
+void DockGlobalElementModel::requestUpdateWindowIconGeometry(const QModelIndex &index, const QRect &geometry, QObject *delegate) const
 {
-    Q_UNUSED(index)
-    Q_UNUSED(geometry)
-    Q_UNUSED(delegate)
+    auto data = m_data.value(index.row());
+    auto id = std::get<0>(data);
+    auto sourceModel = std::get<1>(data);
+    auto sourceRow = std::get<2>(data);
+
+    if (sourceModel == m_activeAppModel) {
+        auto sourceIndex = sourceModel->index(sourceRow, 0);
+        m_activeAppModel->requestUpdateWindowIconGeometry(sourceIndex, geometry, delegate);
+    }
 }
 
 void DockGlobalElementModel::requestWindowsView(const QModelIndexList &indexes) const

--- a/panels/dock/taskmanager/dockglobalelementmodel.h
+++ b/panels/dock/taskmanager/dockglobalelementmodel.h
@@ -32,7 +32,7 @@ public:
 
     void requestOpenUrls(const QModelIndex &index, const QList<QUrl> &urls) const override;
     void requestClose(const QModelIndex &index, bool force = false) const override;
-    void requestUpdateWindowGeometry(const QModelIndex &index, const QRect &geometry, QObject *delegate = nullptr) const override;
+    void requestUpdateWindowIconGeometry(const QModelIndex &index, const QRect &geometry, QObject *delegate = nullptr) const override;
 
     void requestWindowsView(const QModelIndexList &indexes) const override;
 

--- a/panels/dock/taskmanager/dockgroupmodel.cpp
+++ b/panels/dock/taskmanager/dockgroupmodel.cpp
@@ -132,11 +132,17 @@ void DockGroupModel::requestClose(const QModelIndex &index, bool force) const
     }
 }
 
-void DockGroupModel::requestUpdateWindowGeometry(const QModelIndex &index, const QRect &geometry, QObject *delegate) const
+void DockGroupModel::requestUpdateWindowIconGeometry(const QModelIndex &index, const QRect &geometry, QObject *delegate) const
 {
-    Q_UNUSED(index)
-    Q_UNUSED(geometry)
-    Q_UNUSED(delegate)
+    auto interface = dynamic_cast<AbstractTaskManagerInterface *>(sourceModel());
+    if (nullptr == interface)
+        return;
+
+    auto indexRowCount = RoleGroupModel::rowCount(index);
+    for (int i = 0; i < indexRowCount; i++) {
+        auto cIndex = RoleGroupModel::index(i, 0, index);
+        callInterfaceMethod(cIndex, &AbstractTaskManagerInterface::requestUpdateWindowIconGeometry, geometry, delegate);
+    }
 }
 
 void DockGroupModel::requestWindowsView(const QModelIndexList &indexes) const

--- a/panels/dock/taskmanager/dockgroupmodel.h
+++ b/panels/dock/taskmanager/dockgroupmodel.h
@@ -21,7 +21,7 @@ public:
 
     void requestActivate(const QModelIndex &index) const override;
     void requestClose(const QModelIndex &index, bool force = false) const override;
-    void requestUpdateWindowGeometry(const QModelIndex &index, const QRect &geometry, QObject *delegate = nullptr) const override;
+    void requestUpdateWindowIconGeometry(const QModelIndex &index, const QRect &geometry, QObject *delegate = nullptr) const override;
     void requestWindowsView(const QModelIndexList &indexes) const override;
 
 private:

--- a/panels/dock/taskmanager/package/AppItem.qml
+++ b/panels/dock/taskmanager/package/AppItem.qml
@@ -272,8 +272,8 @@ Item {
         repeat: false
         onTriggered: {
             var pos = icon.mapToItem(null, 0, 0)
-            taskmanager.Applet.setAppItemWindowIconGeometry(root.itemId, Panel.rootObject, pos.x, pos.y,
-                pos.x + icon.width, pos.y + icon.height)
+            taskmanager.Applet.requestUpdateWindowIconGeometry(root.modelIndex, Qt.rect(pos.x, pos.y,
+                icon.width, icon.height), Panel.rootObject)
         }
     }
 

--- a/panels/dock/taskmanager/taskmanager.cpp
+++ b/panels/dock/taskmanager/taskmanager.cpp
@@ -201,9 +201,9 @@ void TaskManager::requestClose(const QModelIndex &index, bool force) const
     m_itemModel->requestClose(index, force);
 }
 
-void TaskManager::requestUpdateWindowGeometry(const QModelIndex &index, const QRect &geometry, QObject *delegate) const
+void TaskManager::requestUpdateWindowIconGeometry(const QModelIndex &index, const QRect &geometry, QObject *delegate) const
 {
-    m_itemModel->requestUpdateWindowGeometry(index, geometry, delegate);
+    m_itemModel->requestUpdateWindowIconGeometry(index, geometry, delegate);
 }
 
 void TaskManager::requestPreview(const QModelIndex &index, QObject *relativePositionItem, int32_t previewXoffset, int32_t previewYoffset, uint32_t direction)
@@ -310,16 +310,6 @@ void TaskManager::moveFilesToTrash(const QStringList& urls)
 void TaskManager::hideItemPreview()
 {
     m_windowMonitor->hideItemPreview();
-}
-
-void TaskManager::setAppItemWindowIconGeometry(const QString& appid, QObject* relativePositionItem, const int& x1, const int& y1, const int& x2, const int& y2)
-{
-    QPointer<AppItem> item = static_cast<AppItem*>(ItemModel::instance()->getItemById(appid).get());
-    if (item.isNull()) return;
-
-    for (auto window : item->getAppendWindows()) {
-        window->setWindowIconGeometry(qobject_cast<QWindow*>(relativePositionItem), QRect(QPoint(x1, y1),QPoint(x2, y2)));
-    }
 }
 
 bool TaskManager::allowForceQuit()

--- a/panels/dock/taskmanager/taskmanager.h
+++ b/panels/dock/taskmanager/taskmanager.h
@@ -78,7 +78,7 @@ public:
 
     Q_INVOKABLE void requestOpenUrls(const QModelIndex &index, const QList<QUrl> &urls) const override;
     Q_INVOKABLE void requestClose(const QModelIndex &index, bool force = false) const override;
-    Q_INVOKABLE void requestUpdateWindowGeometry(const QModelIndex &index, const QRect &geometry, QObject *delegate = nullptr) const override;
+    Q_INVOKABLE void requestUpdateWindowIconGeometry(const QModelIndex &index, const QRect &geometry, QObject *delegate = nullptr) const override;
     Q_INVOKABLE void
     requestPreview(const QModelIndex &index, QObject *relativePositionItem, int32_t previewXoffset, int32_t previewYoffset, uint32_t direction);
     Q_INVOKABLE void requestWindowsView(const QModelIndexList &indexes) const override;
@@ -93,7 +93,6 @@ public:
     Q_INVOKABLE void dropFilesOnItem(const QString &itemId, const QStringList &urls);
     Q_INVOKABLE void hideItemPreview();
 
-    Q_INVOKABLE void setAppItemWindowIconGeometry(const QString& appid, QObject* relativePositionItem, const int& x1, const int& y1, const int& x2, const int& y2);
     Q_INVOKABLE void activateWindow(uint32_t windowID);
     Q_INVOKABLE void saveDockElementsOrder(const QStringList &appIds);
 

--- a/panels/dock/taskmanager/x11windowmonitor.cpp
+++ b/panels/dock/taskmanager/x11windowmonitor.cpp
@@ -151,6 +151,13 @@ void X11WindowMonitor::requestPreview(QAbstractItemModel *sourceModel,
     m_windowPreview->updatePosition();
 }
 
+void X11WindowMonitor::requestUpdateWindowIconGeometry(const QModelIndex &index, const QRect &geometry, QObject *delegate) const
+{
+    xcb_window_t winId = index.data(TaskManager::WinIdRole).toUInt();
+    auto pos = qobject_cast<QWindow *>(delegate)->position() + geometry.topLeft();
+    X11->setWindowIconGemeotry(winId, QRect(pos.x(), pos.y(), geometry.width(), geometry.height()));
+}
+
 void X11WindowMonitor::clearPreviewState()
 {
     // 发出信号通知 TaskManager 清空预览过滤状态

--- a/panels/dock/taskmanager/x11windowmonitor.h
+++ b/panels/dock/taskmanager/x11windowmonitor.h
@@ -44,6 +44,7 @@ public:
 
     void
     requestPreview(QAbstractItemModel *sourceModel, QWindow *relativePositionItem, int32_t previewXoffset, int32_t previewYoffset, uint32_t direction) override;
+    void requestUpdateWindowIconGeometry(const QModelIndex &index, const QRect &geometry, QObject *delegate = nullptr) const override;
 
 Q_SIGNALS:
     void windowMapped(xcb_window_t window);


### PR DESCRIPTION
目前,更新窗口所在任务栏区域的调用仍在依赖 ItemModel::instance() 模型, 此提交转而将相关实现补充到新的 taskmanager interface 中,并移除对即将废弃的接口的调用.