### PR TITLE
fix: keep dock visible during multitask view

### DIFF
--- a/panels/dock/dockhelper.cpp
+++ b/panels/dock/dockhelper.cpp
@@ -7,6 +7,7 @@
 #include "dockpanel.h"
 
 #include <QGuiApplication>
+#include <QDBusConnection>
 
 namespace dock
 {
@@ -39,6 +40,13 @@ DockHelper::DockHelper(DockPanel *parent)
 
     connect(m_hideTimer, &QTimer::timeout, this, &DockHelper::checkNeedHideOrNot);
     connect(m_showTimer, &QTimer::timeout, this, &DockHelper::checkNeedShowOrNot);
+
+    QDBusConnection::sessionBus().connect(QString(),
+                                          QStringLiteral("/KWin"),
+                                          QStringLiteral("org.kde.KWin"),
+                                          QStringLiteral("MultitaskStateChanged"),
+                                          this,
+                                          SLOT(onMultitaskStateChanged(bool)));
 
     connect(this, &DockHelper::isWindowOverlapChanged, this, [this](bool overlap) {
         if (overlap) {
@@ -220,6 +228,10 @@ void DockHelper::checkNeedHideOrNot()
         needHide &= !show;
     }    
 
+    if (m_inMultitaskView) {
+        needHide = false;
+    }
+
     if (needHide)
         parent()->setHideState(Hide);
 }
@@ -249,8 +261,24 @@ void DockHelper::checkNeedShowOrNot()
         needShow |= enter;
     }
 
+    if (m_inMultitaskView) {
+        needShow = true;
+    }
+
     if (needShow)
         parent()->setHideState(Show);
+}
+
+void DockHelper::onMultitaskStateChanged(bool inMultitask)
+{
+    if (m_inMultitaskView != inMultitask) {
+        m_inMultitaskView = inMultitask;
+        if (m_inMultitaskView) {
+            checkNeedShowOrNot();
+        } else {
+            checkNeedHideOrNot();
+        }
+    }
 }
 
 DockPanel* DockHelper::parent()

--- a/panels/dock/dockhelper.h
+++ b/panels/dock/dockhelper.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -42,11 +42,13 @@ private:
 public Q_SLOTS:
     void checkNeedHideOrNot();
     void checkNeedShowOrNot();
+    void onMultitaskStateChanged(bool inMultitask);
 
 private:
     void initAreas();
 
 private:
+    bool m_inMultitaskView = false;
     QHash<QScreen *, DockWakeUpArea *> m_areas;
     QHash<QWindow *, bool> m_enters;
     QHash<QWindow *, bool> m_transientChildShows;


### PR DESCRIPTION
1. Add DBus connection to listen for KWin multitask state changes (org.kde.KWin.MultitaskStateChanged signal)
2. Track multitask view state with m_inMultitaskView member variable
3. Override auto-hide behavior to show dock when entering multitask view
4. Ensure dock remains visible during multitask view and properly checks show/hide state when exiting

Log: Fixed dock auto-hide behavior during multitask view

Influence:
1. Test entering and exiting multitask view with dock auto-hide enabled
2. Verify dock remains visible during multitask view
3. Confirm dock returns to normal auto-hide behavior after exiting multitask view
4. Test multiple transitions between normal and multitask views
5. Verify no regression in dock auto-hide under normal conditions

fix: 在多任务视图下保持任务栏可见

1. 添加 DBus 连接监听 KWin 多任务状态变化 （org.kde.KWin.MultitaskStateChanged 信号）
2. 使用 m_inMultitaskView 成员变量跟踪多任务视图状态
3. 重写自动隐藏行为，进入多任务视图时显示任务栏
4. 确保在多任务视图中任务栏保持可见，退出时正确检查显示/隐藏状态

Log: 修复多任务视图下任务栏自动隐藏问题

Influence:
1. 测试启用任务栏自动隐藏时进入和退出多任务视图
2. 验证在多任务视图下任务栏保持可见
3. 确认退出多任务视图后任务栏恢复正常自动隐藏行为
4. 测试正常视图和多任务视图之间的多次切换
5. 验证正常情况下任务栏自动隐藏功能没有回归

PMS: BUG-312371

## Summary by Sourcery

Bug Fixes:
- Prevent the dock from auto-hiding while KWin multitask view is active by tracking multitask state and overriding hide/show decisions accordingly.