### PR TITLE
fix: use sigkill for wayland killClient()

### DIFF
--- a/panels/dock/taskmanager/treelandwindow.cpp
+++ b/panels/dock/taskmanager/treelandwindow.cpp
@@ -7,6 +7,7 @@
 
 #include <cstdint>
 #include <sys/types.h>
+#include <signal.h>
 
 #include <QLoggingCategory>
 
@@ -203,7 +204,12 @@ void TreeLandWindow::minimize()
 
 void TreeLandWindow::killClient()
 {
-    m_foreignToplevelHandle->close();
+    const auto pid = m_foreignToplevelHandle->pid();
+    if (pid <= 0) {
+        qCWarning(waylandwindowLog()) << "Cannot find pid of window" << m_foreignToplevelHandle->appid() << m_foreignToplevelHandle->id();
+        return;
+    }
+    ::kill(pid, SIGKILL);
 }
 
 void TreeLandWindow::setWindowIconGeometry(const QWindow* baseWindow, const QRect& gemeotry)


### PR DESCRIPTION
之前 wayland 下强行停止进程的实现和关闭窗口一样,可能会导致一些程序
无法被强行停止. 现在改用使用 pid 并发送 SIGKILL 的方式强行停止进程

PMS: BUG-364201

## Summary by Sourcery

Bug Fixes:
- Ensure Wayland tasks can always be forcibly stopped by sending SIGKILL to the associated process when killClient() is invoked.