### PR TITLE
fix: destroy wayland proxy before cleanup to prevent use-after-free crash

### DIFF
--- a/panels/dock/taskmanager/treelandwindow.cpp
+++ b/panels/dock/taskmanager/treelandwindow.cpp
@@ -108,6 +108,7 @@ void ForeignToplevelHandle::treeland_foreign_toplevel_handle_v1_done()
 }
 void ForeignToplevelHandle::treeland_foreign_toplevel_handle_v1_closed()
 {
+    destroy();
     Q_EMIT handlerIsDeleted();
 }
 


### PR DESCRIPTION
在treeland渲染器下, 点击系统托盘(dde-tray-loader)中的Xwayland应用图标调出应用主窗口时会引发整个dde-shell (dock栏)崩溃, 该PR用于修复这个问题

Call destroy() on the treeland_foreign_toplevel_handle_v1 proxy before emitting handlerIsDeleted() to stop the compositor from sending further events to a handle scheduled for C++ destruction. Without this, pending state events could arrive after the ForeignToplevelHandle object is freed by QScopedPointer, causing a crash in m_states.append() when activating applications from the system tray.

## Summary by Sourcery

Bug Fixes:
- Destroy the treeland_foreign_toplevel_handle_v1 proxy before emitting the deletion signal to prevent use-after-free crashes triggered by pending Wayland events.