### PR TITLE
fix: separate touchscreen and mouse context menu triggers in notifica…

### DIFF
--- a/panels/notification/center/NotifyViewDelegate.qml
+++ b/panels/notification/center/NotifyViewDelegate.qml
@@ -112,13 +112,25 @@ DelegateChooser {
             defaultAction: model.defaultAction
             indexInGroup: model.indexInGroup
 
+            // Mouse/other devices right-click for context menu
+            // Note: TouchScreen is excluded because its events bypass acceptedButtons check in Qt
             TapHandler {
                 acceptedButtons: Qt.RightButton
+                acceptedDevices: PointerDevice.AllDevices & ~PointerDevice.TouchScreen
                 onPressedChanged: function () {
                     if (pressed) {
                         let pos = point.position
                         setting(pos)
                     }
+                }
+            }
+
+            // Touchscreen long-press for context menu
+            TapHandler {
+                acceptedDevices: PointerDevice.TouchScreen
+                onLongPressed: {
+                    let pos = point.position
+                    setting(pos)
                 }
             }
 
@@ -197,13 +209,25 @@ DelegateChooser {
                 }
             }
 
+            // Mouse/other devices right-click for context menu
+            // Note: TouchScreen is excluded because its events bypass acceptedButtons check in Qt
             TapHandler {
                 acceptedButtons: Qt.RightButton
+                acceptedDevices: PointerDevice.AllDevices & ~PointerDevice.TouchScreen
                 onPressedChanged: function () {
                     if (pressed) {
                         let pos = point.position
                         setting(pos)
                     }
+                }
+            }
+
+            // Touchscreen long-press for context menu
+            TapHandler {
+                acceptedDevices: PointerDevice.TouchScreen
+                onLongPressed: {
+                    let pos = point.position
+                    setting(pos)
                 }
             }
 


### PR DESCRIPTION
…tion center

Split the context menu TapHandler into two separate handlers with device filtering to prevent touchscreen tap from incorrectly triggering the context menu when expanding collapsed notifications:

1. Mouse/Touchpad handler: accepts right-button click from Keyboard, Mouse, and TouchPad devices
2. Touchscreen handler: only accepts long-press gesture from TouchScreen device

This ensures that a single-finger tap on a collapsed notification only expands it without showing the context menu, while long-press still triggers the menu as expected.

Log: fix touchscreen tap incorrectly triggering context menu when expanding collapsed notifications

fix: 通知中心分离触摸屏和鼠标右键菜单触发方式

将右键菜单的 TapHandler 拆分为两个独立的处理器，并添加设备过滤，
防止触摸屏点击展开折叠通知时错误地触发右键菜单：

1. 鼠标/触控板处理器：接受来自键盘、鼠标和触控板设备的右键点击
2. 触摸屏处理器：仅接受来自触摸屏设备的长按手势

这确保了在折叠通知上单指点击只会展开通知而不会显示右键菜单，
同时长按仍然可以按预期触发菜单。

Log: 修复触摸屏点击展开折叠通知时错误触发右键菜单的问题

PMS: BUG-355017

## Summary by Sourcery

Separate mouse and touchscreen context menu triggers in the notification center to avoid accidental context menu activation when expanding notifications.

Bug Fixes:
- Prevent single-finger taps on collapsed notifications from triggering the context menu on touchscreens.

Enhancements:
- Introduce distinct TapHandlers for mouse/touchpad right-clicks and touchscreen long-press gestures with appropriate device filtering.