### PR TITLE
fix: prevent time text flickering on hover

### DIFF
--- a/panels/notification/plugin/NotifyItemContent.qml
+++ b/panels/notification/plugin/NotifyItemContent.qml
@@ -172,7 +172,7 @@ NotifyItem {
 
                     Loader {
                         id: time
-                        active: !root.closeVisible
+                        active: !root.closeVisible && !closePlaceHolder.hovered
                         visible: active
                         Layout.alignment: Qt.AlignRight
                         sourceComponent: Text {


### PR DESCRIPTION
Fix time text flickering issue by ensuring time loader is only active when close button is not visible AND close placeholder is not hovered. Previously, the time text would disappear and reappear when hovering over the close button area due to incorrect activation logic.

The change adds an additional condition to check if closePlaceHolder.hovered is false before activating the time loader, providing more stable visual behavior during hover interactions.

fix: 修复悬停时时间文本闪烁问题

修复时间文本闪烁问题，通过确保时间加载器仅在关闭按钮不可见且关闭占位符未
被悬停时激活。之前当鼠标悬停在关闭按钮区域时，时间文本会因激活逻辑不正确
而消失和重新出现。

此更改添加了一个额外条件来检查 closePlaceHolder.hovered 是否为 false 后 再激活时间加载器，为悬停交互提供更稳定的视觉行为。

PMS: BUG-336145

## Summary by Sourcery

Bug Fixes:
- Prevent time text flickering when hovering over the close button area by refining the loader activation logic