### PR TITLE
fix: resolve occasional crash in TreeLandWindow destructor under treeland

### DIFF
--- a/panels/dock/taskmanager/treelandwindow.cpp
+++ b/panels/dock/taskmanager/treelandwindow.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -120,7 +120,6 @@ TreeLandWindow::TreeLandWindow(uint32_t id, QObject *parent)
 TreeLandWindow::~TreeLandWindow()
 {
     qCDebug(waylandwindowLog()) << "wayland window destoryed";
-    emit stateChanged();
 }
 
 uint32_t TreeLandWindow::id()

--- a/panels/dock/taskmanager/treelandwindowmonitor.cpp
+++ b/panels/dock/taskmanager/treelandwindowmonitor.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -104,6 +104,7 @@ void TreeLandWindowMonitor::clear()
 {
     m_windows.clear();
     m_dockPreview.reset(nullptr);
+    updateFullscreenState();
 }
 
 QPointer<AbstractWindow> TreeLandWindowMonitor::getWindowByWindowId(ulong windowId)
@@ -201,19 +202,7 @@ void TreeLandWindowMonitor::handleForeignToplevelHandleAdded()
         m_windows.insert(id, window);
     }
 
-    connect(window.data(), &AbstractWindow::stateChanged, this, [=] {
-        for (auto w: m_windows) {
-            if (w->isFullscreen() && !m_fullscreenState) {
-                m_fullscreenState = true;
-                emit windowFullscreenChanged(true);
-                return;
-            }
-        }
-        if (m_fullscreenState) {
-            m_fullscreenState = false;
-            emit windowFullscreenChanged(false);
-        }
-    });
+    connect(window.data(), &AbstractWindow::stateChanged, this, &TreeLandWindowMonitor::updateFullscreenState, Qt::UniqueConnection);
 
     window->setForeignToplevelHandle(handle);
 
@@ -236,7 +225,25 @@ void TreeLandWindowMonitor::handleForeignToplevelHandleRemoved()
     if (window) {
         destroyWindow(window.get());
         m_windows.remove(id);
+        updateFullscreenState();
+    }
+}
+
+void TreeLandWindowMonitor::updateFullscreenState()
+{
+    for (auto window : std::as_const(m_windows)) {
+        if (window && window->isFullscreen()) {
+            if (!m_fullscreenState) {
+                m_fullscreenState = true;
+                emit windowFullscreenChanged(true);
+            }
+            return;
+        }
+    }
+
+    if (m_fullscreenState) {
+        m_fullscreenState = false;
+        emit windowFullscreenChanged(false);
     }
 }
 }
-

--- a/panels/dock/taskmanager/treelandwindowmonitor.h
+++ b/panels/dock/taskmanager/treelandwindowmonitor.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -82,6 +82,7 @@ private Q_SLOTS:
 
     void handleForeignToplevelHandleAdded();
     void handleForeignToplevelHandleRemoved();
+    void updateFullscreenState();
 
 private:
     QHash<ulong, QSharedPointer<TreeLandWindow>> m_windows;


### PR DESCRIPTION
Remove the emission of stateChanged signal in TreeLandWindow destructor
to prevent accessing partially destroyed objects. Refactor fullscreen
state update logic into a dedicated method called from multiple
locations (clear, handle remove) instead of using lambda connections.
Added updateFullscreenState call in clear() to maintain correct state
when all windows are removed.

Log: Fixed crash when TreeLandWindow is destroyed under treeland

Influence:
1. Test window management operations under treeland (open/close/
maximize/minimize)
2. Verify fullscreen state detection works correctly
3. Test rapid window creation and destruction
4. Test dock visibility changes during fullscreen transitions

fix: 修复treeland下TreeLandWindow析构时偶发崩溃

移除TreeLandWindow析构函数中的stateChanged信号发射，避免访问已部分析构的
对象。将全屏状态更新逻辑重构为专用方法，在clear()和handle remove等多个位
置调用，替代lambda连接。在clear()中添加updateFullscreenState调用，确保移
除所有窗口时保持正确状态。

Log: 修复treeland下TreeLandWindow析构时的崩溃问题

Influence:
1. 在treeland环境下测试窗口管理操作（打开/关闭/最大化/最小化）
2. 验证全屏状态检测功能正常工作
3. 测试窗口的快速创建和销毁场景
4. 测试全屏切换过程中dock可见性变化

## Summary by Sourcery

Resolve treeland window destruction crash by decoupling fullscreen state tracking from window lifetime and centralizing fullscreen updates in the monitor.

Bug Fixes:
- Prevent occasional crashes when TreeLandWindow objects are destroyed under treeland by avoiding stateChanged emissions during destruction.

Enhancements:
- Centralize fullscreen state detection into TreeLandWindowMonitor::updateFullscreenState and reuse it from window add/remove and clear paths to keep dock fullscreen state in sync.