### PR TITLE
fix: show dock context menu on long press release

### DIFF
--- a/panels/dock/multitaskview/package/multitaskview.qml
+++ b/panels/dock/multitaskview/package/multitaskview.qml
@@ -39,14 +39,25 @@ AppletDockItem {
         }
     }
 
-    MouseArea {
-        id: mouseHandler
-        anchors.fill: parent
-        onClicked: function (mouse) {
-            if (mouse.button === Qt.LeftButton) {
+    TapHandler {
+        id: tapHandler
+        acceptedButtons: Qt.LeftButton | Qt.RightButton
+        gesturePolicy: TapHandler.WithinBounds
+        onTapped: function (eventPoint, buttons) {
+            if (buttons === Qt.LeftButton) {
                 Applet.openWorkspace()
                 toolTip.close()
             }
+        }
+    }
+
+    TapHandler {
+        acceptedButtons: Qt.NoButton
+        acceptedDevices: PointerDevice.TouchScreen
+        gesturePolicy: TapHandler.WithinBounds
+        onTapped: function (eventPoint, buttons) {
+            Applet.openWorkspace()
+            toolTip.close()
         }
     }
     HoverHandler {

--- a/panels/dock/package/main.qml
+++ b/panels/dock/package/main.qml
@@ -422,6 +422,7 @@ Window {
             }
         }
 
+        property bool isLongPressing: false
         TapHandler {
             acceptedButtons: Qt.LeftButton | Qt.RightButton
             gesturePolicy: TapHandler.WithinBounds
@@ -436,6 +437,22 @@ Window {
                     // try to close popup when clicked empty, because dock does not have focus.
                     Panel.requestClosePopup()
                     viewDeactivated()
+                }
+            }
+            onLongPressed: {
+                console.debug("[Mouse Long Press] longPressed")
+                dockContainer.isLongPressing = true
+            }
+            onPressedChanged: {
+                console.debug("[Mouse Long Press] pressedChanged, pressed:", pressed, "isLongPressing:", dockContainer.isLongPressing)
+                if (!pressed && dockContainer.isLongPressing) {
+                    dockContainer.isLongPressing = false
+                    let lastActive = MenuHelper.activeMenu
+                    MenuHelper.closeCurrent()
+                    dockMenuLoader.active = true
+                    if (lastActive !== dockMenuLoader.item) {
+                        requestShowDockMenu()
+                    }
                 }
             }
         }
@@ -453,11 +470,19 @@ Window {
                 viewDeactivated()
             }
             onLongPressed: {
-                let lastActive = MenuHelper.activeMenu
-                MenuHelper.closeCurrent()
-                dockMenuLoader.active = true
-                if (lastActive !== dockMenuLoader.item) {
-                    requestShowDockMenu()
+                console.debug("[Touch Long Press] longPressed")
+                dockContainer.isLongPressing = true
+            }
+            onPressedChanged: {
+                console.debug("[Touch Long Press] pressedChanged, pressed:", pressed, "isLongPressing:", dockContainer.isLongPressing)
+                if (!pressed && dockContainer.isLongPressing) {
+                    dockContainer.isLongPressing = false
+                    let lastActive = MenuHelper.activeMenu
+                    MenuHelper.closeCurrent()
+                    dockMenuLoader.active = true
+                    if (lastActive !== dockMenuLoader.item) {
+                        requestShowDockMenu()
+                    }
                 }
             }
         }


### PR DESCRIPTION
1. Add isLongPressing property to track long press state
2. Defer dock context menu display until long press is released for mouse input
3. Refactor touch long press to use same deferred release pattern
4. Add debug logging for both mouse and touch long press events

Previously the dock context menu opened immediately on the longPressed signal, which could cause unexpected behavior while the user was still pressing. Now the menu only appears after the long press is released, providing a more natural and predictable interaction.

Log: Changed dock long press behavior to show context menu on release instead of immediately

Influence:
1. Test mouse long press on dock - verify context menu appears on release not during press
2. Test touch long press on dock - verify context menu appears on release not during press
3. Test short click/tap on dock - verify context menu does NOT appear
4. Test right-click on dock - verify normal context menu behavior is unaffected
5. Test long press and drag - verify no unexpected menu activation
6. Test rapid long press/release cycles - verify isLongPressing flag resets correctly

fix: 修复任务栏长按上下文菜单在松开时才显示

1. 添加 isLongPressing 属性用于跟踪长按状态
2. 鼠标输入的长按上下文菜单延迟到松开时显示
3. 重构触摸长按逻辑，使用相同的延迟松开模式
4. 为鼠标和触摸长按事件添加调试日志

此前任务栏上下文菜单在 longPressed 信号触发时立即打开，可能导致用户仍在
按压时出现意外行为。现在菜单仅在长按松开后显示，提供更自然和可预测的交互
体验。

Log: 修改任务栏长按行为，上下文菜单在松开时显示而非立即显示

Influence:
1. 测试鼠标长按任务栏 - 验证上下文菜单在松开时而非按压时显示
2. 测试触摸长按任务栏 - 验证上下文菜单在松开时而非按压时显示
3. 测试短按/轻点任务栏 - 验证上下文菜单不会出现
4. 测试右键点击任务栏 - 验证正常的上下文菜单行为不受影响
5. 测试长按并拖动 - 验证不会意外激活菜单
6. 测试快速长按/松开循环 - 验证 isLongPressing 标志正确重置

PMS: BUG-358827
Change-Id: I23597cf45ae2c4cea634eb525a6ad09bde5fc89a