### PR TITLE
fix: reset icon scale when attention animation ends

### DIFF
--- a/panels/dock/taskmanager/package/AppItem.qml
+++ b/panels/dock/taskmanager/package/AppItem.qml
@@ -303,6 +303,11 @@ Item {
             anchors.fill: parent
             z: -1
             active: root.attention && !Panel.rootObject.isDragging
+            onActiveChanged: {
+                if (!active) {
+                    icon.scale = 1.0
+                }
+            }
             sourceComponent: Repeater {
                 model: 5
                 Rectangle {


### PR DESCRIPTION
1. Added onActiveChanged handler to reset icon.scale to 1.0 when attention animation becomes inactive
2. This prevents the icon from remaining scaled after attention animation completes
3. Fixes visual issue where icons could appear incorrectly scaled after attention animation

Log: Fixed taskbar icon scaling issue after attention animation

Influence:
1. Test applications that trigger attention requests (like incoming messages)
2. Verify that icons return to normal size after attention animation completes
3. Check that icon scaling works correctly during animation
4. Test with multiple attention animations in sequence
5. Verify no visual artifacts remain after animation

fix: 修复注意力动画结束后图标缩放未重置的问题

1. 添加 onActiveChanged 处理器，在注意力动画变为非活动状态时将 icon.scale 重置为 1.0
2. 防止图标在注意力动画完成后保持缩放状态
3. 修复注意力动画后图标可能显示不正确缩放的问题

Log: 修复任务栏图标在注意力动画后的缩放问题

Influence:
1. 测试触发注意力请求的应用程序（如新消息通知）
2. 验证图标在注意力动画完成后是否恢复正常大小
3. 检查图标在动画期间的缩放是否正确
4. 测试连续多个注意力动画的情况
5. 验证动画后没有视觉残留问题

## Summary by Sourcery

Bug Fixes:
- Ensure the attention animation deactivation resets the app icon scale back to its normal size to prevent lingering visual scaling artifacts on the taskbar.