### PR TITLE
fix: add qq.weixin work to dock window icon whitelist

### DIFF
--- a/panels/dock/taskmanager/dconfig/org.deepin.ds.dock.taskmanager.json
+++ b/panels/dock/taskmanager/dconfig/org.deepin.ds.dock.taskmanager.json
@@ -98,7 +98,7 @@
 			"visibility": "private"
 		},
 		"windowIconWhitelist": {
-			"value": ["com.tencent.wechat"],
+			"value": ["com.tencent.wechat", "com.qq.weixin.work.deepin"],
 			"serial": 0,
 			"flags": [],
 			"name": "windowIconWhitelist",


### PR DESCRIPTION
Add "com.qq.weixin.work.deepin" to the windowIconWhitelist configuration
in the taskmanager dconfig, ensuring that QChat (WeChat Work) windows
display their own icons in the dock instead of falling back to default
or generic icons. This change extends the existing whitelist for Tencent
applications, which already includes "com.tencent.wechat", to provide
a consistent icon experience for both personal WeChat and QChat Work on
the dock.

Log: Added qq.weixin Work to dock window icon whitelist

Influence:
1. Verify QChat Work windows show custom icons in the dock
2. Check that personal WeChat icon display remains unaffected
3. Test dock behavior with both applications open simultaneously
4. Ensure icon display is consistent across different workspace states

fix: 将企业微信加入Dock窗口图标白名单

在任务管理器的dconfig配置中，将"com.qq.weixin.work.deepin"加入
windowIconWhitelist，确保企业微信窗口在Dock上显示其专属图标，而
非回退至默认或通用图标。此更改扩展了已有的腾讯应用白名单（已包
含"com.tencent.wechat"），为个人微信和企业微信在Dock上提供一致的图标
体验。

Log: 新增企业微信到Dock窗口图标白名单

Influence:
1. 验证企业微信窗口在Dock上显示自定义图标
2. 检查个人微信图标显示不受影响
3. 测试两个应用同时打开时Dock的行为
4. 确保图标在不同工作区状态下显示一致

PMS: TASK-389031
