### PR TITLE
fix: keep notification close button hoverable at the edge

### DIFF
--- a/panels/notification/bubble/package/BubbleDelegate.qml
+++ b/panels/notification/bubble/package/BubbleDelegate.qml
@@ -5,9 +5,14 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 
+import org.deepin.ds 1.0
+
 Item {
     id: delegateRoot
-    width: 360
+    width: ListView.view ? ListView.view.width : 360
+    // Close button overhang: half of 20px button height minus 2px visual offset
+    // (see NotifyItemContent.qml closePlaceHolder topMargin: -height / 2 + 2)
+    readonly property int closeButtonOverhang: 8
     property var bubble: model
     property int maxCount: 3
     // ListView 的 remove 动画执行的时候,remove Item的index会以负数的方式出现
@@ -15,10 +20,22 @@ Item {
     
     height: bubbleContent.height
     z: -realIndex
+
+    HoverHandler {
+        id: delegateHoverHandler
+        margin: delegateRoot.closeButtonOverhang
+        onHoveredChanged: {
+            Applet.setHoveredId(hovered && delegateRoot.bubble ? delegateRoot.bubble.id : 0)
+        }
+    }
+
     Bubble {
         id: bubbleContent
         width: 360
+        anchors.right: parent.right
+        anchors.rightMargin: 10
         bubble: delegateRoot.bubble
+        parentHovered: delegateHoverHandler.hovered
         
         transformOrigin: Item.Top
         

--- a/panels/notification/bubble/package/main.qml
+++ b/panels/notification/bubble/package/main.qml
@@ -91,21 +91,24 @@ Window {
 
     ListView  {
         id: bubbleView
-        width: 360
+        // Close button overhang: half of 20px button height minus 2px visual offset
+        // (see NotifyItemContent.qml closePlaceHolder topMargin: -height / 2 + 2)
+        readonly property int closeButtonOverhang: 8
+        width: root.width
         height: contentHeight
         anchors {
             right: parent.right
             bottom: parent.bottom
-            rightMargin: 10
+            rightMargin: 0
             bottomMargin: 10
         }
 
         function updateInputRegion() {
             root.DLayerShellWindow.setInputRegionRect(
                 Math.ceil(bubbleView.x),
-                Math.ceil(bubbleView.y),
-                Math.ceil(bubbleView.width), 
-                Math.ceil(Math.max(10, bubbleView.contentHeight))
+                Math.ceil(bubbleView.y - bubbleView.closeButtonOverhang),
+                Math.ceil(root.width),
+                Math.ceil(Math.max(10, bubbleView.contentHeight) + bubbleView.closeButtonOverhang)
             )
         }
         onContentHeightChanged: updateInputRegion()
@@ -168,24 +171,6 @@ Window {
 
         delegate: BubbleDelegate {
             maxCount: model.bubbleCount
-        }
-
-        HoverHandler {
-            onPointChanged: {
-                const local = point.position
-                let hoveredItem = bubbleView.itemAt(local.x, local.y)
-                if (hoveredItem && hoveredItem.bubble) {
-                    Applet.setHoveredId(hoveredItem.bubble.id)
-                } else {
-                    Applet.setHoveredId(0)
-                }
-            }
-
-            onHoveredChanged: {
-                if (!hovered) {
-                    Applet.setHoveredId(0)
-                }
-            }
         }
     }
 }


### PR DESCRIPTION
## Summary

- Extend the notification bubble input region to cover the close button area outside the card boundary.
- Add a stable close button hover state based on the outer hit area.
- Keep the notification content layout unchanged and preserve the original visual position.

## Verification

- Built locally with `export PATH="/usr/lib/icecc/bin:$PATH"` and `export LD_LIBRARY_PATH=""`.
- Deployed the generated deb packages to debug machine 10.20.9.188.
- Verified target QML md5 values on the debug machine.
- Verified the close button remains hoverable at the top-right edge.

PMS: BUG-365963
