### PR TITLE
refactor: move dockiteminfo to shared frame library

### DIFF
--- a/frame/CMakeLists.txt
+++ b/frame/CMakeLists.txt
@@ -17,6 +17,7 @@ set(PUBLIC_HEADERS
     layershell/dlayershellwindow.h
     models/listtotableproxymodel.h
     dsutility.h
+    dockiteminfo.h
 )
 
 set(PRIVATE_HEADERS
@@ -63,6 +64,7 @@ add_library(dde-shell-frame SHARED
     qmlengine.cpp
     appletitemmodel.h
     appletitemmodel.cpp
+    dockiteminfo.cpp
     dsqmlglobal.cpp
     layershell/dlayershellwindow.cpp
     layershell/qwaylandlayershellsurface.cpp

--- a/frame/dockiteminfo.cpp
+++ b/frame/dockiteminfo.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/frame/dockiteminfo.h
+++ b/frame/dockiteminfo.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 #pragma once

--- a/panels/dock/CMakeLists.txt
+++ b/panels/dock/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+# SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -18,8 +18,6 @@ file(
     dockabstractsettingsconfig.h
     dockdbusproxy.cpp
     dockdbusproxy.h
-    dockiteminfo.cpp
-    dockiteminfo.h
     dockpanel.cpp
     dockpanel.h
     docksettings.cpp

--- a/panels/dock/appruntimeitem/CMakeLists.txt
+++ b/panels/dock/appruntimeitem/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+# SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -13,8 +13,6 @@ add_library(dock-appruntimeitem SHARED
     xcbgetinfo.h
     xcbgetinfo.cpp
     qmlappruntime.qrc
-    ${CMAKE_SOURCE_DIR}/panels/dock/dockiteminfo.cpp
-    ${CMAKE_SOURCE_DIR}/panels/dock/dockiteminfo.h
     ${CMAKE_SOURCE_DIR}/panels/dock/constants.h
     ${CMAKE_SOURCE_DIR}/panels/dock/taskmanager/x11utils.h
     ${CMAKE_SOURCE_DIR}/panels/dock/taskmanager/x11utils.cpp

--- a/panels/dock/multitaskview/CMakeLists.txt
+++ b/panels/dock/multitaskview/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+# SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -12,8 +12,6 @@ add_library(dock-multitaskview SHARED
     multitaskview.h
     treelandmultitaskview.cpp
     treelandmultitaskview.h
-    ../dockiteminfo.cpp
-    ../dockiteminfo.h
 )
 
 target_include_directories(dock-multitaskview PRIVATE

--- a/panels/dock/multitaskview/multitaskview.h
+++ b/panels/dock/multitaskview/multitaskview.h
@@ -1,10 +1,10 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #pragma once
 
-#include "../dockiteminfo.h"
+#include "dockiteminfo.h"
 #include "applet.h"
 #include "dsglobal.h"
 #include "treelandmultitaskview.h"

--- a/panels/dock/tray/CMakeLists.txt
+++ b/panels/dock/tray/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+# SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 #
 # SPDX-License-Identifier: CC0-1.0
 
@@ -42,8 +42,6 @@ add_library(trayitem SHARED
     trayitem.h
     traysettings.cpp
     traysettings.h
-    ../dockiteminfo.cpp
-    ../dockiteminfo.h
     ../constants.h
 )
 

--- a/panels/dock/tray/trayitem.h
+++ b/panels/dock/tray/trayitem.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 


### PR DESCRIPTION
1. Moved dockiteminfo.h and dockiteminfo.cpp from panels/dock to frame directory
2. Updated CMakeLists.txt in frame to include dockiteminfo as a public header and source file
3. Removed dockiteminfo files from panels/dock CMakeLists.txt and its subdirectories (appruntimeitem, multitaskview, tray)
4. Updated include statements in multiple dock components to use <dockiteminfo.h> instead of "dockiteminfo.h"
5. This refactoring centralizes dockiteminfo as a shared component accessible across different modules

Log: Refactored dockiteminfo to be part of shared frame library

Influence:
1. Verify dock functionality still works correctly after the move
2. Test application runtime items display properly in dock
3. Check multitask view functionality
4. Verify system tray items work as expected
5. Ensure all dock components can access dockiteminfo without compilation errors
6. Test build process to confirm no missing dependencies

refactor: 将 dockiteminfo 移动到共享框架库

1. 将 dockiteminfo.h 和 dockiteminfo.cpp 从 panels/dock 移动到 frame 目录
2. 更新 frame 中的 CMakeLists.txt，将 dockiteminfo 添加为公共头文件和源 文件
3. 从 panels/dock 及其子目录（appruntimeitem、multitaskview、tray）的 CMakeLists.txt 中移除 dockiteminfo 文件
4. 更新多个 dock 组件中的包含语句，使用 <dockiteminfo.h> 替代 "dockiteminfo.h"
5. 此次重构将 dockiteminfo 集中为可在不同模块间访问的共享组件

Log: 重构 dockiteminfo 使其成为共享框架库的一部分

Influence:
1. 验证移动后 dock 功能是否正常工作
2. 测试应用程序运行时项目在 dock 中正确显示
3. 检查多任务视图功能
4. 验证系统托盘项目按预期工作
5. 确保所有 dock 组件都能访问 dockiteminfo 而无编译错误
6. 测试构建过程以确认没有缺失的依赖项