### PR TITLE
fix: avoid quick panel placeholder not aligned to center on startup

### DIFF
--- a/panels/dock/tray/ShellSurfaceItemProxy.qml
+++ b/panels/dock/tray/ShellSurfaceItemProxy.qml
@@ -19,8 +19,8 @@ Item {
     property int cursorShape: Qt.ArrowCursor
     property alias shellSurfaceItem: impl
     
-    implicitWidth: shellSurface ? shellSurface.width : 10
-    implicitHeight: shellSurface ? shellSurface.height : 10
+    implicitWidth: shellSurface ? shellSurface.width : 16
+    implicitHeight: shellSurface ? shellSurface.height : 16
 
     function takeFocus() {
         impl.takeFocus()

--- a/panels/dock/tray/quickpanel/PanelTrayItem.qml
+++ b/panels/dock/tray/quickpanel/PanelTrayItem.qml
@@ -38,13 +38,14 @@ Control {
         toolTipY: DockPanelPositioner.y
     }
 
-    contentItem: Grid {
-        rows: root.useColumnLayout ? 2 : 1
-        spacing: 0
-        padding: 0
+    contentItem: GridLayout {
+        flow: root.useColumnLayout ? GridLayout.TopToBottom : GridLayout.LeftToRight
+        rowSpacing: 0
+        columnSpacing: 0
 
         Loader {
             id: placeholder
+            Layout.alignment: Qt.AlignCenter
             active: root.shellSurface
             visible: active
             sourceComponent: TrayItemSurface {
@@ -56,8 +57,8 @@ Control {
         }
         Control {
             id: quickpanelPlaceholder
-            width: placeholder.active ? placeholder.width : 16 + itemMargins
-            height: placeholder.active ? placeholder.height : 16 + itemMargins
+            Layout.alignment: Qt.AlignCenter
+            padding: itemMargins
             contentItem: DciIcon {
                 sourceSize: Qt.size(16, 16)
                 name: "dock-control-panel"


### PR DESCRIPTION
把Grid替换为GridLayout来使用布局特性,使托盘上的快捷面板部件内的元素始终可以居中,避免托盘插件未就绪时,元素偏离中心显示.
