### PR TITLE
fix: simulate right-click on tray item long press

### DIFF
--- a/panels/dock/DockCompositor.qml
+++ b/panels/dock/DockCompositor.qml
@@ -23,6 +23,9 @@ Item {
     function notifyXEmbedWindowMoveResult(wid, success) {
         pluginManager.notifyXEmbedWindowMoveResult(wid, success)
     }
+    function sendRightClickForSurface() {
+        pluginManager.sendRightClickForSurface()
+    }
 
     property ListModel trayPluginSurfaces: ListModel {}
     property ListModel quickPluginSurfaces: ListModel {}

--- a/panels/dock/pluginmanagerextension.cpp
+++ b/panels/dock/pluginmanagerextension.cpp
@@ -1008,3 +1008,17 @@ void PluginManager::onTextInputSurfaceEnabled(QWaylandSurface *surface)
         }
     }
 }
+
+void PluginManager::sendRightClickForSurface()
+{
+    QWaylandCompositor *compositor = qobject_cast<QWaylandCompositor *>(extensionContainer());
+    if (!compositor)
+        return;
+
+    QWaylandSeat *seat = compositor->defaultSeat();
+    if (!seat)
+        return;
+    
+    seat->sendMousePressEvent(Qt::RightButton);
+    seat->sendMouseReleaseEvent(Qt::RightButton);
+}

--- a/panels/dock/pluginmanagerextension_p.h
+++ b/panels/dock/pluginmanagerextension_p.h
@@ -73,6 +73,10 @@ public:
     // result: true = success, false = error
     Q_INVOKABLE void notifyXEmbedWindowMoveResult(uint32_t wid, bool result);
 
+    // Called from QML to synthesize a right-click (mouse press + release)
+    // on the given Wayland surface, e.g. on long press from touch input
+    Q_INVOKABLE void sendRightClickForSurface();
+
     uint32_t dockPosition() const;
     void setDockPosition(uint32_t dockPosition);
 

--- a/panels/dock/tray/ShellSurfaceItemProxy.qml
+++ b/panels/dock/tray/ShellSurfaceItemProxy.qml
@@ -52,6 +52,11 @@ Item {
         }
         TapHandler {
             id: tapHandler
+            onLongPressed: {
+                if (tapHandler.point.device.type === PointerDevice.TouchScreen) {
+                    DockCompositor.sendRightClickForSurface()
+                }
+            }
         }
 
         onVisibleChanged: function () {

--- a/panels/dock/tray/quickpanel/PanelTrayItem.qml
+++ b/panels/dock/tray/quickpanel/PanelTrayItem.qml
@@ -116,6 +116,24 @@ Control {
     MouseArea {
         id: mouseHandler
         anchors.fill: parent
-        onClicked: root.clicked()
+        onPressed: function (mouse) {
+            longPressTriggered = false
+            isTouchSource = (mouse.source !== Qt.MouseEventNotSynthesized)
+        }
+        onPressAndHold: {
+            if (isTouchSource) {
+                longPressTriggered = true
+                DockCompositor.sendRightClickForSurface()
+            }
+        }
+        onClicked: {
+            if (!longPressTriggered) {
+                root.clicked()
+            }
+            longPressTriggered = false
+        }
+
+        property bool longPressTriggered: false
+        property bool isTouchSource: false
     }
 }


### PR DESCRIPTION
1. Add sendRightClickForSurface method to synthesize right-click events via Wayland seat for tray surfaces
2. Expose shellSurface property in PluginSurface for QML access
3. Handle long press in ShellSurfaceItemProxy TapHandler to trigger right-click on tray items
4. Handle long press in PanelTrayItem MouseArea and prevent normal click from firing after long press

Log: Simulate right-click mouse events on tray items when long-pressed via touch input

fix: 托盘项长按模拟右键点击

1. 新增 sendRightClickForSurface 方法，通过 Wayland seat 向托盘 表面发送右键点击事件
2. 在 PluginSurface 中暴露 shellSurface 属性供 QML 访问
3. 在 ShellSurfaceItemProxy 的 TapHandler 中处理长按，触发 托盘项右键点击
4. 在 PanelTrayItem 的 MouseArea 中处理长按并防止长按结束后 误触发普通点击

Log: 在触控长按托盘项时模拟右键点击鼠标事件
PMS: BUG-364527