### PR TITLE
chore: update changelog to 2.0.42

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+dde-shell (2.0.42) unstable; urgency=medium
+
+  * fix: disable context menu trigger on multitask view
+  * fix(dock): extend tray plugin list logging delay to ensure stable
+    load
+  * fix: add qq.weixin work to dock window icon whitelist
+
+ -- zhangkun <zhangkun2@uniontech.com>  Wed, 20 May 2026 15:16:51 +0800
+
 dde-shell (2.0.41) unstable; urgency=medium
 
   * fix(dock): fix premature icon label compression in taskbar


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 2.0.42

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 2.0.42
- 目标分支: master

## Summary by Sourcery

Chores:
- Bump Debian changelog entry to version 2.0.42 targeting master.