### PR TITLE
fix: resolve tray submenu display position issue at screen top-left

### DIFF
--- a/panels/dock/tray/SurfaceSubPopup.qml
+++ b/panels/dock/tray/SurfaceSubPopup.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -24,7 +24,9 @@ Item {
             objectName: "subMenu"
             mainMenuWindow: Panel.menuWindow
             updateGeometryer : function () {
-                if (menuWindow.width <= 10 || menuWindow.height <= 10) {
+                if (menuWindow.requestedWidth <= 10 || menuWindow.requestedHeight <= 10) {
+                    menuWindow.width = menuWindow.requestedWidth
+                    menuWindow.height = menuWindow.requestedHeight
                     return
                 }
 
@@ -34,8 +36,9 @@ Item {
                 let bounding = Qt.rect(menuWindow.screen.virtualX + margins, menuWindow.screen.virtualY + margins,
                                        menuWindow.screen.width - margins * 2, menuWindow.screen.height - margins * 2)
                 let pos = Qt.point(xOffset, yOffset)
-                x = selectValue(pos.x, bounding.left, bounding.right - menuWindow.width)
-                y = selectValue(pos.y, bounding.top, bounding.bottom - menuWindow.height)
+                let newX = selectValue(pos.x, bounding.left, bounding.right - menuWindow.requestedWidth)
+                let newY = selectValue(pos.y, bounding.top, bounding.bottom - menuWindow.requestedHeight)
+                menuWindow.setWindowGeometry(newX, newY, menuWindow.requestedWidth, menuWindow.requestedHeight)
             }
             onUpdateGeometryFinished: function () {
                 if (!popup.shellSurface)


### PR DESCRIPTION
1. Fix incorrect property usage in submenu geometry calculation - use
`requestedWidth`/`requestedHeight` instead of `width`/`height`
2. Ensure submenu dimensions are properly set from requested values
before geometry adjustment
3. Use `setWindowGeometry()` to properly position and size the submenu
window with calculated coordinates

Log: Fixed tray tray submenu appearing at screen top-left corner

Influence:
1. Test submenu display position with various application tray icons
2. Verify submenu positioning when screen resolution changes
3. Test submenu behavior with different popup sizes
4. Confirm submenu stays within visible screen boundaries
5. Verify multiple submenu cascade functionality

fix: 修复托盘子菜单显示在屏幕左上角的问题

1. 修复子菜单几何计算中使用错误的属性 - 改用`requestedWidth`/
`requestedHeight`替代`width`/`height`
2. 确保在几何调整前使用请求尺寸正确设置子菜单尺寸
3. 使用`setWindowGeometry()`通过计算坐标正确定位和设置子菜单窗口尺寸

Log: 修复托盘子菜单显示在屏幕左上角的问题

Influence:
1. 测试不同应用托盘图标点击后的子菜单位置
2. 验证屏幕分辨率变化时子菜单位置是否正确
3. 测试不同大小弹出菜单的显示行为
4. 确认子菜单始终显示在屏幕可视区域内
5. 验证多层子菜单的级联显示功能

## Summary by Sourcery

Bug Fixes:
- Correct tray submenu geometry calculations by using requested dimensions and applying them via window geometry APIs to keep the submenu within visible screen area.