### PR TITLE
chore: update changelog to 2.0.45

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-shell (2.0.45) unstable; urgency=medium
+
+  * feat: add XdgActivation support for notifications
+
+ -- zhangkun <zhangkun2@uniontech.com>  Thu, 11 Jun 2026 19:45:36 +0800
+
 dde-shell (2.0.44) unstable; urgency=medium
 
   * fix(dock): align multitask view to first app gap with app icon


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 2.0.45

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 2.0.45
- 目标分支: master

## Summary by Sourcery

Documentation:
- Document release 2.0.45 in debian/changelog.