### PR TITLE
fix: remove appId parameter from token request

### DIFF
--- a/panels/dock/xdgactivationmanager.cpp
+++ b/panels/dock/xdgactivationmanager.cpp
@@ -121,7 +121,7 @@ void XdgActivationTokenV1::xdg_activation_token_v1_commit(Resource *resource)
 
     // Store this token as pending and request from the outer compositor
     m_manager->setPendingToken(this);
-    m_manager->requestOuterToken(m_appId);
+    m_manager->requestOuterToken({});
 }
 
 void XdgActivationTokenV1::xdg_activation_token_v1_destroy(Resource *resource)


### PR DESCRIPTION
The token request no longer requires the appId from tray-loader when
requesting an activation token from the outer compositor. This change
was made to simplify the token retrieval process, as the appId parameter
is not needed by the outer compositor for token generation in this
context.

Log: Removed unnecessary appId parameter from token request

Influence:
1. Test activation token generation and validation
2. Verify token request works without appId parameter
3. Ensure existing functionality remains intact

fix: 移除令牌请求中的 appId 参数

当从外部合成器请求激活令牌时，不再需要 tray-loader 传递的 appId。此更
改简化了令牌获取流程，因为在此上下文中，外部合成器生成令牌不需要 appId
参数。

Log: 移除令牌请求中不必要的 appId 参数

Influence:
1. 测试激活令牌的生成和验证功能
2. 验证没有 appId 参数时令牌请求是否正常
3. 确保现有功能不受影响
