### PR TITLE
feat: add attention state support for treeland task manager

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -40,7 +40,7 @@ Build-Depends:
  qt6-wayland-dev-tools,
  qt6-wayland-private-dev,
  systemd,
- treeland-protocols,
+ treeland-protocols (>= 0.5.7),
  wayland-protocols,
 Standards-Version: 4.6.2
 Homepage: https://github.com/linuxdeepin/dde-shell

--- a/panels/dock/taskmanager/treelandwindow.cpp
+++ b/panels/dock/taskmanager/treelandwindow.cpp
@@ -17,7 +17,7 @@ Q_LOGGING_CATEGORY(waylandwindowLog, "org.deepin.dde.shell.dock.taskmanager.tree
 
 namespace dock {
 ForeignToplevelHandle::ForeignToplevelHandle(struct ::treeland_foreign_toplevel_handle_v1 *object)
-    : QWaylandClientExtensionTemplate<ForeignToplevelHandle>(1)
+    : QWaylandClientExtensionTemplate<ForeignToplevelHandle>(2)
     , QtWayland::treeland_foreign_toplevel_handle_v1(object)
     , m_pid(0)
     , m_isReady(false)
@@ -174,7 +174,7 @@ bool TreeLandWindow::allowClose()
 
 bool TreeLandWindow::isAttention()
 {
-    return false;
+    return m_foreignToplevelHandle->state().contains(Attention);
 }
 
 void TreeLandWindow::close()

--- a/panels/dock/taskmanager/treelandwindow.h
+++ b/panels/dock/taskmanager/treelandwindow.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -67,7 +67,8 @@ class TreeLandWindow : public AbstractWindow
         Active      = QtWayland::treeland_foreign_toplevel_handle_v1::state_activated,
         Maximized   = QtWayland::treeland_foreign_toplevel_handle_v1::state_maximized,
         Minimized   = QtWayland::treeland_foreign_toplevel_handle_v1::state_minimized,
-        Fullscreen  = QtWayland::treeland_foreign_toplevel_handle_v1::state_fullscreen
+        Fullscreen  = QtWayland::treeland_foreign_toplevel_handle_v1::state_fullscreen,
+        Attention   = QtWayland::treeland_foreign_toplevel_handle_v1::state_attention
     };
 
 public:

--- a/panels/dock/taskmanager/treelandwindowmonitor.cpp
+++ b/panels/dock/taskmanager/treelandwindowmonitor.cpp
@@ -19,7 +19,7 @@
 
 namespace dock {
 ForeignToplevelManager::ForeignToplevelManager(TreeLandWindowMonitor* monitor)
-    : QWaylandClientExtensionTemplate<ForeignToplevelManager>(1)
+    : QWaylandClientExtensionTemplate<ForeignToplevelManager>(2)
     , m_monitor(monitor)
 {
 }


### PR DESCRIPTION
1. Bump treeland-protocols dependency to version > 0.5.7 to ensure
protocol compatibility
2. Use local protocol XML file instead of system-installed one for
easier development and stability
3. Add Attention state handling to TreeLandWindow, enabling taskbar to
reflect window attention state
4. Update wayland extension versions to v2 for both
ForeignToplevelHandle and ForeignToplevelManager to utilize new protocol
features
5. Implement isAttention() method to check attention state from foreign
toplevel handle

Log: Taskbar now supports treeland window attention state display

Influence:
1. Test taskbar window entries show attention state (e.g., flashing/
urgent) when window requests attention
2. Verify normal window behavior without attention state remains
unchanged
3. Test with treeland compositor version > 0.5.7 to ensure protocol
compatibility
4. Verify backward compatibility with older treeland versions (if
applicable)
5. Test attention state reset when window gains focus or user interacts
with taskbar entry

feat: 为treeland任务管理器添加注意力状态支持

1. 将treeland-protocols依赖提升至>0.5.7版本以确保协议兼容性
2. 使用本地协议XML文件替代系统安装的协议文件，便于开发和保持稳定性
3. 为TreeLandWindow添加注意力状态处理，使任务栏能够反映窗口的注意力请求
4. 将ForeignToplevelHandle和ForeignToplevelManager的wayland扩展版本更新
至v2，以利用新协议特性
5. 实现isAttention()方法，从foreign toplevel handle中检查注意力状态

Log: 任务栏现在支持treeland窗口注意力状态显示

Influence:
1. 测试任务栏窗口条目在窗口请求注意力时显示注意力状态（如闪烁/紧急状态）
2. 验证无注意力状态的窗口行为保持不变
3. 使用treeland合成器版本>0.5.7测试，确保协议兼容性
4. 验证与旧版本treeland的向后兼容性（如适用）
5. 测试窗口获得焦点或用户与任务栏条目交互时注意力状态重置

## Summary by Sourcery

Add support for Treeland window attention state in the dock task manager and update Treeland Wayland protocol integration.

New Features:
- Expose an attention state for Treeland windows so the task manager can reflect when a window requests attention.

Enhancements:
- Update Treeland foreign toplevel handle and manager Wayland extensions to version 2 to use newer protocol capabilities.
- Reference a local Treeland foreign toplevel manager protocol XML in the task manager build configuration for more stable protocol generation.

Build:
- Adjust CMake configuration to use a project-local Treeland protocol XML file for generating Wayland client sources.