### PR TITLE
fix: correct SPDX comment syntax in DDEShellDockConfig.cmake.in

### DIFF
--- a/panels/dock/frame/DDEShellDockConfig.cmake.in
+++ b/panels/dock/frame/DDEShellDockConfig.cmake.in
@@ -1,6 +1,6 @@
-// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
-//
-// SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 @PACKAGE_INIT@
 include(CMakeFindDependencyMacro)


### PR DESCRIPTION
Changed the SPDX license header from C++ style `//` comments to CMake `#` style comments to match the file's CMake language syntax, ensuring proper SPDX license handling.

Log: Fixed SPDX license comment syntax in CMake configuration file

Influence:
1. Verify SPDX license header parsing tools recognize the corrected syntax
2. Confirm CMake build system processes the file without warnings
3. Ensure no functional impact on the dock panel configuration

fix: 修正 DDEShellDockConfig.cmake.in 中 SPDX 注释语法

将 SPDX 许可证头从 C++ 风格的 `//` 注释改为 CMake 风格的 `#` 注释，以匹 配文件的 CMake 语言语法，确保 SPDX 许可证的正确处理。

Log: 修复 CMake 配置文件中的 SPDX 许可证注释语法

Influence:
1. 验证 SPDX 许可证头解析工具能识别修正后的语法
2. 确认 CMake 构建系统处理该文件时无警告
3. 确保对 Dock 面板配置无功能影响

## Summary by Sourcery

Enhancements:
- Align the SPDX license header in DDEShellDockConfig.cmake.in with CMake `#` comment syntax for proper tooling recognition.