### PR TITLE
fix: adapt control center activation for Wayland

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -82,7 +82,7 @@ Depends:
  qml6-module-qtquick-layouts,
  qml6-module-qtquick-window,
  qt6-wayland (>= 6.8),
- dde-application-manager (>> 1.2.51),
+ dde-application-manager (>> 1.2.54),
  ${misc:Depends},
  ${shlibs:Depends},
 Breaks:

--- a/panels/dock/dockpanel.cpp
+++ b/panels/dock/dockpanel.cpp
@@ -17,12 +17,14 @@
 #include "dockdaemonadaptor.h"
 #include "loadtrayplugins.h"
 
-#include <DDBusSender>
-#include <QQuickWindow>
-#include <QLoggingCategory>
-#include <QGuiApplication>
-#include <QQuickItem>
 #include <DGuiApplicationHelper>
+#include <QGuiApplication>
+#include <QLoggingCategory>
+#include <QProcess>
+#include <QQuickItem>
+#include <QQuickWindow>
+
+#include <wayland/xdgactivation.h>
 
 #ifdef HAVE_DDE_API_EVENTLOGGER
 #include <dde-api/eventlogger.hpp>
@@ -356,15 +358,23 @@ bool DockPanel::debugMode() const
 #endif
 }
 
-void DockPanel::openDockSettings() const
+void DockPanel::openDockSettings()
 {
-    DDBusSender()
-        .service(QStringLiteral("org.deepin.dde.ControlCenter1"))
-        .path(QStringLiteral("/org/deepin/dde/ControlCenter1"))
-        .interface(QStringLiteral("org.deepin.dde.ControlCenter1"))
-        .method(QStringLiteral("ShowPage"))
-        .arg(QStringLiteral("personalization/dock"))
-        .call();
+    qCDebug(dockLog) << "openDockSettings";
+    auto *activation = new ds::XdgActivation(this);
+    connect(activation, &ds::XdgActivation::tokenReady, this, [activation](const QString &token) {
+        QStringList args = {"--by-user", "org.deepin.dde.control-center"};
+        if (!token.isEmpty()) {
+            qCDebug(dockLog) << "Passing XDG_ACTIVATION_TOKEN to dde-am";
+            args << "-e" << QStringLiteral("XDG_ACTIVATION_TOKEN=") + token;
+        }
+        args << "--"
+             << "-p"
+             << "personalization/dock";
+        QProcess::startDetached("dde-am", args);
+        activation->deleteLater();
+    });
+    activation->requestToken();
 }
 
 void DockPanel::notifyDockPositionChanged(int offsetX, int offsetY)

--- a/panels/dock/dockpanel.h
+++ b/panels/dock/dockpanel.h
@@ -80,7 +80,7 @@ public:
 
     bool debugMode() const;
 
-    Q_INVOKABLE void openDockSettings() const;
+    Q_INVOKABLE void openDockSettings();
 
     Q_INVOKABLE void notifyDockPositionChanged(int offsetX, int offsetY);
     

--- a/panels/dock/tray/quickpanel/CMakeLists.txt
+++ b/panels/dock/tray/quickpanel/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+# SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -24,6 +24,8 @@ qt_add_qml_module(tray-quickpanel
 
 target_link_libraries(tray-quickpanel PRIVATE
     Dtk${DTK_VERSION_MAJOR}::Core
+    Qt${QT_VERSION_MAJOR}::Gui
+    dde-shell-frame
 )
 
 install(TARGETS tray-quickpanel DESTINATION "${QML_INSTALL_DIR}/org/deepin/ds/dock/tray/quickpanel/")

--- a/panels/dock/tray/quickpanel/quickpanelproxymodel.cpp
+++ b/panels/dock/tray/quickpanel/quickpanelproxymodel.cpp
@@ -1,13 +1,18 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "quickpanelproxymodel.h"
 
-#include <QDebug>
 #include <DConfig>
-#include <DDBusSender>
+#include <QDebug>
+#include <QLoggingCategory>
+#include <QProcess>
+
+#include <wayland/xdgactivation.h>
 DCORE_USE_NAMESPACE
+
+Q_LOGGING_CATEGORY(quickpanelLog, "org.deepin.dde.shell.dock.quickpanel")
 
 namespace dock {
 namespace {
@@ -46,12 +51,18 @@ bool QuickPanelProxyModel::isQuickPanelPopup(const QString &pluginId, const QStr
 
 void QuickPanelProxyModel::openSystemSettings()
 {
-    DDBusSender()
-        .service("org.deepin.dde.ControlCenter1")
-        .interface("org.deepin.dde.ControlCenter1")
-        .path("/org/deepin/dde/ControlCenter1")
-        .method(QString("Show"))
-        .call();
+    qCDebug(quickpanelLog) << "openSystemSettings";
+    auto *activation = new ds::XdgActivation(this);
+    connect(activation, &ds::XdgActivation::tokenReady, this, [activation](const QString &token) {
+        QStringList args = {"--by-user", "org.deepin.dde.control-center"};
+        if (!token.isEmpty()) {
+            qCDebug(quickpanelLog) << "Passing XDG_ACTIVATION_TOKEN to dde-am";
+            args << "-e" << QStringLiteral("XDG_ACTIVATION_TOKEN=") + token;
+        }
+        QProcess::startDetached("dde-am", args);
+        activation->deleteLater();
+    });
+    activation->requestToken();
 }
 
 QVariant QuickPanelProxyModel::data(const QModelIndex &index, int role) const

--- a/panels/notification/center/notifyaccessor.cpp
+++ b/panels/notification/center/notifyaccessor.cpp
@@ -7,14 +7,12 @@
 #include <QQmlEngine>
 #include <QGuiApplication>
 #include <QLoggingCategory>
-#include <QDBusInterface>
-#include <QDBusPendingReply>
 #include <QProcess>
-#include <QDBusReply>
 
 #include <DConfig>
 
 #include "dataaccessor.h"
+#include <wayland/xdgactivation.h>
 
 DCORE_USE_NAMESPACE
 
@@ -210,21 +208,21 @@ bool NotifyAccessor::applicationPin(const QString &appId) const
 
 void NotifyAccessor::openNotificationSetting()
 {
-    qDebug(notifyLog) << "Open notification setting";
-    QDBusMessage msg = QDBusMessage::createMethodCall("org.deepin.dde.ControlCenter1",
-                                                       "/org/deepin/dde/ControlCenter1",
-                                                       "org.deepin.dde.ControlCenter1",
-                                                       "ShowPage");
-    msg << "notification";
-    QDBusPendingCall call = QDBusConnection::sessionBus().asyncCall(msg);
-    QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(call, this);
-    connect(watcher, &QDBusPendingCallWatcher::finished, this, [this](QDBusPendingCallWatcher *self) {
-        QDBusReply<void> reply = *self;
-        if (!reply.isValid()) {
-            qWarning(notifyLog) << "Failed to open notification setting:" << reply.error().message();
+    qDebug(notifyLog) << "openNotificationSetting";
+    auto *activation = new ds::XdgActivation(this);
+    connect(activation, &ds::XdgActivation::tokenReady, this, [activation](const QString &token) {
+        QStringList args = {"--by-user", "org.deepin.dde.control-center"};
+        if (!token.isEmpty()) {
+            qDebug(notifyLog) << "Passing XDG_ACTIVATION_TOKEN to dde-am";
+            args << "-e" << QStringLiteral("XDG_ACTIVATION_TOKEN=") + token;
         }
-        self->deleteLater();
+        args << "--"
+             << "-p"
+             << "notification";
+        QProcess::startDetached("dde-am", args);
+        activation->deleteLater();
     });
+    activation->requestToken();
 }
 
 void NotifyAccessor::onNotificationStateChanged(qint64 id, int processedType)


### PR DESCRIPTION
1. Replace D-Bus direct calls with XdgActivation token-based activation
2. Use dde-application-manager (dde-am) as intermediary for Wayland
protocol
3. Pass XDG_ACTIVATION_TOKEN environment variable when token is
available
4. Update dependency to dde-application-manager >> 1.2.54 for required
features
5. Simplify notification settings opening by removing DBus async call
watcher
6. Add proper logging categories for quick panel and docking panel

Log: Activated control center in Wayland via dde-am and XdgActivation
protocol

Influence:
1. Test opening dock settings in both X11 and Wayland sessions
2. Verify notification settings opening in both display servers
3. Check quick panel system settings entry works correctly
4. Ensure activation token is properly passed when available
5. Test backward compatibility with X11 sessions (no Wayland protocol)
6. Verify dde-am is invoked with correct arguments and environment
7. Check that token cleanup (deleteLater) works properly

fix: 适配 Wayland 下激活控制中心

1. 使用 XdgActivation token 替代直接的 D-Bus 调用
2. 通过 dde-application-manager (dde-am) 作为 Wayland 协议中介
3. 在 token 可用时传递 XDG_ACTIVATION_TOKEN 环境变量
4. 更新依赖至 dde-application-manager >> 1.2.54 以支持新功能
5. 简化通知设置打开流程，移除 D-Bus 异步调用监听器
6. 为快捷面板和停靠面板添加正确的日志分类

Log: 通过 dde-am 和 XdgActivation 协议在 Wayland 下激活控制中心

Influence:
1. 在 X11 和 Wayland 会话中测试打开停靠设置
2. 验证两种显示服务器下的通知设置打开功能
3. 检查快捷面板系统设置入口是否正常工作
4. 确保 token 可用时正确传递激活令牌
5. 测试与 X11 会话的向后兼容性（无 Wayland 协议）
6. 验证 dde-am 使用正确的参数和环境变量调用
7. 检查 token 清理（deleteLater）是否正确执行

PMS: BUG-295555
