### PR TITLE
chore: update Chinese translations for fold action

### DIFF
--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_zh_CN.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_zh_CN.ts
@@ -9,7 +9,7 @@
     </message>
     <message>
         <source>Fold</source>
-        <translation>折叠</translation>
+        <translation>收起</translation>
     </message>
     <message>
         <source>More</source>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_zh_HK.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_zh_HK.ts
@@ -9,7 +9,7 @@
     </message>
     <message>
         <source>Fold</source>
-        <translation>折疊</translation>
+        <translation>收起</translation>
     </message>
     <message>
         <source>More</source>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_zh_TW.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_zh_TW.ts
@@ -9,7 +9,7 @@
     </message>
     <message>
         <source>Fold</source>
-        <translation>折疊</translation>
+        <translation>收起</translation>
     </message>
     <message>
         <source>More</source>


### PR DESCRIPTION
1. Changed translation of "Fold" from "折叠" to "收起" in Simplified Chinese
2. Changed translation of "Fold" from "折疊" to "收起" in Traditional Chinese (both Hong Kong and Taiwan variants)
3. This change provides more accurate and user-friendly terminology for the fold/collapse action in notification center
4. "收起" better conveys the action of hiding or minimizing content compared to "折叠" which implies physical folding

chore: 更新中文翻译中的折叠操作术语

1. 将简体中文中"Fold"的翻译从"折叠"改为"收起"
2. 将繁体中文中"Fold"的翻译从"折疊"改为"收起"（包括香港和台湾变体）
3. 此更改提供了更准确和用户友好的通知中心折叠操作术语
4. "收起"比"折叠"更能准确表达隐藏或最小化内容的操作意图

Pms: BUG-336147

## Summary by Sourcery

Enhancements:
- Update Chinese translation for the "Fold" action from "折叠"/"折疊" to "收起" in Simplified and Traditional variants