### PR TITLE
fix: bind hover and pressed states to background

### DIFF
--- a/panels/dock/taskmanager/package/AppItem.qml
+++ b/panels/dock/taskmanager/package/AppItem.qml
@@ -97,6 +97,8 @@ Item {
             isActive: root.active
             windowCount: root.windows.length
             displayMode: root.displayMode
+            D.ColorSelector.hovered: hoverHandler.hovered
+            D.ColorSelector.pressed: mouseArea.pressed
         }
         Item {
             id: iconContainer


### PR DESCRIPTION
1. Add D.ColorSelector.hovered and D.ColorSelector.pressed properties to the app item background delegate
2. Fix taskbar app retaining selected state after long-press popup is dismissed by clicking desktop blank area

Log: fix taskbar app keeping selected state after dismissing long-press popup

fix: 绑定悬停和按下状态到背景

1. 为应用项背景委托添加 D.ColorSelector.hovered 和 D.ColorSelector.pressed 属性
2. 修复单指长按任务栏应用弹出面板后，点击桌面空白处 任务栏应用依然有选中状态的问题

Log: 修复长按弹出面板关闭后任务栏应用残留选中状态的问题
PMS: BUG-364531

## Summary by Sourcery

Bug Fixes:
- Resolve taskbar app items incorrectly remaining in a selected state after dismissing the long-press popup by clicking on the desktop.