### PR TITLE
fix: ensure minimum OSD window size to prevent zero-size protocol error

### DIFF
--- a/panels/notification/osd/package/main.qml
+++ b/panels/notification/osd/package/main.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -40,8 +40,8 @@ Window {
         root.screen = Qt.binding(function () { return Qt.application.screens[0]})
     }
 
-    width: osdView ? osdView.width : 100
-    height: osdView ? osdView.height : 100
+    width: Math.max(osdView?.width ?? 0, 60)
+    height: Math.max(osdView?.height ?? 0, 60)
 
     property Item osdView
     property bool isSingleView: false
@@ -97,3 +97,4 @@ Window {
         }
     }
 }
+


### PR DESCRIPTION
Use Math.max to enforce a minimum size of 60px for OSD window width and height when osdView is null or has zero dimensions, preventing Wayland protocol errors caused by zero-size windows.

Log: Fixed OSD window width=0 protocol error by enforcing minimum size

Influence:
1. Test OSD notifications display correctly with various content sizes
2. Verify no Wayland protocol error when osdView dimensions are zero
3. Test OSD window positioning and display under different screen configurations

fix: 确保 OSD 窗口最小尺寸以防止零尺寸协议错误

使用 Math.max 为 OSD 窗口的宽度和高度设置 60px 的最小尺寸限制，当
osdView 为空或尺寸为零时防止因零尺寸窗口导致的 Wayland 协议错误。

Log: 修复 OSD 窗口 width=0 协议错误，强制设置最小尺寸

Influence:
1. 测试不同内容大小下 OSD 通知的正常显示
2. 验证 osdView 尺寸为零时不会出现 Wayland 协议错误
3. 测试不同屏幕配置下 OSD 窗口的定位和显示

PMS: BUG-344893