### PR TITLE
fix: synchronize OSD selection with external window effect changes

### DIFF
--- a/panels/notification/osd/windoweffect/package/main.qml
+++ b/panels/notification/osd/windoweffect/package/main.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -32,7 +32,14 @@ AppletItem {
         enabled: match(control.Panel.osdType)
         function onVisibleChanged() {
             if (!control.Panel.visible) {
+                // OSD hidden: write selected effect type back
                 Applet.effectType = effectModel.get(selectIndex).value
+            } else {
+                // OSD shown: re-establish selectIndex binding to track current effect type.
+                // This handles the case where the binding was broken by a cyclic switch.
+                control.selectIndex = Qt.binding(function() {
+                    return indexByValue(Applet.effectType)
+                })
             }
         }
     }


### PR DESCRIPTION
1. Added else branch in windoweffect OSD update() to re-initialize selectIndex from the current Applet.effectType when the OSD is shown for the first time
2. This ensures the OSD selection always reflects the actual window effect type, even when changed externally via dde-control-center

fix: OSD窗口效果选项在外部修改后不同步

1. 在windoweffect OSD的update()函数中添加else分支
2. 当OSD首次显示时从当前Applet.effectType重新初始化selectIndex
3. 确保OSD的选中项始终反映实际的窗口效果类型，即使在控制中心 等外部途径修改后也能正确显示

PMS: BUG-365207