### PR TITLE
fix: correct relative time format for yesterday

### DIFF
--- a/panels/notification/common/notifyentity.cpp
+++ b/panels/notification/common/notifyentity.cpp
@@ -405,7 +405,7 @@ QString NotifyEntity::formatRelativeTime(qint64 ctimeMs)
             return toQString(result);
         }
     } else if (elapsedDay >= 1 && elapsedDay < 2) {
-        formatter->format(1, UDAT_DIRECTION_LAST, UDAT_RELATIVE_DAYS, result, status);
+        formatter->format(UDAT_DIRECTION_LAST, UDAT_ABSOLUTE_DAY, result, status);
         UnicodeString combinedString;
         UErrorCode timeStatus = U_ZERO_ERROR;
         SimpleDateFormat timeFormatter("HH:mm", icu::Locale::getDefault(), timeStatus);


### PR DESCRIPTION
1. Use UDAT_ABSOLUTE_DAY instead of UDAT_DIRECTION_LAST + UDAT_RELATIVE_DAYS
2. Remove the redundant numeric argument that was passed to formatter->format()
3. Ensure the ICU API call matches the correct overload for absolute day formatting

Log: Fix yesterday's relative time formatting by using correct ICU API arguments

fix: 修复"昨天"相对时间格式错误

1. 使用 UDAT_ABSOLUTE_DAY 替换 UDAT_DIRECTION_LAST + UDAT_RELATIVE_DAYS
2. 移除传递给 formatter->format() 的多余数值参数
3. 确保 ICU API 调用匹配绝对日期格式的正确重载

Log: 修复昨天相对时间格式化问题，使用正确的 ICU API 参数
PMS: BUG-359117

## Summary by Sourcery

Bug Fixes:
- Correct yesterday relative time formatting by using the absolute day ICU formatter overload instead of a relative days formatter with a numeric argument.