### PR TITLE
fix: filter clipboard data for plugin Wayland clients

### DIFF
--- a/panels/dock/pluginmanagerextension.cpp
+++ b/panels/dock/pluginmanagerextension.cpp
@@ -80,7 +80,7 @@ struct WlQtTextInputMethodHelper : public QtWaylandServer::qt_text_input_method_
             base->send_enter(d->resource->handle, d->focusedSurface->resource());
             base->send_input_direction_changed(d->resource->handle, int(qApp->inputMethod()->inputDirection()));
             base->send_locale_changed(d->resource->handle, qApp->inputMethod()->locale().bcp47Name());
-            
+
             d->focusDestroyListener.listenForDestruction(surface->resource());
             if (d->inputPanelVisible && d->enabledSurfaces.values().contains(surface))
                 qApp->inputMethod()->show();
@@ -520,16 +520,31 @@ void PluginManager::initialize()
     // 启用剪贴板保留并在宿主系统剪贴板更新时同步给插件 Wayland 客户端，实现粘贴功能
     compositor->setRetainedSelectionEnabled(true);
     if (auto *clipboard = QGuiApplication::clipboard()) {
-        QObject::connect(clipboard, &QClipboard::changed, this, [compositor](QClipboard::Mode mode) {
-            if (mode == QClipboard::Clipboard) {
-                if (const QMimeData *mimeData = QGuiApplication::clipboard()->mimeData(mode)) {
-                    compositor->overrideSelection(mimeData);
+        auto syncClipboardData = [compositor](const QMimeData *mimeData) {
+            if (!mimeData) return;
+            QMimeData lightweightData;
+            static QStringList allowedFormats = {"text/plain", "text/html"};
+            bool hasData = false;
+            
+            for (const QString &format : mimeData->formats()) {
+                if (allowedFormats.contains(format)) {
+                    lightweightData.setData(format, mimeData->data(format));
+                    hasData = true;
                 }
             }
+
+            if (hasData) {
+                compositor->overrideSelection(&lightweightData);
+            }
+        };
+
+        QObject::connect(clipboard, &QClipboard::changed, this, [clipboard, syncClipboardData](QClipboard::Mode mode) {
+            if (mode == QClipboard::Clipboard) {
+                syncClipboardData(clipboard->mimeData(mode));
+            }
         });
-        if (const QMimeData *mimeData = clipboard->mimeData(QClipboard::Clipboard)) {
-            compositor->overrideSelection(mimeData);
-        }
+
+        syncClipboardData(clipboard->mimeData(QClipboard::Clipboard));
     }
 }
 


### PR DESCRIPTION
The clipboard synchronization to plugin Wayland clients was passing through all MIME data formats from the host system, which could include sensitive or unsupported data types. This change filters the clipboard data to only allow "text/plain" and "text/html" formats before forwarding to the compositor. A lightweight QMimeData object is created with only the allowed formats to prevent exposing unnecessary data. This improves security and compatibility with plugin clients.

fix: 为插件 Wayland 客户端过滤剪贴板数据

之前向插件 Wayland 客户端同步剪贴板数据时，会传递宿主系统的所有 MIME 数
据格式，这可能包含敏感或不支持的数据类型。此更改在将数据转发到合成器之
前，将剪贴板数据过滤为仅允许 "text/plain" 和 "text/html" 格式。创建一个
仅包含允许格式的轻量级 QMimeData 对象，以防止暴露不必要的数据。这提高了
安全性和与插件客户端的兼容性。

PMS: BUG-357249

## Summary by Sourcery

Bug Fixes:
- Restrict clipboard synchronization to only text/plain and text/html for plugin Wayland clients to avoid exposing unsupported or sensitive MIME data.