### PR TITLE
fix(dock): fix premature icon label compression in taskbar

### DIFF
--- a/panels/dock/package/main.qml
+++ b/panels/dock/package/main.qml
@@ -27,7 +27,7 @@ Window {
             
         let otherOccupied = 0;
         if (otherCount > 0) {
-            otherOccupied = otherCount * dockItemMaxSize + otherCount * spacing;
+            otherOccupied = otherCount * dockItemIconSize + otherCount * spacing;
         }
 
         if (useColumnLayout) {

--- a/panels/dock/taskmanager/package/AppItem.qml
+++ b/panels/dock/taskmanager/package/AppItem.qml
@@ -38,7 +38,7 @@ Item {
     Drag.mimeData: { "text/x-dde-dock-dnd-appid": itemId, "text/x-dde-dock-dnd-source": "taskbar", "text/x-dde-dock-dnd-winid": windows.length > 0 ? windows[0] : ""}
     
     property bool useColumnLayout: Panel.rootObject.useColumnLayout
-    property int iconSize: Panel.rootObject.dockItemMaxSize * 9 / 14
+    property real iconSize: Panel.rootObject.dockItemMaxSize * 9 / 14
     property bool enableTitle: false
     property bool titleActive: enableTitle && titleLoader.active
     property var iconGlobalPoint: {

--- a/panels/dock/taskmanager/package/TaskManager.qml
+++ b/panels/dock/taskmanager/package/TaskManager.qml
@@ -62,8 +62,8 @@ ContainmentItem {
         dataModel: taskmanager.Applet.dataModel
         iconSize: Panel.rootObject.dockItemMaxSize * 9 / 14
         spacing: appContainer.spacing
-        cellSize: visualModel.cellWidth
-        itemPadding: taskmanager.appTitleSpacing
+        cellSize: textCalculator.iconSize
+        itemPadding: Math.round(textCalculator.iconSize / 8)
         remainingSpace: taskmanager.remainingSpacesForTaskManager
         font.family: D.DTK.fontManager.t6.family
         font.pixelSize: Math.max(10, Math.min(20, Math.round(textCalculator.iconSize * 0.35)))
@@ -132,24 +132,8 @@ ContainmentItem {
                 Behavior on opacity { NumberAnimation { duration: 200 } }
                 Behavior on scale { NumberAnimation { duration: 200 } }
 
-                implicitWidth: {
-                    let targetW = useColumnLayout ? taskmanager.implicitWidth : appItem.implicitWidth;
-                    if (useColumnLayout || visualModel.count <= 0) return targetW;
-                    
-                    let totalSpacing = Math.max(0, visualModel.count - 1) * taskmanager.appTitleSpacing;
-                    let availableW = taskmanager.remainingSpacesForTaskManager - totalSpacing;
-                    let maxW = availableW / visualModel.count;
-                    return Math.min(targetW, Math.max(1, maxW));
-                }
-                implicitHeight: {
-                    let targetH = useColumnLayout ? visualModel.cellWidth : taskmanager.implicitHeight;
-                    if (!useColumnLayout || visualModel.count <= 0) return targetH;
-                    
-                    let totalSpacing = Math.max(0, visualModel.count - 1) * taskmanager.appTitleSpacing;
-                    let availableH = taskmanager.remainingSpacesForTaskManager - totalSpacing;
-                    let maxH = availableH / visualModel.count;
-                    return Math.min(targetH, Math.max(1, maxH));
-                }
+                implicitWidth: useColumnLayout ? taskmanager.implicitWidth : appItem.implicitWidth
+                implicitHeight: useColumnLayout ? visualModel.cellWidth : taskmanager.implicitHeight
 
                 property int visualIndex: DelegateModel.itemsIndex
                 property var modelIndex: visualModel.modelIndex(index)


### PR DESCRIPTION
Use iconSize instead of maxSize to calculate other items' occupied space, and remove overly aggressive implicit size constraints that shrink task items before the taskbar is actually full.

使用图标尺寸而非最大尺寸计算其他项占用空间，移除过度限制
隐式大小的约束，避免任务栏未满时就开始压缩图标标签。

Log: 修复任务栏未满时图标标签被过早压缩的问题
PMS: 358915
Influence: 1.打开多个应用时，任务栏要占满时再开始挤压应用标签；2.相邻应用标签的文案和背景不重叠；3.应用程序过多时，应用图标会溢出任务栏中间区域，后期考虑溢出处理方案。

## Summary by Sourcery

Adjust dock taskbar layout calculations to prevent premature compression of app labels and ensure space is based on actual icon sizes.

Bug Fixes:
- Base task label cell size and padding on the calculated icon size to avoid early text squeezing.
- Remove overly aggressive implicit size constraints on task items so they only shrink when the taskbar is actually full.
- Use the actual dock item icon size, rather than the maximum size, when computing other items' occupied space in the dock.

Enhancements:
- Align task item icon size handling by switching the AppItem iconSize property to a real value for more precise layout calculations.