### PR TITLE
fix: fall back to Qt default drag for wayland quick panel

### DIFF
--- a/panels/dock/tray/quickpanel/DragItem.qml
+++ b/panels/dock/tray/quickpanel/DragItem.qml
@@ -28,11 +28,22 @@ Item {
         })
         dragItem.Drag.dragType = Drag.Automatic
         dragItem.Drag.supportedActions = Qt.CopyAction
+        if (Qt.platform.pluginName !== "xcb") {
+            dragItem.Drag.imageSource = Qt.binding(function () {
+                return root.draggingImage
+            })
+            dragItem.Drag.hotSpot.x = Qt.binding(function () {
+                return dragItem.width / 2
+            })
+            dragItem.Drag.hotSpot.y = Qt.binding(function () {
+                return dragItem.height / 2
+            })
+        }
         dragItem.DQuickDrag.hotSpotScale = Qt.binding(function () {
             return Qt.size(0.5, 0.5)
         })
         dragItem.DQuickDrag.active = Qt.binding(function () {
-            return dragItem.Drag.active
+            return dragItem.Drag.active && Qt.platform.pluginName === "xcb"
         })
         dragItem.DQuickDrag.overlay = Qt.binding(function () {
             return overlayWindow


### PR DESCRIPTION
In Wayland environment, the custom DQuickDrag overlay window causes
issues with the quick panel drag functionality. This change forces
DQuickDrag to be inactive on non-X11 platforms, falling back to Qt's
native drag which uses the automatic image source. Additionally, the
Drag properties (imageSource and hotSpot) are only set when not on XCB,
as Qt's automatic drag handles these correctly on Wayland.

Log: Disable custom drag overlay on Wayland for quick panel items

Influence:
1. Test quick panel item drag on X11 session to ensure custom overlay
still works
2. Test quick panel item drag on Wayland session to verify Qt default
drag works
3. Check that the drag image and hotspot are positioned correctly on
both platforms
4. Verify no visual glitches or crashes during drag operations

fix: wayland下快捷面板拖拽回退到qt默认拖拽

在wayland环境下，自定义DQuickDrag覆盖窗口会导致快捷面板拖拽功能出现问
题。此修改强制在非X11平台上禁用DQuickDrag，回退到使用自动图片源的Qt原生
拖拽。同时，Drag属性（imageSource和hotSpot）仅在不使用XCB时设置，因为Qt
的自动拖拽在wayland上能正确处理这些属性。

Log: 在wayland上禁用快捷面板项目的自定义拖拽覆盖

Influence:
1. 在X11会话中测试快捷面板项目拖拽，确保自定义覆盖仍正常工作
2. 在wayland会话中测试快捷面板项目拖拽，验证Qt默认拖拽功能正常
3. 检查两个平台下拖拽图片和热点位置是否正确
4. 验证拖拽操作过程中无视觉异常或崩溃

PMS: BUG-346735
