### PR TITLE
fix: remove unnecessary platform check in AppItem tooltip

### DIFF
--- a/panels/dock/taskmanager/package/AppItem.qml
+++ b/panels/dock/taskmanager/package/AppItem.qml
@@ -429,7 +429,7 @@ Item {
 
 
     function onEntered() {
-        if (Qt.platform.pluginName === "xcb" && windows.length === 0) {
+        if (windows.length === 0) {
             toolTipShowTimer.start()
             return
         }
@@ -457,7 +457,7 @@ Item {
             previewTimer.stop()
         }
 
-        if (Qt.platform.pluginName === "xcb" && windows.length === 0) {
+        if (windows.length === 0) {
             toolTip.close()
             return
         }


### PR DESCRIPTION
1. Removed the platform-specific check `Qt.platform.pluginName === "xcb"` from the `onEntered` function
2. The condition now only checks if there are no windows, regardless of the platform
3. This fix ensures consistent tooltip behavior across all display backends (X11/Wayland)

Influence:
1. Verify tooltip shows correctly when no windows are open on X11
2. Verify tooltip shows correctly when no windows are open on Wayland
3. Test tooltip behavior when windows are present on both platforms
4. Ensure no regression in existing tooltip functionality

fix: 移除AppItem工具提示中不必要的平台检查

1. 从`onEntered`函数中移除了平台特定的检查`Qt.platform.pluginName === "xcb"`
2. 现在条件仅检查是否有窗口存在，与平台无关
3. 此修复确保在所有显示后端（X11/Wayland）上工具提示行为一致

Influence:
1. 验证在X11上无窗口时工具提示正常显示
2. 验证在Wayland上无窗口时工具提示正常显示
3. 测试两种平台上存在窗口时的工具提示行为
4. 确保现有工具提示功能无回归问题

PMS: BUG-344907

## Summary by Sourcery

Bug Fixes:
- Fix AppItem tooltip visibility logic so it triggers based only on whether any windows exist, not on the Qt X11 platform plugin.