### PR TITLE
feat: add dock library and refactor dock plugin management

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -93,3 +93,13 @@ Depends:
  ${misc:Depends},
 Description: DDE Shell devel library
  DDE Shell is a plugin system that integrates plugins developed based on this plugin system into DDE.
+
+Package: libdde-shell-dock-dev
+Architecture: any
+Depends:
+ libdde-shell-dev (= ${binary:Version}),
+ qt6-base-dev,
+ qt6-declarative-dev,
+ ${misc:Depends},
+Description: DDE Shell dock devel library
+ DDE Shell Dock is a library for dock item info.

--- a/debian/dde-shell.install
+++ b/debian/dde-shell.install
@@ -7,7 +7,7 @@ usr/lib/*/dde-shell/org.deepin.ds.dock*
 usr/lib/*/dde-shell/org.deepin.ds.notification*
 usr/lib/*/dde-shell/org.deepin.ds.notificationcenter*
 usr/lib/*/dde-shell/org.deepin.ds.osd*
-usr/lib/*/libds-notification-shared.so.*
+usr/lib/*/libds-notification-shared.so*
 usr/lib/*/qt6/qml/org/deepin/ds/dock/*
 usr/lib/*/qt6/qml/org/deepin/ds/notification/*
 usr/lib/*/qt6/qml/org/deepin/ds/notificationcenter/*

--- a/debian/libdde-shell-dev.install
+++ b/debian/libdde-shell-dev.install
@@ -1,3 +1,3 @@
-usr/include
-usr/lib/*/cmake/*/*.cmake
-usr/lib/*/lib*.so
+usr/include/dde-shell/*.h
+usr/lib/*/cmake/DDEShell/*.cmake
+usr/lib/*/libdde-shell.so

--- a/debian/libdde-shell-dock-dev.install
+++ b/debian/libdde-shell-dock-dev.install
@@ -1,0 +1,3 @@
+usr/include/dde-shell/dock/*.h
+usr/lib/*/libdde-shell-dock.so*
+usr/lib/*/cmake/DDEShellDock/*.cmake

--- a/panels/dock/AppletDockItem.qml
+++ b/panels/dock/AppletDockItem.qml
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import QtQuick
+import org.deepin.ds 1.0
+
+AppletItem {
+    id: appletDockItem
+
+    property int dockOrder: 0
+    property bool shouldVisible: Applet.visible
+    property bool useColumnLayout: Panel.position % 2
+    implicitWidth: useColumnLayout ? Panel.rootObject.dockSize : Panel.rootObject.dockItemMaxSize * 0.8
+    implicitHeight: useColumnLayout ? Panel.rootObject.dockItemMaxSize * 0.8 : Panel.rootObject.dockSize
+
+}

--- a/panels/dock/CMakeLists.txt
+++ b/panels/dock/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+# SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -18,8 +18,6 @@ file(
     dockabstractsettingsconfig.h
     dockdbusproxy.cpp
     dockdbusproxy.h
-    dockiteminfo.cpp
-    dockiteminfo.h
     dockpanel.cpp
     dockpanel.h
     docksettings.cpp
@@ -74,6 +72,7 @@ target_link_libraries(dockpanel PRIVATE
     Qt${QT_VERSION_MAJOR}::WaylandClientPrivate
     Qt${QT_VERSION_MAJOR}::Widgets
     dde-shell-frame
+    dde-shell-dock
 )
 
 if (BUILD_WITH_X11)
@@ -97,6 +96,7 @@ add_subdirectory(showdesktop)
 add_subdirectory(taskmanager)
 add_subdirectory(tray)
 add_subdirectory(multitaskview)
+add_subdirectory(frame)
 
 #add_subdirectory(appruntimeitem)
 
@@ -135,6 +135,7 @@ qt_add_qml_module(dock-plugin
     QML_FILES DockCompositor.qml OverflowContainer.qml MenuHelper.qml DockPalette.qml
     AppletItemButton.qml
     AppletItemBackground.qml
+    AppletDockItem.qml
     OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/plugins/org/deepin/ds/dock/
 )
 

--- a/panels/dock/appruntimeitem/CMakeLists.txt
+++ b/panels/dock/appruntimeitem/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+# SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -13,8 +13,8 @@ add_library(dock-appruntimeitem SHARED
     xcbgetinfo.h
     xcbgetinfo.cpp
     qmlappruntime.qrc
-    ${CMAKE_SOURCE_DIR}/panels/dock/dockiteminfo.cpp
-    ${CMAKE_SOURCE_DIR}/panels/dock/dockiteminfo.h
+    ${CMAKE_SOURCE_DIR}/frame/dock/dockiteminfo.cpp
+    ${CMAKE_SOURCE_DIR}/frame/dock/dockiteminfo.h
     ${CMAKE_SOURCE_DIR}/panels/dock/constants.h
     ${CMAKE_SOURCE_DIR}/panels/dock/taskmanager/x11utils.h
     ${CMAKE_SOURCE_DIR}/panels/dock/taskmanager/x11utils.cpp

--- a/panels/dock/appruntimeitem/appruntimeitem.h
+++ b/panels/dock/appruntimeitem/appruntimeitem.h
@@ -1,11 +1,11 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #pragma once
 #include "applet.h"
 #include "dsglobal.h"
-#include "dockiteminfo.h"
+#include "dock/dockiteminfo.h"
 
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>

--- a/panels/dock/dockdbusproxy.cpp
+++ b/panels/dock/dockdbusproxy.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -15,22 +15,38 @@
 
 DGUI_USE_NAMESPACE
 DS_USE_NAMESPACE
+namespace {
+constexpr auto DockVersionV1 = "1.0";
 
+QList<DS_NAMESPACE::DAppletDock *> dockApplets(dock::DockPanel *panel)
+{
+    QList<DS_NAMESPACE::DAppletDock *> list;
+    if (!panel) return list;
+
+    for (auto *applet : panel->applets()) {
+        if (applet->pluginMetaData().value("dock").toMap().value("version").toString() == DockVersionV1) {
+            if (auto dockApplet = qobject_cast<DS_NAMESPACE::DAppletDock *>(applet)) {
+                list.append(dockApplet);
+            }
+        }
+    }
+    return list;
+}
+}
 namespace dock {
 DockDBusProxy::DockDBusProxy(DockPanel* parent)
     : QObject(parent)
     , m_oldDockApplet(nullptr)
-    , m_multitaskviewApplet(nullptr)
     , m_trayApplet(nullptr)
 {
     registerPluginInfoMetaType();
 
     connect(DockSettings::instance(), &DockSettings::pluginsVisibleChanged, this, [this] (const QVariantMap &pluginsVisible) {
-        setPluginVisible("org.deepin.ds.dock.multitaskview", pluginsVisible);
+        updateDockPluginsVisible(pluginsVisible);
     });
     connect(parent, &DockPanel::rootObjectChanged, this, [this]() {
         auto pluginsVisible = DockSettings::instance()->pluginsVisible();
-        setPluginVisible("org.deepin.ds.dock.multitaskview", pluginsVisible);
+        updateDockPluginsVisible(pluginsVisible);
     });
 
     // Communicate with the other module
@@ -39,12 +55,8 @@ DockDBusProxy::DockDBusProxy(DockPanel* parent)
             DAppletBridge bridge("org.deepin.ds.dock.tray");
             m_trayApplet = bridge.applet();
         }
-        {
-            DAppletBridge bridge("org.deepin.ds.dock.multitaskview");
-            m_multitaskviewApplet = bridge.applet();
-        }
 
-        return m_trayApplet && m_multitaskviewApplet;
+        return m_trayApplet;
     };
 
     // TODO: DQmlGlobal maybe missing a  signal which named `appletListChanged`?
@@ -77,14 +89,13 @@ QRect DockDBusProxy::geometry()
     return parent()->window() ? parent()->window()->geometry() : QRect();
 }
 
-void DockDBusProxy::setPluginVisible(const QString &pluginId, const QVariantMap &pluginsVisible)
+void DockDBusProxy::updateDockPluginsVisible(const QVariantMap &pluginsVisible)
 {
-    if (DAppletBridge bridge(pluginId); auto item = bridge.applet()) {
-        DockItemInfo itemInfo;
-        QMetaObject::invokeMethod(item, "dockItemInfo", Qt::DirectConnection, qReturnArg(itemInfo));
+    for (auto *dockApplet : dockApplets(parent())) {
+        DockItemInfo itemInfo = dockApplet->dockItemInfo();
         QString itemKey = itemInfo.itemKey;
         if (pluginsVisible.contains(itemKey)) {
-            QMetaObject::invokeMethod(item, "setVisible", Qt::QueuedConnection, pluginsVisible[itemKey].toBool());
+           dockApplet->setVisible(pluginsVisible[itemKey].toBool());
         } else {
             auto settingPluginsVisible = DockSettings::instance()->pluginsVisible();
             settingPluginsVisible[itemKey] = true;
@@ -223,12 +234,10 @@ DockItemInfos DockDBusProxy::plugins()
         QMetaObject::invokeMethod(m_trayApplet, "dockItemInfos", Qt::DirectConnection, qReturnArg(iteminfos));
     }
 
-    if (m_multitaskviewApplet && DWindowManagerHelper::instance()->hasBlurWindow()) {
-        DockItemInfo info;
-        if (QMetaObject::invokeMethod(m_multitaskviewApplet, "dockItemInfo", Qt::DirectConnection, qReturnArg(info))) {
-            iteminfos.append(info);
-        }
+    for (auto *dockApplet : dockApplets(parent())) {
+        iteminfos.append(dockApplet->dockItemInfo());
     }
+
     return iteminfos;
 }
 
@@ -244,13 +253,18 @@ void DockDBusProxy::callShow()
 
 void DockDBusProxy::setItemOnDock(const QString &settingKey, const QString &itemKey, bool visible)
 {
-    if (itemKey == "multitasking-view" && m_multitaskviewApplet) {
-        QMetaObject::invokeMethod(m_multitaskviewApplet, "setVisible", Qt::QueuedConnection, visible);
-        auto pluginsVisible = DockSettings::instance()->pluginsVisible();
-        pluginsVisible[itemKey] = visible;
-        DockSettings::instance()->setPluginsVisible(pluginsVisible);
-        Q_EMIT pluginVisibleChanged(itemKey, visible);
-    } else if (m_trayApplet) {
+    for (auto *dockApplet : dockApplets(parent())) {
+        if (dockApplet->dockItemInfo().itemKey == itemKey) {
+            dockApplet->setVisible(visible);
+            auto pluginsVisible = DockSettings::instance()->pluginsVisible();
+            pluginsVisible[itemKey] = visible;
+            DockSettings::instance()->setPluginsVisible(pluginsVisible);
+            Q_EMIT pluginVisibleChanged(itemKey, visible);
+            return;
+        }
+    }
+
+    if (m_trayApplet) {
         Q_EMIT pluginVisibleChanged(itemKey, visible);
         QMetaObject::invokeMethod(m_trayApplet, "setItemOnDock", Qt::QueuedConnection, settingKey, itemKey, visible);
     }

--- a/panels/dock/dockdbusproxy.h
+++ b/panels/dock/dockdbusproxy.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -7,7 +7,8 @@
 #include "dsglobal.h"
 #include "dockpanel.h"
 #include "constants.h"
-#include "dockiteminfo.h"
+#include "frame/dockiteminfo.h"
+#include "frame/dappletdock.h"
 
 #include <appletproxy.h>
 
@@ -86,10 +87,9 @@ Q_SIGNALS:
 private:
     DockPanel* parent() const;
     QString getAppID(const QString &desktopfile);
-    void setPluginVisible(const QString &pluginId, const QVariantMap &pluginsVisible);
+    void updateDockPluginsVisible(const QVariantMap &pluginsVisible);
 
     DS_NAMESPACE::DAppletProxy *m_oldDockApplet;
-    DS_NAMESPACE::DAppletProxy *m_multitaskviewApplet;
     DS_NAMESPACE::DAppletProxy *m_trayApplet;
 };
 }

--- a/panels/dock/frame/CMakeLists.txt
+++ b/panels/dock/frame/CMakeLists.txt
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+set(DOCK_PUBLIC_HEADERS
+    dockiteminfo.h
+    dappletdock.h
+)
+
+add_library(dde-shell-dock SHARED
+    ${DOCK_PUBLIC_HEADERS}
+    dockiteminfo.cpp
+    dappletdock.cpp
+)
+
+set_target_properties(dde-shell-dock PROPERTIES
+    PUBLIC_HEADER "${DOCK_PUBLIC_HEADERS}"
+    VERSION ${CMAKE_PROJECT_VERSION}
+    SOVERSION 1
+    OUTPUT_NAME dde-shell-dock
+    EXPORT_NAME ShellDock
+)
+
+target_link_libraries(dde-shell-dock
+PUBLIC
+    dde-shell-frame
+    Qt${QT_VERSION_MAJOR}::Core
+    Qt${QT_VERSION_MAJOR}::Gui
+    Qt${QT_VERSION_MAJOR}::Quick
+)
+
+target_include_directories(dde-shell-dock INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>
+    $<INSTALL_INTERFACE:${INCLUDE_INSTALL_DIR}>
+)
+target_link_directories(dde-shell-dock INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+    $<INSTALL_INTERFACE:${LIB_INSTALL_DIR}>
+)
+
+target_compile_definitions(dde-shell-dock PRIVATE DS_LIB)
+
+install(TARGETS dde-shell-dock EXPORT DDEShellDockTargets DESTINATION "${LIB_INSTALL_DIR}" PUBLIC_HEADER DESTINATION "${INCLUDE_INSTALL_DIR}/dock")
+
+set(DOCK_CONFIG_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/DDEShellDock")
+
+install(EXPORT DDEShellDockTargets NAMESPACE Dde:: FILE DDEShellDockTargets.cmake DESTINATION "${DOCK_CONFIG_INSTALL_DIR}")
+
+include(CMakePackageConfigHelpers)
+configure_package_config_file(
+    "${CMAKE_CURRENT_LIST_DIR}/DDEShellDockConfig.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/DDEShellDockConfig.cmake"
+    INSTALL_DESTINATION "${DOCK_CONFIG_INSTALL_DIR}"
+)
+
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/DDEShellDockConfigVersion.cmake"
+    VERSION ${CMAKE_PROJECT_VERSION}
+    COMPATIBILITY AnyNewerVersion
+)
+
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/DDEShellDockConfig.cmake" DESTINATION "${DOCK_CONFIG_INSTALL_DIR}")
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/DDEShellDockConfigVersion.cmake" DESTINATION "${DOCK_CONFIG_INSTALL_DIR}")

--- a/panels/dock/frame/DDEShellDockConfig.cmake.in
+++ b/panels/dock/frame/DDEShellDockConfig.cmake.in
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+@PACKAGE_INIT@
+include(CMakeFindDependencyMacro)
+
+find_dependency(Qt@QT_VERSION_MAJOR@ COMPONENTS Core Gui Quick REQUIRED)
+find_dependency(DDEShell)
+
+include(${CMAKE_CURRENT_LIST_DIR}/DDEShellDockTargets.cmake)
+
+check_required_components(Qt@QT_VERSION_MAJOR@)

--- a/panels/dock/frame/dappletdock.cpp
+++ b/panels/dock/frame/dappletdock.cpp
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "dappletdock.h"
+#include <private/applet_p.h>
+
+DS_BEGIN_NAMESPACE
+
+class DAppletDockPrivate : public DAppletPrivate
+{
+public:
+    explicit DAppletDockPrivate(DAppletDock *qq)
+        : DAppletPrivate(qq)
+    {
+    }
+    ~DAppletDockPrivate() override = default;
+
+    bool m_visible = true;
+
+    D_DECLARE_PUBLIC(DAppletDock)
+};
+
+DAppletDock::DAppletDock(QObject *parent)
+    : DApplet(*new DAppletDockPrivate(this), parent)
+{
+}
+
+DAppletDock::DAppletDock(DAppletDockPrivate &dd, QObject *parent)
+    : DApplet(dd, parent)
+{
+}
+
+bool DAppletDock::visible() const
+{
+    D_DC(DAppletDock);
+    return d->m_visible;
+}
+
+void DAppletDock::setVisible(bool visible)
+{
+    D_D(DAppletDock);
+    if (d->m_visible == visible)
+        return;
+
+    d->m_visible = visible;
+    Q_EMIT visibleChanged();
+}
+
+DockItemInfo DAppletDock::dockItemInfo()
+{
+    return {};
+}
+
+DS_END_NAMESPACE

--- a/panels/dock/frame/dappletdock.h
+++ b/panels/dock/frame/dappletdock.h
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include "applet.h"
+#include "dockiteminfo.h"
+#include "dsglobal.h"
+
+DS_BEGIN_NAMESPACE
+
+class DAppletDockPrivate;
+
+class DS_SHARE DAppletDock : public DApplet
+{
+    Q_OBJECT
+    Q_PROPERTY(bool visible READ visible WRITE setVisible NOTIFY visibleChanged)
+    D_DECLARE_PRIVATE(DAppletDock)
+
+public:
+    explicit DAppletDock(QObject *parent = nullptr);
+    virtual ~DAppletDock() = default;
+
+    virtual DockItemInfo dockItemInfo();
+
+    bool visible() const;
+    void setVisible(bool visible);
+
+Q_SIGNALS:
+    void visibleChanged();
+
+protected:
+    explicit DAppletDock(DAppletDockPrivate &dd, QObject *parent = nullptr);
+};
+
+DS_END_NAMESPACE

--- a/panels/dock/frame/dockiteminfo.cpp
+++ b/panels/dock/frame/dockiteminfo.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/panels/dock/frame/dockiteminfo.h
+++ b/panels/dock/frame/dockiteminfo.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 #pragma once

--- a/panels/dock/multitaskview/CMakeLists.txt
+++ b/panels/dock/multitaskview/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+# SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -12,8 +12,6 @@ add_library(dock-multitaskview SHARED
     multitaskview.h
     treelandmultitaskview.cpp
     treelandmultitaskview.h
-    ../dockiteminfo.cpp
-    ../dockiteminfo.h
 )
 
 target_include_directories(dock-multitaskview PRIVATE
@@ -31,6 +29,7 @@ target_link_libraries(dock-multitaskview PRIVATE
     PkgConfig::WaylandClient
     Qt${QT_VERSION_MAJOR}::WaylandClient
     dde-shell-frame
+    dde-shell-dock
 )
 
 ds_install_package(PACKAGE org.deepin.ds.dock.multitaskview TARGET dock-multitaskview)

--- a/panels/dock/multitaskview/multitaskview.cpp
+++ b/panels/dock/multitaskview/multitaskview.cpp
@@ -1,8 +1,7 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-#include "applet.h"
 #include "multitaskview.h"
 #include "pluginfactory.h"
 #include "../constants.h"
@@ -23,7 +22,7 @@ constexpr int KWinOptimalPerformance = 4;
 const QString windowEffectTypeKey = QStringLiteral("user_type");
 
 MultiTaskView::MultiTaskView(QObject *parent)
-    : DApplet(parent)
+    : DAppletDock(parent)
     , m_iconName("deepin-multitasking-view")
 {
     connect(DWindowManagerHelper::instance(), &DWindowManagerHelper::hasCompositeChanged, this, &MultiTaskView::visibleChanged);
@@ -48,7 +47,7 @@ MultiTaskView::MultiTaskView(QObject *parent)
 
 bool MultiTaskView::init()
 {
-    DApplet::init();
+    DAppletDock::init();
     return true;
 }
 
@@ -80,11 +79,6 @@ void MultiTaskView::setIconName(const QString& iconName)
     }
 }
 
-bool MultiTaskView::visible() const
-{
-    return m_kWinEffect && m_visible && DWindowManagerHelper::instance()->hasComposite();
-}
-
 DockItemInfo MultiTaskView::dockItemInfo()
 {
     DockItemInfo info;
@@ -92,18 +86,9 @@ DockItemInfo MultiTaskView::dockItemInfo()
     info.displayName = tr("Multitasking View");
     info.itemKey = "multitasking-view";
     info.settingKey = "multitasking-view";
-    info.visible = visible();
+    info.visible = m_kWinEffect && DWindowManagerHelper::instance()->hasComposite();
     info.dccIcon = DCCIconPath + "multitasking-view.svg";
     return info;
-}
-
-void MultiTaskView::setVisible(bool visible)
-{
-    if (m_visible != visible) {
-        m_visible = visible;
-
-        Q_EMIT visibleChanged();
-    }
 }
 
 D_APPLET_CLASS(MultiTaskView)

--- a/panels/dock/multitaskview/multitaskview.h
+++ b/panels/dock/multitaskview/multitaskview.h
@@ -1,10 +1,11 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #pragma once
 
-#include "../dockiteminfo.h"
+#include "../frame/dappletdock.h"
+#include "../frame/dockiteminfo.h"
 #include "applet.h"
 #include "dsglobal.h"
 #include "treelandmultitaskview.h"
@@ -13,11 +14,10 @@
 
 namespace dock {
 
-class MultiTaskView : public DS_NAMESPACE::DApplet
+class MultiTaskView : public DS_NAMESPACE::DAppletDock
 {
     Q_OBJECT
     Q_PROPERTY(QString iconName READ iconName WRITE setIconName NOTIFY iconNameChanged FINAL)
-    Q_PROPERTY(bool visible READ visible WRITE setVisible NOTIFY visibleChanged)
 
 public:
     explicit MultiTaskView(QObject *parent = nullptr);
@@ -28,17 +28,12 @@ public:
     bool hasComposite();
 
     Q_INVOKABLE void openWorkspace();
-    Q_INVOKABLE DockItemInfo dockItemInfo();
-
-    Q_INVOKABLE bool visible() const;
-    Q_INVOKABLE void setVisible(bool visible);
+    DockItemInfo dockItemInfo() override;
 
 Q_SIGNALS:
     void iconNameChanged();
-    void visibleChanged();
 
 private:
-    bool m_visible = true;
     bool m_kWinEffect = true;
     QString m_iconName;
     QScopedPointer<TreeLandMultitaskview> m_multitaskview;

--- a/panels/dock/multitaskview/package/metadata.json
+++ b/panels/dock/multitaskview/package/metadata.json
@@ -1,6 +1,9 @@
 {
     "Plugin": {
         "Version": "1.0",
+        "dock": {
+            "version": "1.0"
+        },
         "Id": "org.deepin.ds.dock.multitaskview",
         "Url": "multitaskview.qml",
         "Parent": "org.deepin.ds.dock"

--- a/panels/dock/multitaskview/package/multitaskview.qml
+++ b/panels/dock/multitaskview/package/multitaskview.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -9,14 +9,9 @@ import org.deepin.ds 1.0
 import org.deepin.dtk 1.0 as D
 import org.deepin.ds.dock 1.0
 
-AppletItem {
+AppletDockItem {
     id: toggleworkspace
-    property bool useColumnLayout: Panel.position % 2
-    property int dockOrder: 15
-    property bool shouldVisible: Applet.visible
-    // 1:4 the distance between app : dock height; get width/height≈0.8
-    implicitWidth: useColumnLayout ? Panel.rootObject.dockSize : Panel.rootObject.dockItemMaxSize * 0.8
-    implicitHeight: useColumnLayout ? Panel.rootObject.dockItemMaxSize * 0.8 : Panel.rootObject.dockSize
+    dockOrder: 15
 
     PanelToolTip {
         id: toolTip

--- a/panels/dock/tray/CMakeLists.txt
+++ b/panels/dock/tray/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+# SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 #
 # SPDX-License-Identifier: CC0-1.0
 
@@ -42,8 +42,6 @@ add_library(trayitem SHARED
     trayitem.h
     traysettings.cpp
     traysettings.h
-    ../dockiteminfo.cpp
-    ../dockiteminfo.h
     ../constants.h
 )
 
@@ -54,6 +52,7 @@ target_include_directories(trayitem PUBLIC
 
 target_link_libraries(trayitem PRIVATE
     dde-shell-frame
+    dde-shell-dock
 )
 
 install(TARGETS dock-tray DESTINATION "${QML_INSTALL_DIR}/org/deepin/ds/dock/tray/")

--- a/panels/dock/tray/trayitem.h
+++ b/panels/dock/tray/trayitem.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -6,7 +6,7 @@
 
 #include "applet.h"
 #include "dsglobal.h"
-#include "dockiteminfo.h"
+#include "../frame/dockiteminfo.h"
 
 #include <QAbstractItemModel>
 


### PR DESCRIPTION
1. Added new libdde-shell-dock library to provide dock item interface
2. Created DAppletDock abstract base class for dock plugins with dockItemInfo() and setVisible() methods
3. Refactored dock plugin management to use new library instead of hardcoded plugin IDs
4. Updated build system to include new library and development packages
5. Modified multitaskview plugin to inherit from DAppletDock instead of DApplet
6. Added dockVersion metadata field to identify dock-compatible plugins
7. Fixed installation paths for header files and libraries in Debian packaging

Log: Improved dock plugin architecture with standardized interface

Influence:
1. Test dock plugin visibility management through settings
2. Verify multitaskview plugin still works correctly
3. Check that tray functionality remains unchanged
4. Test building and installation of new libdde-shell-dock packages
5. Verify backward compatibility with existing dock plugins
6. Test dock item information retrieval through D-Bus interface

feat: 新增Dock库并重构Dock插件管理

1. 新增libdde-shell-dock库，提供Dock项目接口
2. 创建DAppletDock抽象基类，包含dockItemInfo()和setVisible()方法
3. 重构Dock插件管理，使用新库替代硬编码的插件ID
4. 更新构建系统以包含新库和开发包
5. 修改multitaskview插件继承自DAppletDock而非DApplet
6. 新增dockVersion元数据字段以识别Dock兼容插件
7. 修复Debian打包中头文件和库的安装路径

Log: 改进Dock插件架构，提供标准化接口

Influence:
1. 测试通过设置管理Dock插件可见性
2. 验证multitaskview插件仍正常工作
3. 检查托盘功能是否保持不变
4. 测试新建libdde-shell-dock包的构建和安装
5. 验证与现有Dock插件的向后兼容性
6. 测试通过D-Bus接口获取Dock项目信息

PMS: TASK-388449

## Summary by Sourcery

Introduce a shared dock library and unify dock plugin handling around a standard dock applet interface.

New Features:
- Add the shared libdde-shell-dock library providing common dock item types and the DAppletDock base class for dock plugins.
- Make the multitaskview dock plugin inherit from DAppletDock and expose standardized dock item metadata.

Bug Fixes:
- Correct Debian installation paths for dock-related headers and libraries via new packaging entries.

Enhancements:
- Refactor dock D-Bus proxy logic to discover and control dock plugins dynamically using dockVersion metadata instead of hardcoded plugin IDs.
- Centralize DockItemInfo and related types in the new dock library and link existing dock components against it.

Build:
- Extend the build configuration to build and install the new dde-shell-dock library and link dock-related plugins against it.

Deployment:
- Add Debian packaging entries for the new libdde-shell-dock runtime and -dev packages.