### PR TITLE
chore: update changelog to 2.0.37

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,16 @@
+dde-shell (2.0.37) unstable; urgency=medium
+
+  * fix: update tooltip window property bindings and hover behavior
+  * fix: resolve abnormal compositor window size due to popup panel
+    height change
+  * feat: add split window background support for dock app items
+  * feat: fix notification center height calculation for bottom dock
+  * fix: guard PanelPopup close behavior against transient X11 grab
+    focus changes
+  * fix: fix notification bubble animation glitch
+
+ -- zhangkun <zhangkun2@uniontech.com>  Thu, 09 Apr 2026 20:27:14 +0800
+
 dde-shell (2.0.36) unstable; urgency=medium
 
   * fix: prevent position fix during drag or animation


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 2.0.37

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 2.0.37
- 目标分支: master

## Summary by Sourcery

Documentation:
- Document the 2.0.37 release in debian/changelog.