### PR TITLE
fix(tray): pre-create stashed popup to eliminate first-open lag

### DIFF
--- a/panels/dock/tray/package/tray.qml
+++ b/panels/dock/tray/package/tray.qml
@@ -43,6 +43,9 @@ AppletItem {
 
         property alias dropHover: stashContainer.dropHover
         property alias stashItemDragging: stashContainer.stashItemDragging
+        property bool preCreating: false
+
+        opacity: preCreating ? 0 : 1
 
         popupX: DockPanelPositioner.x
         popupY: DockPanelPositioner.y
@@ -79,8 +82,25 @@ AppletItem {
             DockPanelPositioner.bounding = Qt.binding(function () {
                 return Qt.rect(collapsedBtnCenterPoint.x, collapsedBtnCenterPoint.y, stashedPopup.width, stashedPopup.height)
             })
+            // Pre-create popup to avoid first-open lag
+            Qt.callLater(function() {
+                stashedPopup.preCreating = true
+                stashedPopup.open()
+                preCreateCloseTimer.start()
+            })
         }
     }
+
+    Timer {
+        id: preCreateCloseTimer
+        interval: 200
+        repeat: false
+        onTriggered: {
+            stashedPopup.close()
+            stashedPopup.preCreating = false
+        }
+    }
+
     Connections {
         target: DDT.TraySortOrderModel
         function onActionsAlwaysVisibleChanged(val) {


### PR DESCRIPTION
Pre-create the stashed tray popup during initialization to avoid lag when first opening it, especially noticeable at high DPI scales (225%). The popup is opened with zero opacity during startup and closed after 200ms, ensuring all components are fully initialized. This eliminates the frame drops and stuttering that occurred when hovering over or clicking the application tray button for the first time.

修复系统托盘折叠弹窗首次打开时的卡顿问题。在初始化时预创建弹窗，
通过设置透明度为0在后台完成组件初始化和渲染，避免首次打开时的
帧率下降和卡顿，特别是在高DPI缩放（225%）下的表现。

PMS: BUG-344705

## Summary by Sourcery

Eliminate the initial lag when opening the stashed tray popup by pre-creating and briefly showing it invisibly during initialization.

Bug Fixes:
- Fix stuttering and frame drops when the tray’s stashed popup is opened for the first time, particularly on high-DPI displays.

Enhancements:
- Initialize the stashed tray popup in the background with zero opacity and automatically close it shortly after startup to ensure it is ready for subsequent use.