### PR TITLE
fix: Build-Depends: dde-tray-loader-dev (>= 2.0.24)

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Build-Depends:
  cmake,
  dde-application-manager-api (>= 1.2.48),
  dde-api-dev (>> 6.0.39),
- dde-tray-loader-dev (> 2.0.24),
+ dde-tray-loader-dev (>> 2.0.24),
  extra-cmake-modules,
  libdtk6core-bin,
  libdtk6core-dev,


### PR DESCRIPTION
> means later or equal

## Summary by Sourcery

Build:
- Raise the Build-Depends version constraint for dde-tray-loader-dev to require at least version 2.0.24 in debian/control.