### PR TITLE
fix: bind taskmanager start timer to applet lifetime

### DIFF
--- a/panels/dock/taskmanager/taskmanager.cpp
+++ b/panels/dock/taskmanager/taskmanager.cpp
@@ -247,7 +247,7 @@ bool TaskManager::init()
         modifyOpacityChanged();
         connect(appearanceApplet, SIGNAL(opacityChanged()), this, SLOT(modifyOpacityChanged()));
     }
-    QTimer::singleShot(500, [this]() {
+    QTimer::singleShot(500, this, [this]() {
         if (m_windowMonitor)
             m_windowMonitor->start();
     });


### PR DESCRIPTION
## Summary
- Bind the delayed taskmanager window monitor startup to the applet lifetime.
- Prevent the single-shot callback from running after taskmanager is destroyed during dde-shell restart.

## Test plan
- cmake --build build --target dock-taskmanager

## Summary by Sourcery

Bug Fixes:
- Ensure the delayed window monitor startup timer does not fire after the taskmanager is destroyed during shell restarts.