### PR TITLE
fix: fallback dock theme to system settings on wayland

### DIFF
--- a/panels/dock/dockpanel.cpp
+++ b/panels/dock/dockpanel.cpp
@@ -161,8 +161,13 @@ bool DockPanel::init()
     m_theme = static_cast<ColorTheme>(Dtk::Gui::DGuiApplicationHelper::instance()->themeType());
     auto platformName = QGuiApplication::platformName();
     if (QStringLiteral("wayland") == platformName) {
-        // TODO: support get color type from wayland
         m_helper = new WaylandDockHelper(this);
+        // Fallback to DGuiApplicationHelper for theme color when wayland wallpaper color is not available.
+        // TODO: remove this when initWallpaperColorManager is re-enabled
+        QObject::connect(Dtk::Gui::DGuiApplicationHelper::instance(), &Dtk::Gui::DGuiApplicationHelper::themeTypeChanged,
+                         this, [this]() {
+            setColorTheme(static_cast<ColorTheme>(Dtk::Gui::DGuiApplicationHelper::instance()->themeType()));
+        });
     } else if (QStringLiteral("xcb") == platformName) {
         QObject::connect(Dtk::Gui::DGuiApplicationHelper::instance(), &Dtk::Gui::DGuiApplicationHelper::themeTypeChanged,
                             this, [this](){

--- a/panels/dock/waylanddockhelper.cpp
+++ b/panels/dock/waylanddockhelper.cpp
@@ -22,7 +22,6 @@ WaylandDockHelper::WaylandDockHelper(DockPanel *panel)
     , m_isCurrentActiveWindowFullscreened(false)
     , m_panel(panel)
 {
-    m_wallpaperColorManager.reset(new WallpaperColorManager(this));
     m_ddeShellManager.reset(new TreeLandDDEShellManager());
     DS_NAMESPACE::DAppletBridge bridge("org.deepin.ds.dock.taskmanager");
     if (auto applet = bridge.applet()) {
@@ -37,19 +36,6 @@ WaylandDockHelper::WaylandDockHelper(DockPanel *panel)
         }
     }
 
-    connect(m_panel, &DockPanel::rootObjectChanged, this, [this]() {
-        m_wallpaperColorManager->watchScreen(dockScreenName());
-    });
-
-    connect(m_wallpaperColorManager.get(), &WallpaperColorManager::activeChanged, this, [this]() {
-        if (m_panel->rootObject() != nullptr) {
-            m_wallpaperColorManager->watchScreen(dockScreenName());
-        }
-    });
-
-    connect(m_panel, &DockPanel::dockScreenChanged, this, [this]() {
-        m_wallpaperColorManager->watchScreen(dockScreenName());
-    });
 
     connect(m_panel, &DockPanel::positionChanged, this, &WaylandDockHelper::updateOverlapCheckerPos);
     connect(m_panel, &DockPanel::dockSizeChanged, this, &WaylandDockHelper::updateOverlapCheckerPos);
@@ -73,9 +59,6 @@ WaylandDockHelper::WaylandDockHelper(DockPanel *panel)
         }
     });
 
-    if (m_panel->rootObject() != nullptr) {
-        m_wallpaperColorManager->watchScreen(dockScreenName());
-    }
 }
 
 void WaylandDockHelper::updateOverlapCheckerPos()
@@ -145,6 +128,29 @@ void WaylandDockHelper::setCurrentActiveWindowFullscreened(bool isFullscreen)
 bool WaylandDockHelper::isWindowOverlap()
 {
     return m_isWindowOverlap;
+}
+
+void WaylandDockHelper::initWallpaperColorManager()
+{
+    m_wallpaperColorManager.reset(new WallpaperColorManager(this));
+
+    connect(m_panel, &DockPanel::rootObjectChanged, this, [this]() {
+        m_wallpaperColorManager->watchScreen(dockScreenName());
+    });
+
+    connect(m_wallpaperColorManager.get(), &WallpaperColorManager::activeChanged, this, [this]() {
+        if (m_panel->rootObject() != nullptr) {
+            m_wallpaperColorManager->watchScreen(dockScreenName());
+        }
+    });
+
+    connect(m_panel, &DockPanel::dockScreenChanged, this, [this]() {
+        m_wallpaperColorManager->watchScreen(dockScreenName());
+    });
+
+    if (m_panel->rootObject() != nullptr) {
+        m_wallpaperColorManager->watchScreen(dockScreenName());
+    }
 }
 
 void WaylandDockHelper::setDockColorTheme(const ColorTheme &theme)

--- a/panels/dock/waylanddockhelper.h
+++ b/panels/dock/waylanddockhelper.h
@@ -47,6 +47,7 @@ protected Q_SLOTS:
 
 private:
     void updateOverlapCheckerPos();
+    void initWallpaperColorManager();
 
 private:
     friend class TreeLandWindowOverlapChecker;


### PR DESCRIPTION
1. Disable WallpaperColorManager initialization in WaylandDockHelper
constructor
2. Extract wallpaper color management to a separate
initWallpaperColorManager() method
3. Connect dock theme changes to DGuiApplicationHelper themeTypeChanged
signal on Wayland
4. This ensures dock follows system theme when wallpaper color is
unavailable

Log: Dock theme on Wayland now falls back to system color settings

Influence:
1. Test dock color theme toggling between light and dark on Wayland
2. Verify dock theme syncs with system settings after change
3. Ensure no regression in dock color behavior on X11
4. Check that wallpaper color feature is cleanly disabled without errors
5. Verify dock screen changes don't trigger wallpaper color manager
calls

fix: wayland下dock暗亮色回退到系统设置

1. 禁用WaylandDockHelper构造函数中的WallpaperColorManager初始化
2. 将壁纸颜色管理提取到独立的initWallpaperColorManager()方法中
3. 在Wayland上连接dock主题变化到DGuiApplicationHelper的themeTypeChanged
信号
4. 确保壁纸颜色不可用时dock遵循系统主题

Log: Wayland下Dock主题现在回退到系统颜色设置

Influence:
1. 在Wayland上测试dock颜色主题在亮色和暗色间切换
2. 验证dock主题在系统设置更改后同步
3. 确保X11上dock颜色行为无回归
4. 检查壁纸颜色功能被干净禁用，无错误产生
5. 验证dock屏幕变化不会触发壁纸颜色管理器调用

PMS: BUG-344841

## Summary by Sourcery

Make the Wayland dock fall back to system theme settings when wallpaper-based colors are unavailable.

Bug Fixes:
- Ensure the dock color theme on Wayland tracks system light/dark theme changes when wallpaper color data is not available.

Enhancements:
- Isolate wallpaper color management into an initWallpaperColorManager() helper for future re-enablement.