### PR TITLE
chore: update changelog to 2.0.44

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-shell (2.0.44) unstable; urgency=medium
+
+  * fix(dock): align multitask view to first app gap with app icon
+    spacing
+
+ -- zhangkun <zhangkun2@uniontech.com>  Thu, 04 Jun 2026 19:32:58 +0800
+
 dde-shell (2.0.43) unstable; urgency=medium
 
   * fix: xembed tray popup window position correction for stashed


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 2.0.44

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 2.0.44
- 目标分支: master

## Summary by Sourcery

Build:
- Bump Debian package changelog entry to version 2.0.44.