### PR TITLE
Revert "refactor: move dockiteminfo to shared frame library"

### DIFF
--- a/frame/CMakeLists.txt
+++ b/frame/CMakeLists.txt
@@ -17,7 +17,6 @@ set(PUBLIC_HEADERS
     layershell/dlayershellwindow.h
     models/listtotableproxymodel.h
     dsutility.h
-    dockiteminfo.h
 )
 
 set(PRIVATE_HEADERS
@@ -64,7 +63,6 @@ add_library(dde-shell-frame SHARED
     qmlengine.cpp
     appletitemmodel.h
     appletitemmodel.cpp
-    dockiteminfo.cpp
     dsqmlglobal.cpp
     layershell/dlayershellwindow.cpp
     layershell/qwaylandlayershellsurface.cpp

--- a/panels/dock/CMakeLists.txt
+++ b/panels/dock/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
+# SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -18,6 +18,8 @@ file(
     dockabstractsettingsconfig.h
     dockdbusproxy.cpp
     dockdbusproxy.h
+    dockiteminfo.cpp
+    dockiteminfo.h
     dockpanel.cpp
     dockpanel.h
     docksettings.cpp

--- a/panels/dock/appruntimeitem/CMakeLists.txt
+++ b/panels/dock/appruntimeitem/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
+# SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -13,6 +13,8 @@ add_library(dock-appruntimeitem SHARED
     xcbgetinfo.h
     xcbgetinfo.cpp
     qmlappruntime.qrc
+    ${CMAKE_SOURCE_DIR}/panels/dock/dockiteminfo.cpp
+    ${CMAKE_SOURCE_DIR}/panels/dock/dockiteminfo.h
     ${CMAKE_SOURCE_DIR}/panels/dock/constants.h
     ${CMAKE_SOURCE_DIR}/panels/dock/taskmanager/x11utils.h
     ${CMAKE_SOURCE_DIR}/panels/dock/taskmanager/x11utils.cpp

--- a/panels/dock/dockiteminfo.cpp
+++ b/panels/dock/dockiteminfo.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/panels/dock/dockiteminfo.h
+++ b/panels/dock/dockiteminfo.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 #pragma once

--- a/panels/dock/multitaskview/CMakeLists.txt
+++ b/panels/dock/multitaskview/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
+# SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -12,6 +12,8 @@ add_library(dock-multitaskview SHARED
     multitaskview.h
     treelandmultitaskview.cpp
     treelandmultitaskview.h
+    ../dockiteminfo.cpp
+    ../dockiteminfo.h
 )
 
 target_include_directories(dock-multitaskview PRIVATE

--- a/panels/dock/multitaskview/multitaskview.h
+++ b/panels/dock/multitaskview/multitaskview.h
@@ -1,10 +1,10 @@
-// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #pragma once
 
-#include "dockiteminfo.h"
+#include "../dockiteminfo.h"
 #include "applet.h"
 #include "dsglobal.h"
 #include "treelandmultitaskview.h"

--- a/panels/dock/tray/CMakeLists.txt
+++ b/panels/dock/tray/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
+# SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
 #
 # SPDX-License-Identifier: CC0-1.0
 
@@ -42,6 +42,8 @@ add_library(trayitem SHARED
     trayitem.h
     traysettings.cpp
     traysettings.h
+    ../dockiteminfo.cpp
+    ../dockiteminfo.h
     ../constants.h
 )
 

--- a/panels/dock/tray/trayitem.h
+++ b/panels/dock/tray/trayitem.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 


### PR DESCRIPTION
This reverts commit 154a3a291f590b07dcd8646bfb2e2b552a8ce8a5.

## Summary by Sourcery

Revert the migration of dockiteminfo into the shared frame library by relocating it back into the dock panel modules and updating build configuration and includes accordingly.

Enhancements:
- Restore dockiteminfo as a dock-specific component rather than a shared frame-level header/source.

Build:
- Update dock, appruntimeitem, multitaskview, and tray CMake targets to compile dockiteminfo from the panels/dock directory instead of the shared frame library.
- Remove dockiteminfo sources and headers from the dde-shell-frame build configuration.

Chores:
- Normalize SPDX copyright year ranges in affected dock and tray source and CMake files.