### PR TITLE
fix: improve dock center space calculation and taskmanager layout

### DIFF
--- a/panels/dock/package/main.qml
+++ b/panels/dock/package/main.qml
@@ -19,20 +19,29 @@ Window {
     id: dock
     property int positionForAnimation: Panel.position
     property bool useColumnLayout: positionForAnimation % 2
-    // TODO: 临时溢出逻辑，待后面修改
-    property int dockLeftSpaceForCenter: useColumnLayout ?
-        (Screen.height - dockLeftPart.implicitHeight - dockRightPart.implicitHeight) :
-        (Screen.width - dockLeftPart.implicitWidth - dockRightPart.implicitWidth)
-    property int dockRemainingSpaceForCenter: useColumnLayout ?
-        (Screen.height / 1.8 - dockRightPart.implicitHeight)  :
-        (Screen.width / 1.8 - dockRightPart.implicitWidth) 
+    property int dockCenterPartCount: dockCenterPartModel.count
+
+    property int dockRemainingSpaceForCenter: {
+        const otherCount = dockCenterPartCount - 1; // not include taskmanager
+        const spacing = useColumnLayout ? gridLayout.rowSpacing : gridLayout.columnSpacing;
+            
+        let otherOccupied = 0;
+        if (otherCount > 0) {
+            otherOccupied = otherCount * dockItemMaxSize + otherCount * spacing;
+        }
+
+        if (useColumnLayout) {
+            return Screen.height - dockLeftPart.implicitHeight - dockRightPart.implicitHeight - otherOccupied;
+        } else {
+            return Screen.width - dockLeftPart.implicitWidth - dockRightPart.implicitWidth - otherOccupied;
+        }
+    }
+
     property int dockPartSpacing: gridLayout.columnSpacing
     // TODO
     signal dockCenterPartPosChanged()
     signal pressedAndDragging(bool isDragging)
     signal viewDeactivated()
-
-    property int dockCenterPartCount: dockCenterPartModel.count
 
     property int dockSize: Applet.dockSize
     property int dockItemMaxSize: dockSize
@@ -527,18 +536,8 @@ Window {
 
             Item {  
                 id: dockCenterPart
-                property var taskmanagerRootObject: {
-                    let applet = DS.applet("org.deepin.ds.dock.taskmanager")
-                    return applet ? applet.rootObject : null
-                }
-                
-                readonly property real taskmanagerImplicitWidth: taskmanagerRootObject ? taskmanagerRootObject.implicitWidth : 0
-                readonly property real taskmanagerImplicitHeight: taskmanagerRootObject ? taskmanagerRootObject.implicitHeight : 0
-                readonly property real taskmanagerAppContainerWidth: taskmanagerRootObject ? taskmanagerRootObject.appContainerWidth : 0
-                readonly property real taskmanagerAppContainerHeight: taskmanagerRootObject ? taskmanagerRootObject.appContainerHeight : 0
-                
-                implicitWidth: centerLoader.implicitWidth - taskmanagerImplicitWidth + taskmanagerAppContainerWidth
-                implicitHeight: centerLoader.implicitHeight - taskmanagerImplicitHeight + taskmanagerAppContainerHeight
+                implicitWidth: centerLoader.implicitWidth
+                implicitHeight: centerLoader.implicitHeight
                 onXChanged: dockCenterPartPosChanged()
                 onYChanged: dockCenterPartPosChanged()
                 Layout.leftMargin: !useColumnLayout && Panel.itemAlignment === Dock.CenterAlignment ?

--- a/panels/dock/taskmanager/package/TaskManager.qml
+++ b/panels/dock/taskmanager/package/TaskManager.qml
@@ -14,18 +14,17 @@ ContainmentItem {
     id: taskmanager
     property bool useColumnLayout: Panel.rootObject.useColumnLayout
     property int dockOrder: 16
-    property real remainingSpacesForTaskManager: Panel.itemAlignment === Dock.LeftAlignment ? Panel.rootObject.dockLeftSpaceForCenter : Panel.rootObject.dockRemainingSpaceForCenter
-
+    property real remainingSpacesForTaskManager: Panel.rootObject.dockRemainingSpaceForCenter 
     readonly property int appTitleSpacing: Math.max(10, Math.round(Panel.rootObject.dockItemMaxSize * 9 / 14) / 3)
-    property real remainingSpacesForSplitWindow: Panel.rootObject.dockLeftSpaceForCenter - (
-        (Panel.rootObject.dockCenterPartCount - 1) * (visualModel.cellWidth + appTitleSpacing) + (Panel.rootObject.dockCenterPartCount) * Panel.rootObject.dockPartSpacing)
-    // 用于居中计算的实际应用区域尺寸
-    property int appContainerWidth: useColumnLayout ? Panel.rootObject.dockSize : appContainer.implicitWidth
-    property int appContainerHeight: useColumnLayout ? appContainer.implicitHeight : Panel.rootObject.dockSize
-    
-    implicitWidth: useColumnLayout ? Panel.rootObject.dockSize : Math.max(remainingSpacesForTaskManager, appContainer.implicitWidth)
-    implicitHeight: useColumnLayout ? Math.max(remainingSpacesForTaskManager, appContainer.implicitHeight) : Panel.rootObject.dockSize
 
+    implicitWidth: {
+        let maxW = Panel.itemAlignment === Dock.LeftAlignment ? Math.max(remainingSpacesForTaskManager, appContainer.implicitWidth) : Math.min(remainingSpacesForTaskManager, appContainer.implicitWidth)
+        return useColumnLayout ? Panel.rootObject.dockSize : maxW
+    }
+    implicitHeight: {
+        let maxH = Panel.itemAlignment === Dock.LeftAlignment ? Math.max(remainingSpacesForTaskManager, appContainer.implicitHeight) : Math.min(remainingSpacesForTaskManager, appContainer.implicitHeight)
+        return useColumnLayout ? maxH : Panel.rootObject.dockSize
+    }
     // Helper function to find the current index of an app by its appId in the visualModel
     function findAppIndex(appId) {
         for (let i = 0; i < visualModel.items.count; i++) {
@@ -65,7 +64,7 @@ ContainmentItem {
         spacing: appContainer.spacing
         cellSize: visualModel.cellWidth
         itemPadding: taskmanager.appTitleSpacing
-        remainingSpace: taskmanager.remainingSpacesForSplitWindow
+        remainingSpace: taskmanager.remainingSpacesForTaskManager
         font.family: D.DTK.fontManager.t6.family
         font.pixelSize: Math.max(10, Math.min(20, Math.round(textCalculator.iconSize * 0.35)))
     }
@@ -133,8 +132,24 @@ ContainmentItem {
                 Behavior on opacity { NumberAnimation { duration: 200 } }
                 Behavior on scale { NumberAnimation { duration: 200 } }
 
-                implicitWidth: useColumnLayout ? taskmanager.implicitWidth : appItem.implicitWidth
-                implicitHeight: useColumnLayout ? visualModel.cellWidth : taskmanager.implicitHeight
+                implicitWidth: {
+                    let targetW = useColumnLayout ? taskmanager.implicitWidth : appItem.implicitWidth;
+                    if (useColumnLayout || visualModel.count <= 0) return targetW;
+                    
+                    let totalSpacing = Math.max(0, visualModel.count - 1) * taskmanager.appTitleSpacing;
+                    let availableW = taskmanager.remainingSpacesForTaskManager - totalSpacing;
+                    let maxW = availableW / visualModel.count;
+                    return Math.min(targetW, Math.max(1, maxW));
+                }
+                implicitHeight: {
+                    let targetH = useColumnLayout ? visualModel.cellWidth : taskmanager.implicitHeight;
+                    if (!useColumnLayout || visualModel.count <= 0) return targetH;
+                    
+                    let totalSpacing = Math.max(0, visualModel.count - 1) * taskmanager.appTitleSpacing;
+                    let availableH = taskmanager.remainingSpacesForTaskManager - totalSpacing;
+                    let maxH = availableH / visualModel.count;
+                    return Math.min(targetH, Math.max(1, maxH));
+                }
 
                 property int visualIndex: DelegateModel.itemsIndex
                 property var modelIndex: visualModel.modelIndex(index)
@@ -274,7 +289,7 @@ ContainmentItem {
 
     Component.onCompleted: {
         Panel.rootObject.dockItemMaxSize = Qt.binding(function(){
-            return Math.min(Panel.rootObject.dockSize, Panel.rootObject.dockLeftSpaceForCenter * 1.2 / (Panel.rootObject.dockCenterPartCount - 1 + visualModel.count) - 2)
+            return Math.min(Panel.rootObject.dockSize, Panel.rootObject.dockRemainingSpaceForCenter * 1.2 / (Panel.rootObject.dockCenterPartCount - 1 + visualModel.count) - 2)
         })
     }
 }


### PR DESCRIPTION
1. Replaced temporary overflow logic with dynamic calculation of remaining space for center dock area
2. Added function to count center applets excluding TaskManager for accurate space allocation
3. Simplified dockCenterPart implicit dimensions by removing TaskManager-specific adjustments
4. Updated TaskManager to use consistent remaining space calculation and improved implicit dimension logic
5. Enhanced app container sizing to properly distribute available space among app items
6. Fixed dockItemMaxSize calculation to use correct remaining space reference

Log: Improved dock layout calculation for better space distribution and task manager display

Influence:
1. Test dock layout in different positions (left, right, top, bottom)
2. Verify center area plugins display correctly with varying numbers
3. Check TaskManager app item sizing and spacing in different configurations
4. Test with multiple center area plugins alongside TaskManager
5. Verify layout stability when adding/removing center plugins
6. Test edge cases with minimal/maximal numbers of app items

fix: 改进任务栏中心区域空间计算和任务管理器布局

1. 用动态计算替换临时的溢出逻辑，准确计算中心区域剩余空间
2. 新增函数统计除任务管理器外的中心区域插件数量，实现精确空间分配
3. 简化dockCenterPart的隐式尺寸计算，移除任务管理器特定调整
4. 更新任务管理器使用一致的剩余空间计算和改进的隐式尺寸逻辑
5. 增强应用容器尺寸计算，在应用项之间合理分配可用空间
6. 修复dockItemMaxSize计算，使用正确的剩余空间引用

Log: 改进任务栏布局计算，优化空间分配和任务管理器显示

Influence:
1. 测试任务栏在不同位置（左、右、上、下）的布局
2. 验证中心区域插件在不同数量下的正确显示
3. 检查任务管理器应用项在不同配置下的尺寸和间距
4. 测试多个中心区域插件与任务管理器共存的情况
5. 验证添加/移除中心插件时的布局稳定性
6. 测试最小/最大应用项数量的边界情况

PMS: BUG-355833

## Summary by Sourcery

Improve dock center area space calculation and TaskManager layout for more accurate and consistent space distribution.

Enhancements:
- Compute remaining dock center space dynamically, excluding the TaskManager and other center applets’ footprints for more accurate layout.
- Simplify dock center container sizing by relying directly on the center loader’s implicit dimensions.
- Align TaskManager sizing with the shared remaining-space calculation and adjust its implicit width/height based on alignment and orientation.
- Constrain TaskManager app item sizes using remaining space and item count to distribute available space evenly.
- Base dockItemMaxSize on the unified remaining-center-space property for consistent item sizing.