### PR TITLE
fix: update tooltip window property bindings and hover behavior

### DIFF
--- a/frame/qml/PanelMenu.qml
+++ b/frame/qml/PanelMenu.qml
@@ -22,12 +22,12 @@ Item {
 
     Binding {
         when: readyBinding
-        target: menuWindow; property: "width"
+        target: menuWindow; property: "requestedWidth"
         value: menu.width
     }
     Binding {
         when: readyBinding
-        target: menuWindow; property: "height"
+        target: menuWindow; property: "requestedHeight"
         value: menu.height
     }
     Binding {

--- a/frame/qml/PanelToolTip.qml
+++ b/frame/qml/PanelToolTip.qml
@@ -25,12 +25,12 @@ Item {
 
     Binding {
         when: readyBinding
-        target: toolTipWindow; property: "width"
+        target: toolTipWindow; property: "requestedWidth"
         value: toolTip.width + toolTip.leftPadding + toolTip.rightPadding
     }
     Binding {
         when: readyBinding
-        target: toolTipWindow; property: "height"
+        target: toolTipWindow; property: "requestedHeight"
         value: toolTip.height
     }
     Binding {

--- a/panels/dock/tray/quickpanel/PanelTrayItem.qml
+++ b/panels/dock/tray/quickpanel/PanelTrayItem.qml
@@ -25,6 +25,12 @@ Control {
     property Palette textColor: DockPalette.iconTextPalette
     palette.windowText: ColorSelector.textColor
 
+    onIsOpenedChanged: {
+        if (root.isOpened) {
+            toolTip.close()
+        }
+    }
+
     PanelToolTip {
         id: toolTip
         text: qsTr("Quick actions")
@@ -60,7 +66,6 @@ Control {
                 smooth: false
             }
             HoverHandler {
-                enabled: !root.isOpened
                 onHoveredChanged: function () {
                     root.contentHovered = hovered
                     if (hovered && !root.isOpened) {


### PR DESCRIPTION
1. Changed tooltip window property bindings from "width"/"height" to "requestedWidth"/"requestedHeight" in PanelToolTip.qml
2. Added tooltip close functionality when quick panel is opened in PanelTrayItem.qml
3. Removed hover handler enabled condition to ensure consistent hover behavior

The changes update tooltip property bindings to use more appropriate property names ("requestedWidth"/"requestedHeight") which better reflect their purpose. Also fixes tooltip behavior by closing it when the quick panel opens, preventing tooltips from remaining visible when they shouldn't be. The hover handler condition removal ensures hover detection works consistently regardless of panel state.

Log: Fixed tooltip behavior in quick panel - tooltips now properly close when panel opens

Influence:
1. Test tooltip display when hovering over quick panel icon
2. Verify tooltip disappears when quick panel is opened
3. Check tooltip positioning and sizing with different content
4. Test hover behavior consistency when panel is open/closed
5. Verify no visual artifacts or overlapping elements

fix: 更新工具提示窗口属性绑定和悬停行为

1. 在 PanelToolTip.qml 中将工具提示窗口属性绑定从 "width"/"height" 改为 "requestedWidth"/"requestedHeight"
2. 在 PanelTrayItem.qml 中添加快速面板打开时关闭工具提示的功能
3. 移除悬停处理器的启用条件以确保一致的悬停行为

这些更改将工具提示属性绑定更新为使用更合适的属性名称
（"requestedWidth"/"requestedHeight"），更好地反映其用途。同时修复了工具 提示行为，在快速面板打开时关闭工具提示，防止工具提示在不应该显示时仍然可
见。移除悬停处理器条件可确保悬停检测无论面板状态如何都能一致工作。

Log: 修复快速面板中的工具提示行为 - 面板打开时工具提示现在能正确关闭

Influence:
1. 测试悬停在快速面板图标上时工具提示的显示
2. 验证打开快速面板时工具提示是否消失
3. 检查不同内容下工具提示的定位和大小调整
4. 测试面板打开/关闭时的悬停行为一致性
5. 验证没有视觉伪影或元素重叠

PMS: BUG-296251

## Summary by Sourcery

Align tooltip sizing and visibility behavior for quick panel items to ensure consistent hover interaction and correct closing when the panel opens.

Bug Fixes:
- Close quick panel tooltips automatically when the panel is opened to avoid lingering tooltips.
- Ensure hover detection and tooltip activation remain consistent regardless of the panel open state.
- Use the tooltip window's requested size properties to better match tooltip content and padding, preventing sizing issues.

Enhancements:
- Update tooltip window bindings to use requested size properties that better represent intended layout behavior.