### PR TITLE
fix: correct bubble height calc on cold start

### DIFF
--- a/panels/notification/plugin/NotifyItemContent.qml
+++ b/panels/notification/plugin/NotifyItemContent.qml
@@ -202,6 +202,8 @@ NotifyItem {
                 id: appIcon
                 name: root.iconName !== "" ? root.iconName : "application-x-desktop"
                 sourceSize: Qt.size(24, 24)
+                implicitWidth: 24
+                implicitHeight: 24
                 Layout.alignment: Qt.AlignLeft | Qt.AlignTop
                 Layout.topMargin: 8
                 Layout.leftMargin: 10


### PR DESCRIPTION
1. Replace appIcon.width with appIcon.sourceSize.width for bodyText preferredWidth calculation to avoid layout dependency issues
2. Fix bubble popup position error caused by incorrect width during cold start when icon width is not yet finalized

Log: Fix incorrect bubble height calculation causing wrong popup position on cold start

fix: 修复冷启动时气泡高度计算错误

1. 将 bodyText 宽度计算中的 appIcon.width 替换为 appIcon.sourceSize.width， 避免依赖未就绪的布局宽度
2. 修复冷启动时图标宽度尚未确定导致气泡弹出位置不正确的问题

Log: 修复冷启动时气泡高度计算错误导致弹出位置偏移的问题
PMS: BUG-362143