### PR TITLE
fix(dock): delay plugin resident status until drag release from quick…

### DIFF
--- a/panels/dock/tray/package/TrayContainer.qml
+++ b/panels/dock/tray/package/TrayContainer.qml
@@ -191,12 +191,12 @@ Item {
             
             // 根据 ActionShowStashDelegate 的显示状态动态改变条件
             let shouldAllowDrop = showStashActionVisible ? (dropHoverIndex !== 0) : (dropHoverIndex !== -1)
-            
-            // 使用暂存机制
-            if (isStash && shouldAllowDrop) {
-                // 调用 stageDropPosition 来预览拖放位置，预留空位
+
+            if (shouldAllowDrop && (isStash || source === "quickPanel")) {
+                // 收纳区或快捷面板拖拽：使用暂存机制
                 DDT.TraySortOrderModel.stageDropPosition(surfaceId, Math.floor(currentItemIndex))
-            } else if (!isStash && shouldAllowDrop) {
+            } else if (shouldAllowDrop) {
+                // 托盘内部拖拽：使用定时器机制
                 dropTrayTimer.handleDrop = function() {
                     if (isDropped || dragExited) return
                     DDT.TraySortOrderModel.dropToDockTray(surfaceId, Math.floor(currentItemIndex), isBefore)
@@ -215,11 +215,12 @@ Item {
             let isBefore = dropIdx.isBefore
             let isStash = dropEvent.getDataAsString("text/x-dde-shell-tray-dnd-sectionType") === "stashed"
             console.log("dropped", currentItemIndex, isBefore, isStash)
-            
-            if (isStash) {
-                // 提交暂存的拖放位置
+
+            // 从收纳区或快捷中心拖拽的使用暂存机制
+            if (isStash || source === "quickPanel") {
                 DDT.TraySortOrderModel.commitStagedDrop()
             } else {
+                // 托盘内部拖拽直接提交
                 DDT.TraySortOrderModel.dropToDockTray(surfaceId, Math.floor(currentItemIndex), isBefore);
             }
             DDT.TraySortOrderModel.actionsAlwaysVisible = false
@@ -228,11 +229,6 @@ Item {
         onExited: function () {
             dragExited = true
             DDT.TraySortOrderModel.clearStagedDrop()
-            // dragging from quickPanel, entered trayContainer, but not dropped in this area
-            if (source !== "" && !isDropped) {
-                dropTrayTimer.stop()
-                DDT.TraySortOrderModel.setSurfaceVisible(surfaceId, false)
-            }
             // Hide action icons when drag leaves tray without dropping
             if (!isDropped) {
                 DDT.TraySortOrderModel.actionsAlwaysVisible = false


### PR DESCRIPTION
… panel

1. Use staging mechanism for plugins dragged from quick panel to tray
2. Only commit visibility change when mouse is released, not during drag
3. Preserve original behavior for plugins dragged within tray itself
4. Remove unnecessary setSurfaceVisible call in onExited handler

Log: Fix plugins being marked as resident during drag instead of on drop

Influence:
1. Verify plugins from quick panel are not marked resident until drop
2. Verify tray-internal plugin dragging still works correctly

fix(dock): 延迟插件驻留状态直到从快捷中心拖拽松手

1. 对从快捷中心拖拽到托盘的插件使用暂存机制
2. 仅在松手时提交可见性变更，拖拽过程中不触发
3. 保留托盘内部插件拖拽的原有行为
4. 移除 onExited 处理器中不必要的 setSurfaceVisible 调用

Log: 修复插件在拖拽过程中被标记为驻留而非松手时标记的问题

Influence:
1. 验证从快捷中心拖拽的插件在松手前不会被标记为驻留
2. 验证托盘内部插件拖拽仍然正常工作

PMS: BUG-361185