### PR TITLE
chore: update changelog to 2.0.43

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+dde-shell (2.0.43) unstable; urgency=medium
+
+  * fix: xembed tray popup window position correction for stashed
+    container (#1608)
+  * fix: fallback dock theme to system settings on wayland
+  * feat: support move xembed window on treeland
+  * fix: handle touch outside popup on X11
+
+ -- zhangkun <zhangkun2@uniontech.com>  Thu, 28 May 2026 17:33:40 +0800
+
 dde-shell (2.0.42) unstable; urgency=medium
 
   * fix: disable context menu trigger on multitask view


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 2.0.43

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 2.0.43
- 目标分支: master

## Summary by Sourcery

Documentation:
- Refresh debian/changelog entries to document version 2.0.43.