### PR TITLE
feat: add attention animation toggle for taskmanager

### DIFF
--- a/panels/dock/taskmanager/dconfig/org.deepin.ds.dock.taskmanager.json
+++ b/panels/dock/taskmanager/dconfig/org.deepin.ds.dock.taskmanager.json
@@ -22,6 +22,17 @@
 			"permissions": "readwrite",
 			"visibility": "private"
 		},
+		"showAttentionAnimation": {
+			"value": true,
+			"serial": 0,
+			"flags": [],
+			"name": "Show Attention Animation",
+			"name[zh_CN]": "显示消息通知动画",
+			"description": "Show attention animation for applications",
+			"description[zh_CN]": "显示应用有新消息时的水波纹动画",
+			"permissions": "readwrite",
+			"visibility": "private"
+		},
 		"noTaskGrouping": {
 			"value": false,
 			"serial": 0,

--- a/panels/dock/taskmanager/globals.h
+++ b/panels/dock/taskmanager/globals.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -20,6 +20,7 @@ static inline const QString DOCK_ACTION_DOCK = "dock-action-dock";
 // setting keys
 static inline const QString TASKMANAGER_ALLOWFOCEQUIT_KEY = "Allow_Force_Quit";
 static inline const QString TASKMANAGER_WINDOWSPLIT_KEY = "noTaskGrouping";
+static inline const QString TASKMANAGER_SHOW_ATTENTION_ANIMATION_KEY = "showAttentionAnimation";
 static inline const QString TASKMANAGER_CGROUPS_BASED_GROUPING_KEY = "cgroupsBasedGrouping";
 static inline const QString TASKMANAGER_CGROUPS_BASED_GROUPING_SKIP_APPIDS = "cgroupsBasedGroupingSkipAppIds";
 static inline const QString TASKMANAGER_CGROUPS_BASED_GROUPING_SKIP_CATEGORIES = "cgroupsBasedGroupingSkipCategories";

--- a/panels/dock/taskmanager/package/AppItem.qml
+++ b/panels/dock/taskmanager/package/AppItem.qml
@@ -302,7 +302,7 @@ Item {
             id: animationRoot
             anchors.fill: parent
             z: -1
-            active: root.attention && !Panel.rootObject.isDragging
+            active: root.attention && !Panel.rootObject.isDragging && TaskManager.showAttentionAnimation 
             onActiveChanged: {
                 if (!active) {
                     icon.scale = 1.0

--- a/panels/dock/taskmanager/taskmanager.cpp
+++ b/panels/dock/taskmanager/taskmanager.cpp
@@ -147,6 +147,7 @@ TaskManager::TaskManager(QObject *parent)
     qmlRegisterUncreatableType<TextCalculatorAttached>("org.deepin.ds.dock.taskmanager", 1, 0, "TextCalculatorAttached", "TextCalculator Attached");
 
     connect(Settings, &TaskManagerSettings::allowedForceQuitChanged, this, &TaskManager::allowedForceQuitChanged);
+    connect(Settings, &TaskManagerSettings::showAttentionAnimationChanged, this, &TaskManager::showAttentionAnimationChanged);
     connect(Settings, &TaskManagerSettings::windowSplitChanged, this, &TaskManager::windowSplitChanged);
 }
 
@@ -377,6 +378,11 @@ void TaskManager::hideItemPreview()
 bool TaskManager::allowForceQuit()
 {
     return Settings->isAllowedForceQuit();
+}
+
+bool TaskManager::showAttentionAnimation()
+{
+    return Settings->showAttentionAnimation();
 }
 
 QString TaskManager::desktopIdToAppId(const QString& desktopId)

--- a/panels/dock/taskmanager/taskmanager.h
+++ b/panels/dock/taskmanager/taskmanager.h
@@ -25,6 +25,7 @@ class TaskManager : public DS_NAMESPACE::DContainment, public AbstractTaskManage
     Q_PROPERTY(bool windowSplit READ windowSplit NOTIFY windowSplitChanged)
     Q_PROPERTY(bool windowFullscreen READ windowFullscreen NOTIFY windowFullscreenChanged)
     Q_PROPERTY(bool allowForceQuit READ allowForceQuit NOTIFY allowedForceQuitChanged)
+    Q_PROPERTY(bool showAttentionAnimation READ showAttentionAnimation NOTIFY showAttentionAnimationChanged)
 
 public:
     enum Roles {
@@ -78,6 +79,7 @@ public:
     bool windowSplit();
     bool windowFullscreen();
     bool allowForceQuit();
+    bool showAttentionAnimation();
 
     Q_INVOKABLE void requestActivate(const QModelIndex &index) const override;
     Q_INVOKABLE void requestNewInstance(const QModelIndex &index, const QString &action = QString()) const override;
@@ -110,6 +112,7 @@ Q_SIGNALS:
     void windowSplitChanged();
     void windowFullscreenChanged(bool);
     void allowedForceQuitChanged();
+    void showAttentionAnimationChanged();
 
 private Q_SLOTS:
     void handleWindowAdded(QPointer<AbstractWindow> window);

--- a/panels/dock/taskmanager/taskmanagersettings.cpp
+++ b/panels/dock/taskmanager/taskmanagersettings.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -40,6 +40,9 @@ TaskManagerSettings::TaskManagerSettings(QObject *parent)
         if (TASKMANAGER_ALLOWFOCEQUIT_KEY == key) {
             m_allowForceQuit = enableStr2Bool(m_taskManagerDconfig->value(TASKMANAGER_ALLOWFOCEQUIT_KEY).toString());
             Q_EMIT allowedForceQuitChanged();
+        } else if (TASKMANAGER_SHOW_ATTENTION_ANIMATION_KEY == key) {
+            m_showAttentionAnimation = m_taskManagerDconfig->value(TASKMANAGER_SHOW_ATTENTION_ANIMATION_KEY, true).toBool();
+            Q_EMIT showAttentionAnimationChanged();
         } else if (TASKMANAGER_WINDOWSPLIT_KEY == key) {
             m_windowSplit = m_taskManagerDconfig->value(TASKMANAGER_WINDOWSPLIT_KEY).toBool();
             Q_EMIT windowSplitChanged();
@@ -50,6 +53,7 @@ TaskManagerSettings::TaskManagerSettings(QObject *parent)
     });
 
     m_allowForceQuit = enableStr2Bool(m_taskManagerDconfig->value(TASKMANAGER_ALLOWFOCEQUIT_KEY).toString());
+    m_showAttentionAnimation = m_taskManagerDconfig->value(TASKMANAGER_SHOW_ATTENTION_ANIMATION_KEY, true).toBool();
     m_windowSplit = m_taskManagerDconfig->value(TASKMANAGER_WINDOWSPLIT_KEY).toBool();
     m_cgroupsBasedGrouping = m_taskManagerDconfig->value(TASKMANAGER_CGROUPS_BASED_GROUPING_KEY, true).toBool();
     m_dockedElements = m_taskManagerDconfig->value(TASKMANAGER_DOCKEDELEMENTS_KEY, {}).toStringList();
@@ -67,6 +71,11 @@ void TaskManagerSettings::setAllowedForceQuit(bool allowed)
 {
     m_allowForceQuit = allowed;
     m_taskManagerDconfig->setValue(TASKMANAGER_ALLOWFOCEQUIT_KEY, bool2EnableStr(m_allowForceQuit));
+}
+
+bool TaskManagerSettings::showAttentionAnimation() const
+{
+    return m_showAttentionAnimation;
 }
 
 bool TaskManagerSettings::isWindowSplit()

--- a/panels/dock/taskmanager/taskmanagersettings.h
+++ b/panels/dock/taskmanager/taskmanagersettings.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -26,6 +26,8 @@ public:
     bool isAllowedForceQuit();
     void setAllowedForceQuit(bool allowed);
 
+    bool showAttentionAnimation() const;
+
     bool isWindowSplit();
     void setWindowSplit(bool split);
 
@@ -47,6 +49,7 @@ private:
 
 Q_SIGNALS:
     void allowedForceQuitChanged();
+    void showAttentionAnimationChanged();
     void windowSplitChanged();
     void dockedItemsChanged();
     void dockedElementsChanged();
@@ -55,6 +58,7 @@ private:
     DConfig* m_taskManagerDconfig;
 
     bool m_allowForceQuit;
+    bool m_showAttentionAnimation;
     bool m_windowSplit;
     bool m_cgroupsBasedGrouping;
     QStringList m_dockedElements;


### PR DESCRIPTION
Added a new configuration option to control the display of attention animation for applications in the dock task manager. The animation shows a ripple effect when applications have new notifications. This feature includes DConfig settings, QML property binding, and C++ backend implementation to allow users to enable/disable the animation based on their preference.

Log: Added toggle for attention animation in dock task manager settings

feat: 为任务管理器添加消息通知动画开关

新增配置选项用于控制任务管理器中的应用消息通知动画显示。当应用有新消息
时，会显示水波纹动画效果。此功能包含 DConfig 设置、QML 属性绑定和 C++ 后
端实现，允许用户根据个人偏好启用或禁用该动画。

Log: 在任务管理器设置中添加了消息通知动画开关

## Summary by Sourcery

Add a configurable toggle to control attention notification animations for dock task manager items.

New Features:
- Introduce a task manager setting and QML property to enable or disable attention animations for dock applications.

Enhancements:
- Expose the attention animation setting through the TaskManager API and wire it to DConfig with change notifications.