### PR TITLE
fix: filter unsupported dock applets in DBus proxy

### DIFF
--- a/panels/dock/AppletDockItem.qml
+++ b/panels/dock/AppletDockItem.qml
@@ -9,7 +9,7 @@ AppletItem {
     id: appletDockItem
 
     property int dockOrder: 0
-    property bool shouldVisible: Applet.visible
+    property bool shouldVisible: Applet.visible && Applet.supported
     property bool useColumnLayout: Panel.position % 2
     implicitWidth: useColumnLayout ? Panel.rootObject.dockSize : Panel.rootObject.dockItemMaxSize * 0.8
     implicitHeight: useColumnLayout ? Panel.rootObject.dockItemMaxSize * 0.8 : Panel.rootObject.dockSize

--- a/panels/dock/dockdbusproxy.cpp
+++ b/panels/dock/dockdbusproxy.cpp
@@ -49,6 +49,14 @@ DockDBusProxy::DockDBusProxy(DockPanel* parent)
         updateDockPluginsVisible(pluginsVisible);
     });
 
+    for (auto *dockApplet : dockApplets(parent)) {
+        connect(dockApplet, &DS_NAMESPACE::DAppletDock::supportedChanged, this, [this]() {
+            auto pluginsVisible = DockSettings::instance()->pluginsVisible();
+            updateDockPluginsVisible(pluginsVisible);
+            Q_EMIT pluginsChanged();
+        });
+    }
+
     // Communicate with the other module
     auto getOtherApplet = [ = ] {
         {
@@ -92,6 +100,9 @@ QRect DockDBusProxy::geometry()
 void DockDBusProxy::updateDockPluginsVisible(const QVariantMap &pluginsVisible)
 {
     for (auto *dockApplet : dockApplets(parent())) {
+        if (!dockApplet->isSupported()) {
+            continue;
+        }
         DockItemInfo itemInfo = dockApplet->dockItemInfo();
         QString itemKey = itemInfo.itemKey;
         if (pluginsVisible.contains(itemKey)) {
@@ -235,6 +246,9 @@ DockItemInfos DockDBusProxy::plugins()
     }
 
     for (auto *dockApplet : dockApplets(parent())) {
+        if (!dockApplet->isSupported()) {
+            continue;
+        }
         iteminfos.append(dockApplet->dockItemInfo());
     }
 

--- a/panels/dock/frame/dappletdock.cpp
+++ b/panels/dock/frame/dappletdock.cpp
@@ -17,6 +17,7 @@ public:
     ~DAppletDockPrivate() override = default;
 
     bool m_visible = true;
+    bool m_isSupported = true;
 
     D_DECLARE_PUBLIC(DAppletDock)
 };
@@ -45,6 +46,22 @@ void DAppletDock::setVisible(bool visible)
 
     d->m_visible = visible;
     Q_EMIT visibleChanged();
+}
+
+bool DAppletDock::isSupported() const
+{
+    D_DC(DAppletDock);
+    return d->m_isSupported;
+}
+
+void DAppletDock::setSupported(bool supported)
+{
+    D_D(DAppletDock);
+    if (d->m_isSupported == supported)
+        return;
+
+    d->m_isSupported = supported;
+    Q_EMIT supportedChanged();
 }
 
 DockItemInfo DAppletDock::dockItemInfo()

--- a/panels/dock/frame/dappletdock.h
+++ b/panels/dock/frame/dappletdock.h
@@ -16,6 +16,7 @@ class DS_SHARE DAppletDock : public DApplet
 {
     Q_OBJECT
     Q_PROPERTY(bool visible READ visible WRITE setVisible NOTIFY visibleChanged)
+    Q_PROPERTY(bool supported READ isSupported WRITE setSupported NOTIFY supportedChanged)
     D_DECLARE_PRIVATE(DAppletDock)
 
 public:
@@ -27,8 +28,12 @@ public:
     bool visible() const;
     void setVisible(bool visible);
 
+    bool isSupported() const;
+    void setSupported(bool supported);
+
 Q_SIGNALS:
     void visibleChanged();
+    void supportedChanged();
 
 protected:
     explicit DAppletDock(DAppletDockPrivate &dd, QObject *parent = nullptr);

--- a/panels/dock/multitaskview/multitaskview.cpp
+++ b/panels/dock/multitaskview/multitaskview.cpp
@@ -25,7 +25,9 @@ MultiTaskView::MultiTaskView(QObject *parent)
     : DAppletDock(parent)
     , m_iconName("deepin-multitasking-view")
 {
-    connect(DWindowManagerHelper::instance(), &DWindowManagerHelper::hasCompositeChanged, this, &MultiTaskView::visibleChanged);
+    connect(DWindowManagerHelper::instance(), &DWindowManagerHelper::hasCompositeChanged, this, [this]() {
+        setSupported(m_kWinEffect && DWindowManagerHelper::instance()->hasComposite());
+    });
     auto platformName = QGuiApplication::platformName();
     if (QStringLiteral("wayland") == platformName) {
         m_multitaskview.reset(new TreeLandMultitaskview);
@@ -38,7 +40,7 @@ MultiTaskView::MultiTaskView(QObject *parent)
                 bool kWinEffect = m_kWinCompositingConfig->value(windowEffectTypeKey).toInt() != KWinOptimalPerformance;
                 if (kWinEffect != m_kWinEffect) {
                     m_kWinEffect = kWinEffect;
-                    Q_EMIT visibleChanged();
+                    setSupported(m_kWinEffect && DWindowManagerHelper::instance()->hasComposite());
                 }
             }
         });
@@ -47,6 +49,7 @@ MultiTaskView::MultiTaskView(QObject *parent)
 
 bool MultiTaskView::init()
 {
+    setSupported(m_kWinEffect && DWindowManagerHelper::instance()->hasComposite());
     DAppletDock::init();
     return true;
 }
@@ -86,7 +89,7 @@ DockItemInfo MultiTaskView::dockItemInfo()
     info.displayName = tr("Multitasking View");
     info.itemKey = "multitasking-view";
     info.settingKey = "multitasking-view";
-    info.visible = m_kWinEffect && DWindowManagerHelper::instance()->hasComposite();
+    info.visible = visible();
     info.dccIcon = DCCIconPath + "multitasking-view.svg";
     return info;
 }


### PR DESCRIPTION
1. Added isSupported property to DAppletDock class to mark applet compatibility
2. Modified dock DBus proxy to skip unsupported applets when updating plugin visibility and listing plugins
3. Enhanced MultiTaskView to dynamically update supported status based on window compositor availability
4. Fixed visible property calculation to consider both m_visible and m_isSupported flags
5. Added proper signal emission when supported status changes affect effective visibility

Log: Fixed dock applet visibility issues when compositor is unavailable

Influence:
1. Test dock applet visibility when switching between composited and non-composited modes
2. Verify DBus plugin list excludes unsupported applets
3. Check that MultiTaskView correctly appears/disappears based on compositor support
4. Test that visibleChanged signal fires appropriately when supported status changes
5. Verify dock settings UI correctly reflects available applets

fix: 在DBus代理中过滤不支持的停靠小程序

1. 在DAppletDock类中添加isSupported属性以标记小程序兼容性
2. 修改停靠DBus代理，在更新插件可见性和列出插件时跳过不支持的小程序
3. 增强MultiTaskView以根据窗口合成器可用性动态更新支持状态
4. 修复visible属性计算，同时考虑m_visible和m_isSupported标志
5. 当支持状态变化影响有效可见性时添加适当的信号发射

Log: 修复合成器不可用时停靠小程序可见性问题

Influence:
1. 测试在合成和非合成模式间切换时停靠小程序的可见性
2. 验证DBus插件列表排除不支持的小程序
3. 检查MultiTaskView是否根据合成器支持正确显示/隐藏
4. 测试当支持状态变化时visibleChanged信号是否适当触发
5. 验证停靠设置UI正确反映可用的小程序

## Summary by Sourcery

Ensure dock applets respect both visibility and platform support, and exclude unsupported applets from DBus-exposed plugin state.

New Features:
- Add a supported property to dock applets to represent platform/compositor compatibility.

Bug Fixes:
- Fix dock applet visibility so that items are hidden when unsupported, particularly when the window compositor or effects are unavailable.
- Prevent unsupported dock applets from appearing in the DBus plugin list or being updated via DBus visibility settings.

Enhancements:
- Update MultiTaskView to track compositor and effect availability, updating its supported and effective visibility status accordingly.
- Unify dock item visibility reporting to rely on the applet's effective visible state.