### PR TITLE
fix(dock): fix hover bottom border invisible for non-active app items

### DIFF
--- a/panels/dock/taskmanager/package/AppItemBackground.qml
+++ b/panels/dock/taskmanager/package/AppItemBackground.qml
@@ -105,14 +105,30 @@ AppletItemBackground {
         pressedDark: pressed
     }
     outsideBorderColor: Palette {
-        normal: {
-            crystal: ("transparent")
+        normal {
+            crystal: if (displayMode === Dock.Efficient) {
+                    return Qt.rgba(0, 0, 0, 0.1)
+            } else {
+                    return ("transparent")
+            }
         }
-        normalDark: normal
-        hovered : normal
+        normalDark {
+            crystal: if (displayMode === Dock.Efficient) {
+                    return Qt.rgba(0, 0, 0, 0.05)
+            } else {
+                    return ("transparent")
+            }
+        }
+        hovered {
+            crystal: Qt.rgba(0.0, 0.0, 0.0, 0.10)
+        }
         hoveredDark: hovered
-        pressed: hovered
-        pressedDark: pressed
+        pressed {
+            crystal: Qt.rgba(0.0, 0.0, 0.0, 0.10)
+        }
+        pressedDark {
+            crystal: Qt.rgba(0.0, 0.0, 0.0, 0.05)
+        }
     }
     activeOutsideBorderColor: Palette {
         normal {


### PR DESCRIPTION
When AppItemBackground overrides outsideBorderColor from the base class, the hovered state was incorrectly set to :normal, causing non-active app items to use the normal color (transparent) on hover - making the bottom border completely invisible. Unify outsideBorderColor with the same palette definition as activeOutsideBorderColor to ensure hover state has dedicated visible color values.

AppItemBackground子类覆盖基类outsideBorderColor时，hovered状态 错误地设为:normal，导致非活跃应用的hover底边使用normal色
(transparent)而完全不可见。将outsideBorderColor统一为与
activeOutsideBorderColor相同的完整palette定义，使hover态有独立的 可见颜色值。

Log: 修复任务栏非活跃应用hover底边描边不可见的问题
PMS: BUG-364205
Influence: 仅影响任务栏应用图标hover底边效果，非活跃应用hover时底边描边恢复正常显示，不影响托盘等其他组件。

## Summary by Sourcery

Bug Fixes:
- Restore visible bottom border on hover for non-active dock app items by providing specific hovered and pressed outside border colors.