### PR TITLE
fix(dock): align delegate implicitHeight with icon ratio for consiste…

### DIFF
--- a/panels/dock/taskmanager/package/TaskManager.qml
+++ b/panels/dock/taskmanager/package/TaskManager.qml
@@ -151,7 +151,7 @@ ContainmentItem {
                 Behavior on scale { NumberAnimation { duration: 200 } }
 
                 implicitWidth: useColumnLayout ? taskmanager.implicitWidth : appItem.implicitWidth
-                implicitHeight: useColumnLayout ? visualModel.cellWidth : taskmanager.implicitHeight
+                implicitHeight: useColumnLayout ? Panel.rootObject.dockItemMaxSize * 9 / 14 : taskmanager.implicitHeight
 
                 property int visualIndex: DelegateModel.itemsIndex
                 property var modelIndex: visualModel.modelIndex(index)


### PR DESCRIPTION
…nt spacing

Change the delegate implicitHeight in vertical layout from visualModel.cellWidth (dockItemMaxSize * 0.8) to dockItemMaxSize * 9 / 14 (icon size), so the app item uses the same size coefficient in both orientations. This ensures that the gap between adjacent apps is visually equal to the gap from the last plugin to the first app on both horizontal and vertical docks.

纵向布局时，将 delegate 隐式高度从 dockItemMaxSize * 0.8 改为
dockItemMaxSize * 9 / 14（图标尺寸），使横竖排应用项尺寸系数统一，
确保应用间距与插件到首个应用的间距在双侧布局中保持一致。

Log: 修复纵向任务栏应用间距与插件间距不一致的问题
PMS: BUG-364523

## Summary by Sourcery

Bug Fixes:
- Correct vertical dock app spacing so gaps between apps and between plugins and the first app are visually consistent.