### PR TITLE
feat: add clear button to notification items

### DIFF
--- a/panels/notification/center/NotifyStaging.qml
+++ b/panels/notification/center/NotifyStaging.qml
@@ -48,6 +48,16 @@ FocusScope {
             contentIcon: model.contentIcon
             contentRowCount: model.contentRowCount
 
+            clearButton: SettingActionButton {
+                icon.name: "clean-alone"
+                onClicked: function () {
+                    overlapNotify.removedCallback = function() {
+                        overlapNotify.remove()
+                    }
+                    overlapNotify.state = "removing"
+                }
+            }
+
             onRemove: function () {
                 console.log("remove overlap", model.id)
                 notifyModel.closeNotify(model.id, NotifyItem.Closed)

--- a/panels/notification/center/OverlapNotify.qml
+++ b/panels/notification/center/OverlapNotify.qml
@@ -18,6 +18,16 @@ NotifyItem {
     readonly property int overlapItemRadius: 12
     property bool enableDismissed: true
     property var removedCallback
+    property Component clearButton: AnimationSettingButton {
+        icon.name: "clean-alone"
+        text: qsTr("Clean All")
+        onClicked: function () {
+            root.removedCallback = function() {
+                root.remove()
+            }
+            root.state = "removing"
+        }
+    }
 
     signal expand()
 
@@ -64,16 +74,7 @@ NotifyItem {
                 contentIcon: root.contentIcon
                 contentRowCount: root.contentRowCount
                 enableDismissed: root.enableDismissed
-                clearButton: AnimationSettingButton {
-                    icon.name: "clean-alone"
-                    text: qsTr("Clean All")
-                    onClicked: function () {
-                        root.removedCallback = function() {
-                            root.remove()
-                        }
-                        root.state = "removing"
-                    }
-                }
+                clearButton: root.clearButton
                 onDismiss: function () {
                     root.removedCallback = function () {
                         root.dismiss()


### PR DESCRIPTION
1. Added clearButton property to OverlapNotify component for reusability
2. Implemented clear button functionality in NotifyStaging for individual notification removal
3. The clear button triggers removal animation and calls remove callback
4. Maintains existing clean all functionality while adding per-item clear capability

feat: 为通知项添加清除按钮

1. 在 OverlapNotify 组件中添加 clearButton 属性以提高可重用性
2. 在 NotifyStaging 中实现单个通知的清除按钮功能
3. 清除按钮触发移除动画并调用移除回调函数
4. 保留现有的全部清除功能，同时添加单个项目的清除能力

Pms: BUG-336149

## Summary by Sourcery

Introduce a customizable clearButton on notification items to enable per-notification removal while preserving the existing clean-all behavior

New Features:
- Expose a clearButton property on OverlapNotify for customizable clear actions
- Add a per-item clear button in NotifyStaging to remove individual notifications with animation and callback

Enhancements:
- Retain existing clean-all functionality alongside the new per-item clear capability