### PR TITLE
feat: add libdde-shell-dock package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -54,11 +54,25 @@ Multi-Arch: same
 Description: DDE Shell library
  DDE Shell is a plugin system that integrates plugins developed based on this plugin system into DDE.
 
+Package: libdde-shell-dock
+Architecture: any
+Depends:
+ ${misc:Depends},
+ ${shlibs:Depends},
+Breaks:
+ libdde-shell-dock-dev (<< 2.0.39),
+Replaces:
+ libdde-shell-dock-dev (<< 2.0.39),
+Multi-Arch: same
+Description: DDE Shell dock library
+ DDE Shell Dock is a library for dock item info.
+
 Package: dde-shell
 Architecture: any
 Depends:
  dde-tray-loader (>= 1.99.8),
  libdde-shell (= ${binary:Version}),
+ libdde-shell-dock (= ${binary:Version}),
  libdtk6declarative,
  libqt6sql6-sqlite,
  libqt6svg6,
@@ -102,6 +116,7 @@ Description: DDE Shell devel library
 Package: libdde-shell-dock-dev
 Architecture: any
 Depends:
+ libdde-shell-dock (= ${binary:Version}),
  libdde-shell-dev (= ${binary:Version}),
  qt6-base-dev,
  qt6-declarative-dev,

--- a/debian/libdde-shell-dock-dev.install
+++ b/debian/libdde-shell-dock-dev.install
@@ -1,3 +1,3 @@
 usr/include/dde-shell/dock/*.h
-usr/lib/*/libdde-shell-dock.so*
+usr/lib/*/libdde-shell-dock.so
 usr/lib/*/cmake/DDEShellDock/*.cmake

--- a/debian/libdde-shell-dock.install
+++ b/debian/libdde-shell-dock.install
@@ -1,0 +1,1 @@
+usr/lib/*/libdde-shell-dock.so*

--- a/debian/libdde-shell-dock.install
+++ b/debian/libdde-shell-dock.install
@@ -1,1 +1,1 @@
-usr/lib/*/libdde-shell-dock.so*
+usr/lib/*/libdde-shell-dock.so.*


### PR DESCRIPTION
## Summary by Sourcery

Add Debian packaging for the libdde-shell-dock runtime library and update the corresponding -dev package.

New Features:
- Introduce a libdde-shell-dock binary package to distribute the runtime library.

Build:
- Update debian/control and install manifests to define and install files for the libdde-shell-dock and libdde-shell-dock-dev packages.