### PR TITLE
fix: correct ActiveRole and AttentionRole data retrieval for active

### DIFF
--- a/panels/dock/taskmanager/dockglobalelementmodel.cpp
+++ b/panels/dock/taskmanager/dockglobalelementmodel.cpp
@@ -385,6 +385,14 @@ QVariant DockGlobalElementModel::data(const QModelIndex &index, int role) const
         QModelIndex groupIndex = model->index(row, 0);
         return groupIndex.data(TaskManager::WindowsRole).toStringList();
     }
+    case TaskManager::ActiveRole:
+    case TaskManager::AttentionRole: {
+        if (model == m_activeAppModel) {
+            return model->index(row, 0).data(role);
+        }
+        return false;
+    }
+
     case TaskManager::MenusRole: {
         return getMenus(index);
     }


### PR DESCRIPTION
app model

1. Added case handling for `TaskManager::ActiveRole` and `TaskManager::AttentionRole` in the `data()` method of `DockGlobalElementModel`
2. Fixed issue where these roles returned incorrect values when queried from the active app model (`m_activeAppModel`)
3. Previously, these roles were not explicitly handled, potentially falling through to a default behavior that could return wrong data
4. Now correctly delegates to the underlying model's data method for the specified roles when the model is the active app model
5. Returns `false` for other models (e.g., window group model) as these concepts don't apply there

Log: Fixed incorrect active state and attention state display for dock app icons

Influence:
1. Verify that active dock app icons properly reflect their active state
2. Test attention-requesting apps show correct visual feedback (e.g., blinking)
3. Check that window group icons do not incorrectly display active/ attention states
4. Regression test on app launching and window switching scenarios
5. Test with multiple workspaces and virtual desktops

fix: 修复活跃应用模型的 ActiveRole 和 AttentionRole 数据获取

1. 在 `DockGlobalElementModel` 的 `data()` 方法中增加了 `TaskManager::ActiveRole` 和 `TaskManager::AttentionRole` 的处理分支
2. 修复了从活跃应用模型查询这些角色时返回错误值的问题
3. 现在对于活跃应用模型会正确委托到底层模型的数据方法
4. 其他模型（如窗口组模型）返回 `false`，因为这些概念不适用

Log: 修复任务栏应用图标活跃状态和提醒状态显示异常

Influence:
1. 验证任务栏中活跃应用的图标是否正确显示活跃状态
2. 测试请求关注的应用是否能显示正确的视觉反馈（如闪烁）
3. 确保窗口组图标不会错误显示活跃/关注状态
4. 回归测试应用启动和窗口切换场景
5. 测试多工作区和虚拟桌面下的表现

此问题主要是处理
拆分模式下，关闭某个驻留应用窗口时（有焦点的窗口），他的背景不会消失，问题在于：属性绑定机制里，如果绑定的数据源返回了 undefined（对应 C++ 的空的/无效的 QVariant），QML
会选择不更新此属性，保留上一次的旧值！

因此 默认default返回的是一个 return {}; 会导致 保留了上次值，导致问题。

## Summary by Sourcery

Fix active and attention state data retrieval for dock app entries in the global element model.

Bug Fixes:
- Correct ActiveRole and AttentionRole data returned from the active app model by delegating to the underlying model.
- Prevent non-active models such as window groups from incorrectly reporting active or attention states.