### PR TITLE
chore: update copyright years and fix tooltip behavior

### DIFF
--- a/panels/dock/tray/package/ActionShowStashDelegate.qml
+++ b/panels/dock/tray/package/ActionShowStashDelegate.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -98,6 +98,9 @@ AppletItemButton {
             stashedPopup.close()
         } else {
             stashedPopup.open()
+        }
+        if (toolTipShowTimer.running) {
+            toolTipShowTimer.stop()
         }
         toolTip.close()
     }


### PR DESCRIPTION
1. Update copyright year range from 2024 to 2024-2026
2. Stop the tooltip show timer when clicking the stash action button
3. Ensure tooltip is closed correctly when button is clicked, preventing UI flicker

Influence:
1. Verify the tooltip does not appear when clicking the stash button
2. Check that copyright text displays the correct year range
3. Test repeated clicks on the stash button to ensure no UI flicker

PMS: BUG-358821