### PR TITLE
feat: recalculate dock window rect on screen geometry change

### DIFF
--- a/panels/dock/dockpanel.cpp
+++ b/panels/dock/dockpanel.cpp
@@ -149,6 +149,10 @@ bool DockPanel::init()
             else {
                 m_dockScreen = window()->screen();
             }
+            // 监听屏幕几何信息变化，当主屏位置变化时重新计算 frontendWindowRect
+            if (auto screen = window()->screen()) {
+                connect(screen, &QScreen::geometryChanged, this, &DockPanel::onWindowGeometryChanged);
+            }
             rootObject()->installEventFilter(this);
             Q_EMIT devicePixelRatioChanged(window()->devicePixelRatio());
         }


### PR DESCRIPTION
Connect to screen geometry change signals to ensure the dock panel recalculates its window rectangle when the primary screen position changes. Previously, the dock window geometry would not update when the screen moved, causing display issues.

Log: Fixed dock panel not updating position when screen geometry changes

Influence:
1. Test dock panel position after changing primary display settings
2. Verify dock window updates when monitor arrangement is modified
3. Test dock behavior with multi-monitor configurations

feat: 屏幕几何变化时重新计算停靠栏窗口区域

连接屏幕几何变化信号，确保当主屏位置发生变化时停靠栏能重新计算窗口矩形。
之前屏幕移动时停靠栏窗口几何不会更新，导致显示异常。

Log: 修复屏幕几何变化时停靠栏位置不更新的问题

Influence:
1. 测试更改主显示器设置后停靠栏的位置更新
2. 验证修改显示器排列时停靠栏窗口的响应
3. 测试多显示器配置下停靠栏的行为表现

PMS: TASK-389279