### PR TITLE
fix: Ensure the show desktop line is always 1 physical pixel regardle…

### DIFF
--- a/panels/dock/showdesktop/package/showdesktop.qml
+++ b/panels/dock/showdesktop/package/showdesktop.qml
@@ -32,8 +32,10 @@ AppletItem {
 
         Rectangle {
             property D.Palette lineColor: DockPalette.showDesktopLineColor
-            implicitWidth: useColumnLayout ? showdesktop.implicitWidth : 1
-            implicitHeight: useColumnLayout ? 1 : showdesktop.implicitHeight
+            // Use device pixel ratio to ensure the line is always 1 physical pixel regardless of system scaling
+            property real devicePixelRatio: Screen.devicePixelRatio
+            implicitWidth: useColumnLayout ? showdesktop.implicitWidth : (1 / devicePixelRatio)
+            implicitHeight: useColumnLayout ? (1 / devicePixelRatio) : showdesktop.implicitHeight
 
             color: D.ColorSelector.lineColor
         }


### PR DESCRIPTION
…ss of system scaling

as title

Log: as title
Pms: BUG-302035

## Summary by Sourcery

Ensure the show desktop indicator line remains one physical pixel regardless of system scaling by using the device pixel ratio to compute its dimensions.

Bug Fixes:
- Fix the line thickness changing with system scaling by adjusting implicitWidth and implicitHeight using Screen.devicePixelRatio

Enhancements:
- Import QtQuick.Window to access Screen.devicePixelRatio