### PR TITLE
fix: enable right-click menu via long-press on touchscreen

### DIFF
--- a/panels/dock/taskmanager/package/AppItem.qml
+++ b/panels/dock/taskmanager/package/AppItem.qml
@@ -494,7 +494,19 @@ Item {
             Panel.contextDragging = true
         }
 
+        // 记录是否是触摸长按导致的，防止在 onClicked 中重复处理
+        property bool isTouchLongPressed: false
+
+        TapHandler {
+            acceptedDevices: PointerDevice.TouchScreen
+            gesturePolicy: TapHandler.DragThreshold
+            onLongPressed: {
+                mouseArea.isTouchLongPressed = true
+                requestAppItemMenu()
+            }
+        }
         onPressed: function (mouse) {
+            isTouchLongPressed = false
             if (mouse.button === Qt.LeftButton) {
                 appItem.grabToImage(function(result) {
                     root.Drag.imageSource = result.url;
@@ -503,13 +515,13 @@ Item {
             toolTip.close()
             closeItemPreview()
         }
-        // touchscreen long press.
-        onPressAndHold: function (mouse) {
-            if (mouse.button === Qt.NoButton) {
-                requestAppItemMenu()
-            }
-        }
+
         onClicked: function (mouse) {
+            if (isTouchLongPressed) {
+                isTouchLongPressed = false
+                return
+            }
+
             let index = root.modelIndex;
             if (mouse.button === Qt.RightButton) {
                 requestAppItemMenu()


### PR DESCRIPTION
Previously, only touch long-press events (mouse.button === Qt.NoButton) triggered the app item's context menu. This change also recognizes right-button long-press events, allowing touchscreen users with right- click hardware buttons to access the menu.

Log: Fixed right-click menu not working on touchscreen devices

Influence:
1. Test long-press on a taskbar app item using a touchscreen (simulate touch input)
2. Test long-press using a right-click hardware button on a touchscreen device
3. Verify that the correct context menu appears for both scenarios
4. Ensure normal left-click behavior remains unchanged
5. Verify that the change does not affect desktop mouse right-click behavior

fix: 在触摸屏上支持通过长按右键弹出菜单

之前只有触摸长按事件（mouse.button === Qt.NoButton）能触发应用项的右键
菜单。此次变更同时识别右键长按事件，允许带有右键硬件按钮的触摸屏用户访问
菜单。

Log: 修复触摸屏设备右键菜单无法使用的问题

Influence:
1. 在任务栏应用项上使用触摸屏进行长按测试（模拟触摸输入）
2. 在触摸屏设备上使用右键硬件按钮进行长按测试
3. 验证两种场景下均能弹出正确的上下文菜单
4. 确保普通的左键操作行为不受影响
5. 验证该改动不会影响桌面鼠标右键行为

PMS: BUG-358827

## Summary by Sourcery

Bug Fixes:
- Fix touchscreen devices failing to open the app item context menu when long-pressing with a hardware right-click button.