### PR TITLE
fix(dock): debounce tray plugin list logging to ensure stable state

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Maintainer: Deepin Packages Builder <packages@deepin.com>
 Build-Depends:
  debhelper-compat (= 13),
  cmake,
- dde-application-manager-api (>> 1.2.51),
+ dde-application-manager-api (>= 1.2.48),
  dde-api-dev (>> 6.0.39),
  dde-tray-loader-dev (> 2.0.24),
  extra-cmake-modules,
@@ -82,6 +82,7 @@ Depends:
  qml6-module-qtquick-layouts,
  qml6-module-qtquick-window,
  qt6-wayland (>= 6.8),
+ dde-application-manager (>> 1.2.51),
  ${misc:Depends},
  ${shlibs:Depends},
 Breaks:

--- a/panels/dock/dockdbusproxy.cpp
+++ b/panels/dock/dockdbusproxy.cpp
@@ -81,7 +81,8 @@ DockDBusProxy::DockDBusProxy(DockPanel* parent)
             timer->stop();
             timer->deleteLater();
             connect(m_trayApplet, SIGNAL(pluginsChanged()), this, SIGNAL(pluginsChanged()));
-            QTimer::singleShot(3000, this, [this]() {
+            // Log the initial plugin list after 30s delay to ensure the list has fully loaded
+            QTimer::singleShot(30000, this, [this]() {
                 logInitialPluginState();
             });
         }


### PR DESCRIPTION
Replace fixed 3-second delay with debounce mechanism for tray plugin list event logging. The original approach reported plugin state immediately upon tray applet connection and again after a fixed 3-second delay, which could capture incomplete plugin lists during login.

Use a 2-second debounce timer that resets on each
pluginsChanged signal, ensuring the log only records the final stable plugin list. Also adjust dde-application- manager packaging dependencies.

将托盘插件列表事件上报从固定3秒延迟改为防抖机制。
原始方案在托盘小程序连接后立即上报并延迟3秒再报一次，
在登录时可能捕获到不完整的插件列表。
改用2秒防抖定时器，每次插件列表变化时重置，
确保只记录最终稳定的插件列表。同时调整
dde-application-manager 打包依赖。

PMS: BUG-361067

PS: 打包依赖是dde-am修改的时候，依赖调整，如果需要单独提pr就comment一下。调整pr原因：
版本号来源：https://github.com/linuxdeepin/dde-application-manager/pull/354
依赖修改对应pr：https://github.com/linuxdeepin/dde-shell/pull/1590

## Summary by Sourcery

Debounce logging of the dock tray plugin list so it records only the final stable state after plugin changes.

Bug Fixes:
- Avoid logging incomplete tray plugin lists during startup by deferring logging until the plugin state stabilizes.

Enhancements:
- Introduce a reusable debounced timer in the dock DBus proxy to trigger delayed plugin state logging instead of a fixed single-shot delay.

Build:
- Adjust dde-application-manager packaging dependencies in the Debian control file.