### PR TITLE
feat(dock): pass launch_type when launching apps from taskbar

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Maintainer: Deepin Packages Builder <packages@deepin.com>
 Build-Depends:
  debhelper-compat (= 13),
  cmake,
- dde-application-manager-api (>= 1.2.48),
+ dde-application-manager-api (>> 1.2.51),
  dde-api-dev (>> 6.0.39),
  dde-tray-loader-dev (> 2.0.24),
  extra-cmake-modules,

--- a/panels/dock/taskmanager/CMakeLists.txt
+++ b/panels/dock/taskmanager/CMakeLists.txt
@@ -107,6 +107,7 @@ if (HAVE_DDE_API_EVENTLOGGER)
     target_link_libraries(dock-taskmanager PRIVATE DDEAPI::EventLogger)
 endif()
 
+
 if (BUILD_WITH_X11)
     target_compile_definitions(dock-taskmanager PRIVATE BUILD_WITH_X11=)
     pkg_check_modules(TaskmanagerXcb REQUIRED IMPORTED_TARGET xcb xcb-res xcb-ewmh xcb-icccm)

--- a/panels/dock/taskmanager/desktopfileamparser.cpp
+++ b/panels/dock/taskmanager/desktopfileamparser.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -194,7 +194,7 @@ void DesktopFileAMParser::launchWithAction(const QString& action)
 
 void DesktopFileAMParser::launchWithUrls(const QStringList & urls)
 {
-    m_applicationInterface->Launch(QString(), urls, QVariantMap());
+    m_applicationInterface->Launch(QString(), urls, QVariantMap{{QStringLiteral("_launch_type"), QStringLiteral("dde-shell")}});
 }
 
 void DesktopFileAMParser::requestQuit()
@@ -222,7 +222,11 @@ void DesktopFileAMParser::launchByAMTool(const QString &action)
     QProcess process;
     const auto path = m_applicationInterface->path();
     process.setProcessChannelMode(QProcess::MergedChannels);
+#ifdef HAVE_DDE_API_EVENTLOGGER
+    process.start("dde-am", {"--by-user", "--launch-type", "dde-shell", path, action});
+#else
     process.start("dde-am", {"--by-user", path, action});
+#endif
     if (!process.waitForFinished()) {
         qWarning() << "Failed to launch the path:" << path << process.errorString();
         return;

--- a/panels/dock/taskmanager/dockglobalelementmodel.cpp
+++ b/panels/dock/taskmanager/dockglobalelementmodel.cpp
@@ -443,7 +443,11 @@ void DockGlobalElementModel::requestNewInstance(const QModelIndex &index, const 
     } else {
         QProcess process;
         process.setProcessChannelMode(QProcess::MergedChannels);
+#ifdef HAVE_DDE_API_EVENTLOGGER
+        process.start("dde-am", {"--by-user", "--launch-type", "dde-shell", id, action});
+#else
         process.start("dde-am", {"--by-user", id, action});
+#endif
         process.waitForFinished();
     }
 }
@@ -463,7 +467,7 @@ void DockGlobalElementModel::requestOpenUrls(const QModelIndex &index, const QLi
     Application appInterface(QStringLiteral("org.desktopspec.ApplicationManager1"), dbusPath, QDBusConnection::sessionBus());
 
     if (appInterface.isValid()) {
-        appInterface.Launch(QString(), urlStrings, QVariantMap());
+        appInterface.Launch(QString(), urlStrings, QVariantMap{{QStringLiteral("_launch_type"), QStringLiteral("dde-shell")}});
     }
 }
 

--- a/panels/dock/taskmanager/dockgroupmodel.cpp
+++ b/panels/dock/taskmanager/dockgroupmodel.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -206,7 +206,11 @@ void DockGroupModel::requestNewInstance(const QModelIndex &index, const QString 
         auto desktopId = index.data(TaskManager::DesktopIdRole).toString();
         QProcess process;
         process.setProcessChannelMode(QProcess::MergedChannels);
+#ifdef HAVE_DDE_API_EVENTLOGGER
+        process.start("dde-am", {"--by-user", "--launch-type", "dde-shell", desktopId, action});
+#else
         process.start("dde-am", {"--by-user", desktopId, action});
+#endif
         process.waitForFinished();
         return;
     }


### PR DESCRIPTION
任务栏启动应用时传入 launch_type 参数，用于应用启动埋点统计。
launch_type=2 表示从任务栏快捷启动。涵盖直接 DBus 调用
和 dde-am CLI 两种启动路径。

Pass launch_type parameter when launching applications from taskbar for application launch event reporting. launch_type=2 indicates the app was launched from the taskbar. Covers both direct DBus calls and dde-am CLI launch paths.

PMS: TASK-388657