### PR TITLE
fix: fix notification text being truncated after replace

### DIFF
--- a/panels/notification/bubble/bubblemodel.cpp
+++ b/panels/notification/bubble/bubblemodel.cpp
@@ -94,8 +94,16 @@ BubbleItem *BubbleModel::replaceBubble(BubbleItem *bubble)
     Q_ASSERT(isReplaceBubble(bubble));
     const auto replaceIndex = replaceBubbleIndex(bubble);
     const auto oldBubble = m_bubbles[replaceIndex];
-    m_bubbles.replace(replaceIndex, bubble);
-    Q_EMIT dataChanged(index(replaceIndex), index(replaceIndex));
+
+    // Use remove + insert instead of dataChanged to force the view
+    // to recreate the delegate, so ListView recalculates its height.
+    beginRemoveRows(QModelIndex(), replaceIndex, replaceIndex);
+    m_bubbles.removeAt(replaceIndex);
+    endRemoveRows();
+
+    beginInsertRows(QModelIndex(), replaceIndex, replaceIndex);
+    m_bubbles.insert(replaceIndex, bubble);
+    endInsertRows();
 
     return oldBubble;
 }


### PR DESCRIPTION
Replace dataChanged signal with remove+insert row operations to force
ListView to recalculate delegate size, preventing notification content
from being clipped.

Log: Fixed notification text truncation issue after replacement

Influence:
1. Test notification replacement with various text lengths
2. Verify notification bubble height adapts to content
3. Test multiple rapid replacements for stability
4. Verify notification text is fully visible after each replace

fix: 修复通知替换后文字被截断问题

将 dataChanged 信号替换为移除+插入行操作，强制 ListView 重新计算委托大
小，防止通知内容被裁剪。

Log: 修复通知替换后文字截断问题

Influence:
1. 测试不同文本长度下的通知替换功能
2. 验证通知气泡高度能自适应内容
3. 测试多次快速替换的稳定性
4. 验证每次替换后通知文字完整可见

## Summary by Sourcery

Bug Fixes:
- Prevent notification text from being truncated after a notification item is replaced in the list view.