### PR TITLE
chore: update changelog to 2.0.41

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-shell (2.0.41) unstable; urgency=medium
+
+  * fix(dock): fix premature icon label compression in taskbar
+
+ -- zhangkun <zhangkun2@uniontech.com>  Thu, 14 May 2026 20:03:22 +0800
+
 dde-shell (2.0.40) unstable; urgency=medium
 
   * feat(dock): pass launch_type when launching apps from taskbar


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 2.0.41

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 2.0.41
- 目标分支: master

## Summary by Sourcery

Chores:
- Bump recorded package version to 2.0.41 in debian/changelog.