### PR TITLE
feat: add clean all button to notification center

### DIFF
--- a/panels/notification/center/NotifyViewDelegate.qml
+++ b/panels/notification/center/NotifyViewDelegate.qml
@@ -134,6 +134,13 @@ DelegateChooser {
             contentIcon: model.contentIcon
             contentRowCount: model.contentRowCount
             enableDismissed: false
+            notifyContent.clearButton: AnimationSettingButton {
+                icon.name: "clean-alone"
+                text: qsTr("Clean All")
+                onClicked: function () {
+                    notifyContent.remove()
+                }
+            }
 
             Loader {
                 anchors.fill: parent

--- a/panels/notification/center/OverlapNotify.qml
+++ b/panels/notification/center/OverlapNotify.qml
@@ -18,6 +18,7 @@ NotifyItem {
     readonly property int overlapItemRadius: 12
     property bool enableDismissed: true
     property var removedCallback
+    property alias notifyContent: notifyContent
 
     signal expand()
 
@@ -64,15 +65,11 @@ NotifyItem {
                 contentIcon: root.contentIcon
                 contentRowCount: root.contentRowCount
                 enableDismissed: root.enableDismissed
-                clearButton: AnimationSettingButton {
-                    icon.name: "clean-alone"
-                    text: qsTr("Clean All")
-                    onClicked: function () {
-                        root.removedCallback = function() {
-                            root.remove()
-                        }
-                        root.state = "removing"
+                onRemove: function () {
+                    root.removedCallback = function () {
+                        root.remove()
                     }
+                    root.state = "removing"
                 }
                 onDismiss: function () {
                     root.removedCallback = function () {

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter.ts
@@ -58,7 +58,7 @@
     </message>
 </context>
 <context>
-    <name>OverlapNotify</name>
+    <name>NotifyViewDelegate</name>
     <message>
         <source>Clean All</source>
         <translation type="unfinished"></translation>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_ar.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_ar.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ar">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ar">
 <context>
     <name>GroupNotify</name>
     <message>
@@ -7,18 +9,18 @@
     </message>
     <message>
         <source>Fold</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>More</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>NotifyCenter</name>
     <message>
         <source>No recent notifications</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -33,11 +35,11 @@
     </message>
     <message>
         <source>Fold</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>More</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -56,10 +58,10 @@
     </message>
 </context>
 <context>
-    <name>OverlapNotify</name>
+    <name>NotifyViewDelegate</name>
     <message>
         <source>Clean All</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_az.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_az.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="az">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="az">
 <context>
     <name>GroupNotify</name>
     <message>
@@ -7,18 +9,18 @@
     </message>
     <message>
         <source>Fold</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>More</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>NotifyCenter</name>
     <message>
         <source>No recent notifications</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -33,11 +35,11 @@
     </message>
     <message>
         <source>Fold</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>More</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -56,10 +58,10 @@
     </message>
 </context>
 <context>
-    <name>OverlapNotify</name>
+    <name>NotifyViewDelegate</name>
     <message>
         <source>Clean All</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_bo.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_bo.ts
@@ -58,7 +58,7 @@
     </message>
 </context>
 <context>
-    <name>OverlapNotify</name>
+    <name>NotifyViewDelegate</name>
     <message>
         <source>Clean All</source>
         <translation type="unfinished"></translation>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_ca.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_ca.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ca">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ca">
 <context>
     <name>GroupNotify</name>
     <message>
@@ -56,10 +58,10 @@
     </message>
 </context>
 <context>
-    <name>OverlapNotify</name>
+    <name>NotifyViewDelegate</name>
     <message>
         <source>Clean All</source>
-        <translation>Neteja-ho tot</translation>
+        <translation type="unfinished">Neteja-ho tot</translation>
     </message>
 </context>
 <context>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_de.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_de.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="de">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="de">
 <context>
     <name>GroupNotify</name>
     <message>
@@ -7,18 +9,18 @@
     </message>
     <message>
         <source>Fold</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>More</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>NotifyCenter</name>
     <message>
         <source>No recent notifications</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -33,11 +35,11 @@
     </message>
     <message>
         <source>Fold</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>More</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -56,10 +58,10 @@
     </message>
 </context>
 <context>
-    <name>OverlapNotify</name>
+    <name>NotifyViewDelegate</name>
     <message>
         <source>Clean All</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_es.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_es.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="es">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="es">
 <context>
     <name>GroupNotify</name>
     <message>
@@ -7,11 +9,11 @@
     </message>
     <message>
         <source>Fold</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>More</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -33,11 +35,11 @@
     </message>
     <message>
         <source>Fold</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>More</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -56,10 +58,10 @@
     </message>
 </context>
 <context>
-    <name>OverlapNotify</name>
+    <name>NotifyViewDelegate</name>
     <message>
         <source>Clean All</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_fi.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_fi.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="fi">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fi">
 <context>
     <name>GroupNotify</name>
     <message>
@@ -56,10 +58,10 @@
     </message>
 </context>
 <context>
-    <name>OverlapNotify</name>
+    <name>NotifyViewDelegate</name>
     <message>
         <source>Clean All</source>
-        <translation>Puhdista kaikki</translation>
+        <translation type="unfinished">Puhdista kaikki</translation>
     </message>
 </context>
 <context>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_fr.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_fr.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="fr">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fr">
 <context>
     <name>GroupNotify</name>
     <message>
@@ -7,11 +9,11 @@
     </message>
     <message>
         <source>Fold</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>More</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -33,11 +35,11 @@
     </message>
     <message>
         <source>Fold</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>More</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -56,10 +58,10 @@
     </message>
 </context>
 <context>
-    <name>OverlapNotify</name>
+    <name>NotifyViewDelegate</name>
     <message>
         <source>Clean All</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_hu.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_hu.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="hu">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="hu">
 <context>
     <name>GroupNotify</name>
     <message>
@@ -7,18 +9,18 @@
     </message>
     <message>
         <source>Fold</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>More</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>NotifyCenter</name>
     <message>
         <source>No recent notifications</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -33,11 +35,11 @@
     </message>
     <message>
         <source>Fold</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>More</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -56,10 +58,10 @@
     </message>
 </context>
 <context>
-    <name>OverlapNotify</name>
+    <name>NotifyViewDelegate</name>
     <message>
         <source>Clean All</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_it.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_it.ts
@@ -58,7 +58,7 @@
     </message>
 </context>
 <context>
-    <name>OverlapNotify</name>
+    <name>NotifyViewDelegate</name>
     <message>
         <source>Clean All</source>
         <translation type="unfinished"></translation>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_ja.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_ja.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ja">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ja">
 <context>
     <name>GroupNotify</name>
     <message>
@@ -7,11 +9,11 @@
     </message>
     <message>
         <source>Fold</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>More</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -33,11 +35,11 @@
     </message>
     <message>
         <source>Fold</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>More</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -56,10 +58,10 @@
     </message>
 </context>
 <context>
-    <name>OverlapNotify</name>
+    <name>NotifyViewDelegate</name>
     <message>
         <source>Clean All</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_ko.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_ko.ts
@@ -58,7 +58,7 @@
     </message>
 </context>
 <context>
-    <name>OverlapNotify</name>
+    <name>NotifyViewDelegate</name>
     <message>
         <source>Clean All</source>
         <translation type="unfinished"></translation>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_lo.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_lo.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="lo">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="lo">
 <context>
     <name>GroupNotify</name>
     <message>
@@ -7,11 +9,11 @@
     </message>
     <message>
         <source>Fold</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>More</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -33,11 +35,11 @@
     </message>
     <message>
         <source>Fold</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>More</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -56,10 +58,10 @@
     </message>
 </context>
 <context>
-    <name>OverlapNotify</name>
+    <name>NotifyViewDelegate</name>
     <message>
         <source>Clean All</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_nb_NO.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_nb_NO.ts
@@ -58,7 +58,7 @@
     </message>
 </context>
 <context>
-    <name>OverlapNotify</name>
+    <name>NotifyViewDelegate</name>
     <message>
         <source>Clean All</source>
         <translation type="unfinished"></translation>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_pl.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_pl.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pl">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pl">
 <context>
     <name>GroupNotify</name>
     <message>
@@ -56,10 +58,10 @@
     </message>
 </context>
 <context>
-    <name>OverlapNotify</name>
+    <name>NotifyViewDelegate</name>
     <message>
         <source>Clean All</source>
-        <translation>Wyczyść wszystkie</translation>
+        <translation type="unfinished">Wyczyść wszystkie</translation>
     </message>
 </context>
 <context>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_pt_BR.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_pt_BR.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pt_BR">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pt_BR">
 <context>
     <name>GroupNotify</name>
     <message>
@@ -7,11 +9,11 @@
     </message>
     <message>
         <source>Fold</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>More</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -33,11 +35,11 @@
     </message>
     <message>
         <source>Fold</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>More</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -56,10 +58,10 @@
     </message>
 </context>
 <context>
-    <name>OverlapNotify</name>
+    <name>NotifyViewDelegate</name>
     <message>
         <source>Clean All</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_ru.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_ru.ts
@@ -58,7 +58,7 @@
     </message>
 </context>
 <context>
-    <name>OverlapNotify</name>
+    <name>NotifyViewDelegate</name>
     <message>
         <source>Clean All</source>
         <translation type="unfinished"></translation>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_sq.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_sq.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="sq">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sq">
 <context>
     <name>GroupNotify</name>
     <message>
@@ -7,18 +9,18 @@
     </message>
     <message>
         <source>Fold</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>More</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>NotifyCenter</name>
     <message>
         <source>No recent notifications</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -33,11 +35,11 @@
     </message>
     <message>
         <source>Fold</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>More</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -56,10 +58,10 @@
     </message>
 </context>
 <context>
-    <name>OverlapNotify</name>
+    <name>NotifyViewDelegate</name>
     <message>
         <source>Clean All</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_uk.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_uk.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="uk">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="uk">
 <context>
     <name>GroupNotify</name>
     <message>
@@ -56,10 +58,10 @@
     </message>
 </context>
 <context>
-    <name>OverlapNotify</name>
+    <name>NotifyViewDelegate</name>
     <message>
         <source>Clean All</source>
-        <translation>Вилучити все</translation>
+        <translation type="unfinished">Вилучити все</translation>
     </message>
 </context>
 <context>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_zh_CN.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_zh_CN.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_CN">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_CN">
 <context>
     <name>GroupNotify</name>
     <message>
@@ -56,10 +58,10 @@
     </message>
 </context>
 <context>
-    <name>OverlapNotify</name>
+    <name>NotifyViewDelegate</name>
     <message>
         <source>Clean All</source>
-        <translation>清除全部</translation>
+        <translation type="unfinished">清除全部</translation>
     </message>
 </context>
 <context>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_zh_HK.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_zh_HK.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_HK">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_HK">
 <context>
     <name>GroupNotify</name>
     <message>
@@ -56,10 +58,10 @@
     </message>
 </context>
 <context>
-    <name>OverlapNotify</name>
+    <name>NotifyViewDelegate</name>
     <message>
         <source>Clean All</source>
-        <translation>清除全部</translation>
+        <translation type="unfinished">清除全部</translation>
     </message>
 </context>
 <context>

--- a/panels/notification/center/translations/org.deepin.ds.notificationcenter_zh_TW.ts
+++ b/panels/notification/center/translations/org.deepin.ds.notificationcenter_zh_TW.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_TW">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_TW">
 <context>
     <name>GroupNotify</name>
     <message>
@@ -56,10 +58,10 @@
     </message>
 </context>
 <context>
-    <name>OverlapNotify</name>
+    <name>NotifyViewDelegate</name>
     <message>
         <source>Clean All</source>
-        <translation>清除全部</translation>
+        <translation type="unfinished">清除全部</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
1. Added "Clean All" button to NotifyViewDelegate component for clearing
all notifications
2. Restructured OverlapNotify component to use onRemove signal instead
of inline clearButton
3. Added notifyContent property alias to OverlapNotify for external
access
4. Updated translation context from "OverlapNotify" to
"NotifyViewDelegate" across all language files
5. Standardized XML formatting in translation files with proper encoding
and line breaks

Log: Added "Clean All" button to notification center for batch
notification removal

Influence:
1. Test the "Clean All" button functionality in notification center
2. Verify that clicking the button removes all notifications properly
3. Check translation display for "Clean All" text in different languages
4. Test notification removal animation and behavior
5. Verify that individual notification dismissal still works correctly
6. Test with multiple notification scenarios (single, grouped,
overlapping)

feat: 在通知中心添加清除全部按钮

1. 在 NotifyViewDelegate 组件中添加"清除全部"按钮用于清理所有通知
2. 重构 OverlapNotify 组件，使用 onRemove 信号替代内联 clearButton
3. 添加 notifyContent 属性别名以便外部访问
4. 在所有语言文件中将翻译上下文从"OverlapNotify"更新
为"NotifyViewDelegate"
5. 统一翻译文件的 XML 格式，包含正确的编码和换行符

Log: 新增通知中心"清除全部"按钮，支持批量删除通知

Influence:
1. 测试通知中心"清除全部"按钮功能
2. 验证点击按钮后所有通知是否正确移除
3. 检查不同语言环境下"清除全部"文本的翻译显示
4. 测试通知移除动画和行为
5. 验证单个通知的关闭功能是否仍然正常工作
6. 测试多种通知场景（单个、分组、重叠）

PMS: BUG-336149
