### PR TITLE
fix: fix icon scale reset during attention animation

### DIFF
--- a/panels/dock/taskmanager/package/AppItem.qml
+++ b/panels/dock/taskmanager/package/AppItem.qml
@@ -305,7 +305,9 @@ Item {
             active: root.attention && !Panel.rootObject.isDragging && TaskManager.showAttentionAnimation 
             onActiveChanged: {
                 if (!active) {
-                    icon.scale = 1.0
+                    Qt.callLater(function() {
+                        icon.scale = 1.0
+                    })
                 }
             }
             sourceComponent: Repeater {


### PR DESCRIPTION
Use Qt.callLater to safely reset icon scale when attention animation deactivates. This prevents potential race conditions or binding loops that could occur when directly resetting the scale property in the onActiveChanged handler.

Log: Fixed icon scale reset behavior during attention animation

Influence:
1. Test attention animation activation and deactivation sequence
2. Verify icon scale correctly resets to 1.0 after animation ends
3. Ensure no visual glitches or delayed scale updates
4. Test dragging behavior does not interfere with scale reset

fix: 修复注意动画期间图标缩放重置问题

在注意动画停用时使用 Qt.callLater 安全地重置图标缩放。避免在
onActiveChanged 处理器中直接重置 scale 属性时可能出现的竞态条件或绑定循
环问题。

Log: 修复注意动画过程中的图标缩放重置逻辑

Influence:
1. 测试注意动画的激活和停用序列
2. 验证动画结束后图标缩放正确重置为 1.0
3. 确保没有视觉异常或缩放更新延迟
4. 测试拖动行为不影响缩放重置

PMS: TASK-389209
## Summary by Sourcery

Bug Fixes:
- Fix icon scale not reliably resetting to 1.0 when the attention animation deactivates, especially during interactions like dragging.
