### PR TITLE
feat(dock): integrate optional event logging support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,15 @@ find_package(ICU 74.2 REQUIRED COMPONENTS uc i18n io)
 find_package(WaylandProtocols REQUIRED)
 find_package(PkgConfig REQUIRED)
 
+# Check if dde-api provides EventLogger (header-only)
+find_package(DDEAPI QUIET)
+if(DDEAPI_FOUND)
+    set(HAVE_DDE_API_EVENTLOGGER ON)
+    message(STATUS "Found DDEAPI: EventLogger available")
+else()
+    message(STATUS "DDEAPI not found, event logging will be disabled")
+endif()
+
 qt_policy(SET QTP0001 NEW)
 
 try_compile(COMPILE_RESULT

--- a/debian/control
+++ b/debian/control
@@ -6,6 +6,7 @@ Build-Depends:
  debhelper-compat (= 13),
  cmake,
  dde-application-manager-api (>= 1.2.48),
+ dde-api-dev (>> 6.0.39),
  dde-tray-loader-dev (> 2.0.24),
  extra-cmake-modules,
  libdtk6core-bin,

--- a/panels/dock/CMakeLists.txt
+++ b/panels/dock/CMakeLists.txt
@@ -75,6 +75,11 @@ target_link_libraries(dockpanel PRIVATE
     dde-shell-dock
 )
 
+if (HAVE_DDE_API_EVENTLOGGER)
+    target_compile_definitions(dockpanel PRIVATE HAVE_DDE_API_EVENTLOGGER)
+    target_link_libraries(dockpanel PRIVATE DDEAPI::EventLogger)
+endif()
+
 if (BUILD_WITH_X11)
     target_compile_definitions(dockpanel PRIVATE BUILD_WITH_X11=)
     pkg_check_modules(XCB REQUIRED IMPORTED_TARGET xcb xcb-aux xcb-res xcb-ewmh)

--- a/panels/dock/dockdbusproxy.cpp
+++ b/panels/dock/dockdbusproxy.cpp
@@ -9,6 +9,11 @@
 #include "dockdbusproxy.h"
 
 #include <QObject>
+#include <QJsonObject>
+
+#ifdef HAVE_DDE_API_EVENTLOGGER
+#include <dde-api/eventlogger.hpp>
+#endif
 
 #include <DWindowManagerHelper>
 #include <appletbridge.h>
@@ -17,6 +22,7 @@ DGUI_USE_NAMESPACE
 DS_USE_NAMESPACE
 namespace {
 constexpr auto DockVersionV1 = "1.0";
+constexpr qint64 EVENT_LOGGER_TRAY_PLUGIN_LIST = 1000610007;
 
 QList<DS_NAMESPACE::DAppletDock *> dockApplets(dock::DockPanel *panel)
 {
@@ -75,6 +81,9 @@ DockDBusProxy::DockDBusProxy(DockPanel* parent)
             timer->stop();
             timer->deleteLater();
             connect(m_trayApplet, SIGNAL(pluginsChanged()), this, SIGNAL(pluginsChanged()));
+            QTimer::singleShot(3000, this, [this]() {
+                logInitialPluginState();
+            });
         }
     });
     timer->start();
@@ -255,6 +264,43 @@ DockItemInfos DockDBusProxy::plugins()
     return iteminfos;
 }
 
+void DockDBusProxy::logInitialPluginState()
+{
+    QStringList visibleItemKeys;
+    for (const auto &info : plugins()) {
+        if (info.visible) {
+            visibleItemKeys.append(info.itemKey);
+        }
+    }
+
+#ifdef HAVE_DDE_API_EVENTLOGGER
+    DDE_EventLogger::EventLogger::instance().writeEventLog(
+        DDE_EventLogger::EventLoggerData(EVENT_LOGGER_TRAY_PLUGIN_LIST, QStringLiteral("dock_init"), {
+            {QStringLiteral("tray_plugin_list"), visibleItemKeys.join(QStringLiteral(","))}
+        }));
+#endif
+}
+
+void DockDBusProxy::logCurrentVisiblePluginList(const QString &changedItemKey, bool changedVisible)
+{
+    QStringList visibleItemKeys;
+    for (const auto &info : plugins()) {
+        if (info.itemKey == changedItemKey) {
+            if (changedVisible)
+                visibleItemKeys.append(info.itemKey);
+        } else if (info.visible) {
+            visibleItemKeys.append(info.itemKey);
+        }
+    }
+
+#ifdef HAVE_DDE_API_EVENTLOGGER
+    DDE_EventLogger::EventLogger::instance().writeEventLog(
+        DDE_EventLogger::EventLoggerData(EVENT_LOGGER_TRAY_PLUGIN_LIST, QStringLiteral("dock_plugins_changed"), {
+            {QStringLiteral("tray_plugin_list"), visibleItemKeys.join(QStringLiteral(","))}
+        }));
+#endif
+}
+
 void DockDBusProxy::ReloadPlugins()
 {
     parent()->ReloadPlugins();
@@ -274,6 +320,7 @@ void DockDBusProxy::setItemOnDock(const QString &settingKey, const QString &item
             pluginsVisible[itemKey] = visible;
             DockSettings::instance()->setPluginsVisible(pluginsVisible);
             Q_EMIT pluginVisibleChanged(itemKey, visible);
+            logCurrentVisiblePluginList(itemKey, visible);
             return;
         }
     }
@@ -281,6 +328,7 @@ void DockDBusProxy::setItemOnDock(const QString &settingKey, const QString &item
     if (m_trayApplet) {
         Q_EMIT pluginVisibleChanged(itemKey, visible);
         QMetaObject::invokeMethod(m_trayApplet, "setItemOnDock", Qt::QueuedConnection, settingKey, itemKey, visible);
+        logCurrentVisiblePluginList(itemKey, visible);
     }
 }
 
@@ -340,4 +388,3 @@ void DockDBusProxy::setLocked(bool newLocked)
 }
 
 }
-

--- a/panels/dock/dockdbusproxy.h
+++ b/panels/dock/dockdbusproxy.h
@@ -15,6 +15,7 @@
 #include <QObject>
 #include <QDBusContext>
 #include <QDBusArgument>
+#include <QTimer>
 
 /** this class used for old dock api compatible
   * it will forward old dbus call to new implementation
@@ -88,9 +89,10 @@ private:
     DockPanel* parent() const;
     QString getAppID(const QString &desktopfile);
     void updateDockPluginsVisible(const QVariantMap &pluginsVisible);
+    void logInitialPluginState();
+    void logCurrentVisiblePluginList(const QString &changedItemKey = QString(), bool changedVisible = true);
 
     DS_NAMESPACE::DAppletProxy *m_oldDockApplet;
     DS_NAMESPACE::DAppletProxy *m_trayApplet;
 };
 }
-

--- a/panels/dock/dockpanel.cpp
+++ b/panels/dock/dockpanel.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -23,6 +23,10 @@
 #include <QGuiApplication>
 #include <QQuickItem>
 #include <DGuiApplicationHelper>
+
+#ifdef HAVE_DDE_API_EVENTLOGGER
+#include <dde-api/eventlogger.hpp>
+#endif
 
 #define SETTINGS DockSettings::instance()
 

--- a/panels/dock/docksettings.cpp
+++ b/panels/dock/docksettings.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -8,6 +8,14 @@
 
 #include <QTimer>
 #include <QLoggingCategory>
+
+#include <QJsonObject>
+#ifdef HAVE_DDE_API_EVENTLOGGER
+#include <dde-api/eventlogger.hpp>
+#endif
+
+// Event IDs for dock settings (10-digit numbers)
+constexpr qint64 EVENT_LOGGER_DOCK_CONFIG = 1000610006;
 
 Q_LOGGING_CATEGORY(dockSettingsLog, "org.deepin.dde.shell.dock.docksettings")
 
@@ -82,6 +90,21 @@ static QString itemAlignment2String(const ItemAlignment& alignment)
     return "center";
 }
 
+void DockSettings::logDockConfig(std::optional<Position> pos, std::optional<ItemAlignment> align, const QString &reason) const
+{
+    QJsonObject payload;
+    if (pos)
+        payload.insert(QStringLiteral("shell_pos"), position2String(*pos));
+    if (align)
+        payload.insert(QStringLiteral("shell_dock_mode"), itemAlignment2String(*align));
+
+#ifdef HAVE_DDE_API_EVENTLOGGER
+    DDE_EventLogger::EventLogger::instance().writeEventLog(
+        DDE_EventLogger::EventLoggerData(EVENT_LOGGER_DOCK_CONFIG, QStringLiteral("dock_config"), payload));
+#endif
+    qCInfo(dockSettingsLog) << "EventLogger: dock config" << reason << payload;
+}
+
 static ItemAlignment string2ItenAlignment(const QString& alignmentStr)
 {
     if (alignmentStr == "left")
@@ -136,6 +159,7 @@ DockSettings::DockSettings(QObject* parent)
 {
     m_writeTimer->setSingleShot(true);
     m_writeTimer->setInterval(1000);
+    qCInfo(dockSettingsLog) << "EventLogger initialized";
     init();
 }
 
@@ -150,6 +174,9 @@ void DockSettings::init()
         m_pluginsVisible = m_dockConfig->value(keyPluginsVisible).toMap();
         m_showInPrimary = m_dockConfig->value(keyShowInPrimary).toBool();
         m_locked = m_dockConfig->value(keyLocked).toBool();
+
+        // Log dock config on startup - merge shell_pos and shell_dock_mode into one log entry
+        logDockConfig(m_dockPosition, m_alignment, QStringLiteral("on startup"));
 
         connect(m_dockConfig.data(), &DConfig::valueChanged, this, [this](const QString& key){
             if (keyDockSize == key) {
@@ -237,6 +264,7 @@ void DockSettings::setPosition(const Position& position)
     m_dockPosition = position;
     Q_EMIT positionChanged(m_dockPosition);
     addWriteJob(positionJob);
+    logDockConfig(position, std::nullopt, QStringLiteral("position changed"));
 }
 
 ItemAlignment DockSettings::itemAlignment()
@@ -251,6 +279,7 @@ void DockSettings::setItemAlignment(const ItemAlignment& alignment)
     m_alignment = alignment;
     Q_EMIT itemAlignmentChanged(m_alignment);
     addWriteJob(itemAlignmentJob);
+    logDockConfig(std::nullopt, alignment, QStringLiteral("itemAlignment changed"));
 }
 
 IndicatorStyle DockSettings::indicatorStyle()

--- a/panels/dock/docksettings.h
+++ b/panels/dock/docksettings.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -10,6 +10,7 @@
 #include <QObject>
 #include <DConfig>
 #include <QScopedPointer>
+#include <optional>
 
 DCORE_USE_NAMESPACE
 
@@ -62,6 +63,7 @@ private:
     void init();
 
     void addWriteJob(WriteJob job);
+    void logDockConfig(std::optional<Position> pos, std::optional<ItemAlignment> align, const QString &reason) const;
     inline void checkWriteJob();
 
 Q_SIGNALS:

--- a/panels/dock/multitaskview/CMakeLists.txt
+++ b/panels/dock/multitaskview/CMakeLists.txt
@@ -32,6 +32,11 @@ target_link_libraries(dock-multitaskview PRIVATE
     dde-shell-dock
 )
 
+if (HAVE_DDE_API_EVENTLOGGER)
+    target_compile_definitions(dock-multitaskview PRIVATE HAVE_DDE_API_EVENTLOGGER)
+    target_link_libraries(dock-multitaskview PRIVATE DDEAPI::EventLogger)
+endif()
+
 ds_install_package(PACKAGE org.deepin.ds.dock.multitaskview TARGET dock-multitaskview)
 ds_handle_package_translation(PACKAGE org.deepin.ds.dock.multitaskview)
 

--- a/panels/dock/multitaskview/multitaskview.cpp
+++ b/panels/dock/multitaskview/multitaskview.cpp
@@ -7,14 +7,25 @@
 #include "../constants.h"
 
 #include <QBuffer>
+#include <QProcess>
 
 #include <DDciIcon>
 #include <DDBusSender>
 #include <DWindowManagerHelper>
 #include <DGuiApplicationHelper>
 
+#ifdef HAVE_DDE_API_EVENTLOGGER
+#include <dde-api/eventlogger.hpp>
+#endif
+
 DGUI_USE_NAMESPACE
 DCORE_USE_NAMESPACE
+
+namespace {
+constexpr qint64 EVENT_LOGGER_KWIN_MULTITASK_VIEW = 1000300000;
+constexpr int EventLaunchTypeDockIcon = 2;
+
+}
 
 namespace dock {
 
@@ -50,12 +61,32 @@ MultiTaskView::MultiTaskView(QObject *parent)
 bool MultiTaskView::init()
 {
     setSupported(m_kWinEffect && DWindowManagerHelper::instance()->hasComposite());
+    queryKwinVersion();
     DAppletDock::init();
     return true;
 }
 
+void MultiTaskView::queryKwinVersion()
+{
+    auto *process = new QProcess(this);
+    process->start(QStringLiteral("dpkg-query"), { QStringLiteral("-W"), QStringLiteral("-f=${Version}"), QStringLiteral("kwin-x11") });
+    connect(process, &QProcess::finished, this, [this, process](int exitCode, QProcess::ExitStatus status) {
+        if (status == QProcess::NormalExit && exitCode == 0) {
+            m_kwinVersion = QString::fromLocal8Bit(process->readAllStandardOutput()).trimmed();
+        }
+        process->deleteLater();
+    });
+}
+
 void MultiTaskView::openWorkspace()
 {
+#ifdef HAVE_DDE_API_EVENTLOGGER
+    DDE_EventLogger::EventLogger::instance().writeEventLog(
+        DDE_EventLogger::EventLoggerData(EVENT_LOGGER_KWIN_MULTITASK_VIEW, QStringLiteral("kwin_multitask_view"), {
+            {QStringLiteral("launch_type"), EventLaunchTypeDockIcon},
+            {QStringLiteral("kwin_version"), m_kwinVersion}
+        }));
+#endif
     if (m_multitaskview) {
         m_multitaskview->toggle();
         return;

--- a/panels/dock/multitaskview/multitaskview.h
+++ b/panels/dock/multitaskview/multitaskview.h
@@ -34,7 +34,9 @@ Q_SIGNALS:
     void iconNameChanged();
 
 private:
+    void queryKwinVersion();
     bool m_kWinEffect = true;
+    QString m_kwinVersion;
     QString m_iconName;
     QScopedPointer<TreeLandMultitaskview> m_multitaskview;
     Dtk::Core::DConfig *m_kWinCompositingConfig = nullptr;

--- a/panels/dock/taskmanager/CMakeLists.txt
+++ b/panels/dock/taskmanager/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+# SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -101,6 +101,11 @@ target_link_libraries(dock-taskmanager PRIVATE
     yaml-cpp
     PkgConfig::WaylandClient
 )
+
+if (HAVE_DDE_API_EVENTLOGGER)
+    target_compile_definitions(dock-taskmanager PRIVATE HAVE_DDE_API_EVENTLOGGER)
+    target_link_libraries(dock-taskmanager PRIVATE DDEAPI::EventLogger)
+endif()
 
 if (BUILD_WITH_X11)
     target_compile_definitions(dock-taskmanager PRIVATE BUILD_WITH_X11=)

--- a/panels/dock/taskmanager/taskmanager.cpp
+++ b/panels/dock/taskmanager/taskmanager.cpp
@@ -22,6 +22,10 @@
 #include "textcalculator.h"
 #include "treelandwindowmonitor.h"
 
+#ifdef HAVE_DDE_API_EVENTLOGGER
+#include <dde-api/eventlogger.hpp>
+#endif
+
 #include <QGuiApplication>
 #include <QProcess>
 #include <QStandardPaths>
@@ -170,6 +174,8 @@ bool TaskManager::load()
 
 bool TaskManager::init()
 {
+    Settings->logMergeAppModel(!Settings->isWindowSplit());
+
     auto adaptor = new TaskManagerAdaptor(this);
     Q_UNUSED(adaptor)
     QDBusConnection::sessionBus().registerService("org.deepin.ds.Dock.TaskManager");

--- a/panels/dock/taskmanager/taskmanagersettings.cpp
+++ b/panels/dock/taskmanager/taskmanagersettings.cpp
@@ -5,12 +5,20 @@
 #include "globals.h"
 #include "taskmanagersettings.h"
 
+#include <DConfig>
 #include <QJsonObject>
-#include <QJsonDocument>
 
 #include <string>
 
 #include <yaml-cpp/yaml.h>
+
+#ifdef HAVE_DDE_API_EVENTLOGGER
+#include <dde-api/eventlogger.hpp>
+#endif
+
+namespace {
+constexpr qint64 EVENT_LOGGER_MERGE_APP_MODEL = 1000610011;
+}
 
 namespace dock {
 static inline QString bool2EnableStr(bool enable)
@@ -46,6 +54,7 @@ TaskManagerSettings::TaskManagerSettings(QObject *parent)
         } else if (TASKMANAGER_WINDOWSPLIT_KEY == key) {
             m_windowSplit = m_taskManagerDconfig->value(TASKMANAGER_WINDOWSPLIT_KEY).toBool();
             Q_EMIT windowSplitChanged();
+            logMergeAppModel(!m_windowSplit);
         } else if (TASKMANAGER_DOCKEDELEMENTS_KEY == key) {
             m_dockedElements = m_taskManagerDconfig->value(TASKMANAGER_DOCKEDELEMENTS_KEY, {}).toStringList();
             Q_EMIT dockedElementsChanged();
@@ -190,6 +199,17 @@ void TaskManagerSettings::removeDockedElement(const QString &element)
     m_dockedElements.removeAll(element);
     Q_EMIT dockedElementsChanged();
     saveDockedElements();
+}
+
+void TaskManagerSettings::logMergeAppModel(bool mergeAppModelOn)
+{
+#ifdef HAVE_DDE_API_EVENTLOGGER
+    DDE_EventLogger::EventLogger::instance().writeEventLog(
+        DDE_EventLogger::EventLoggerData(EVENT_LOGGER_MERGE_APP_MODEL, QStringLiteral("taskmanager_config"), {
+            {QStringLiteral("merge_app_model_on"), mergeAppModelOn ? QStringLiteral("true") : QStringLiteral("false")}
+        }));
+#endif
+    qDebug() << "EventLogger: merge_app_model_on:" << mergeAppModelOn;
 }
 
 }

--- a/panels/dock/taskmanager/taskmanagersettings.h
+++ b/panels/dock/taskmanager/taskmanagersettings.h
@@ -42,6 +42,8 @@ public:
     QStringList dockedElements() const;
     bool isDocked(const QString &elementId) const;
 
+    void logMergeAppModel(bool mergeAppModelOn);
+
 private:
     explicit TaskManagerSettings(QObject *parent = nullptr);
     inline void migrateFromDockedItems();


### PR DESCRIPTION
Add conditional event logging support for dock-related modules and wire the required build detection and package dependency. The implementation keeps the logging integration optional when the event logger headers are unavailable.

feat(dock): 集成可选事件日志支持

为 dock 相关模块添加条件事件日志支持，并接入所需的构建检测与包依赖。该实现会在缺少事件日志头文件时保持日志集成可选。

PMS: TASK-388657

## Summary by Sourcery

Integrate optional event logging across dock components while keeping functionality unchanged when the dde-api event logger is unavailable.

New Features:
- Add event logging for tray plugin list visibility changes in the dock DBus proxy.
- Log dock position and alignment configuration changes via the event logger.
- Record multitask view launches from the dock, including KWin version metadata.
- Track task manager merge-app-model configuration changes through the event logger.

Enhancements:
- Update dock and taskmanager source headers with extended copyright years.
- Introduce helper functions for computing visible tray plugin lists used by logging.

Build:
- Add CMake detection for dde-api eventlogger headers and define a HAVE_DDE_API_EVENTLOGGER compile flag.
- Wire the HAVE_DDE_API_EVENTLOGGER definition into dock, taskmanager, and multitaskview targets so logging is compiled conditionally.