### PR TITLE
fix: Let notification center use Wayland exclusive zones

### DIFF
--- a/panels/notification/center/package/main.qml
+++ b/panels/notification/center/package/main.qml
@@ -81,6 +81,13 @@ Window {
         }
     }
 
+    function layerShellMargin(position) {
+        if (Qt.platform.pluginName === "wayland")
+            return 0
+
+        return windowMargin(position)
+    }
+
     // visible: true
     visible: Panel.visible
     flags: Qt.Tool
@@ -90,10 +97,10 @@ Window {
     // height: 800
     DLayerShellWindow.layer: DLayerShellWindow.LayerOverlay
     DLayerShellWindow.anchors: DLayerShellWindow.AnchorRight | DLayerShellWindow.AnchorTop | DLayerShellWindow.AnchorBottom
-    DLayerShellWindow.topMargin: windowMargin(0) + contentPadding
-    DLayerShellWindow.rightMargin: windowMargin(1) + contentPadding
-    DLayerShellWindow.bottomMargin: windowMargin(2) + contentPadding
-    DLayerShellWindow.exclusionZone: -1
+    DLayerShellWindow.topMargin: layerShellMargin(0) + contentPadding
+    DLayerShellWindow.rightMargin: layerShellMargin(1) + contentPadding
+    DLayerShellWindow.bottomMargin: layerShellMargin(2) + contentPadding
+    DLayerShellWindow.exclusionZone: Qt.platform.pluginName === "wayland" ? 0 : -1
     DLayerShellWindow.keyboardInteractivity: DLayerShellWindow.KeyboardInteractivityOnDemand
     palette: DTK.palette
     ColorSelector.family: Palette.CrystalColor


### PR DESCRIPTION
## Summary
- Use zero layer-shell margins for the notification center on Wayland.
- Set the notification center exclusionZone to 0 on Wayland and keep non-Wayland behavior unchanged.
- Preserve the existing windowMargin() path outside Wayland.

## Test Plan
- cmake --build /home/uos/dde-shell/dde-shell-master/build -j2
- Verified notificationcenterpanel and dde-shell build targets complete successfully on the remote test machine.
