### PR TITLE
fix: correct dock context menu popup positioning

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -73,7 +73,7 @@ Depends:
  dde-tray-loader (>= 1.99.8),
  libdde-shell (= ${binary:Version}),
  libdde-shell-dock (= ${binary:Version}),
- libdtk6declarative,
+ libdtk6declarative (>> 6.7.44),
  libqt6sql6-sqlite,
  libqt6svg6,
  qml6-module-qt-labs-platform,

--- a/panels/dock/MenuHelper.qml
+++ b/panels/dock/MenuHelper.qml
@@ -1,31 +1,58 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 pragma Singleton
 import QtQuick
-import Qt.labs.platform
+import org.deepin.ds.dock 1.0
 
 Item {
-    property Menu activeMenu: null
+    id: root
+
+    property var activeMenu: null
     
     signal menuClosed()
     Connections {
-        target: activeMenu
+        target: root.activeMenu
         function onAboutToHide() {
-            activeMenu = null
-            menuClosed()
+            root.activeMenu = null
+            root.menuClosed()
         }
     }
-    function openMenu(menu: Menu) {
+    function openMenu(menu, parentItem, point) {
+        if (!menu) {
+            return
+        }
+
         if (activeMenu) {
             activeMenu.close()
         }
-        menu.open()
+
+        if (parentItem !== undefined && point !== undefined) {
+            menu.popup(parentItem, point.x, point.y)
+        } else {
+            menu.open()
+        }
         activeMenu = menu
     }
-    function closeMenu(menu: Menu) {
-        menu.close()
+    function calculateMenuPosition(point, menu, position) {
+        let menuWidth = Math.max(menu.implicitWidth, menu.width, 1)
+        let menuHeight = Math.max(menu.implicitHeight, menu.height, 1)
+        switch (position) {
+        case Dock.Right:
+            return Qt.point(point.x - menuWidth, point.y)
+        case Dock.Bottom:
+            return Qt.point(point.x, point.y - menuHeight)
+        case Dock.Left:
+        case Dock.Top:
+        default:
+            return point
+        }
+    }
+    function closeMenu(menu) {
+        if (menu) {
+            menu.close()
+        }
     }
     function closeCurrent() {
         if (activeMenu) {

--- a/panels/dock/package/main.qml
+++ b/panels/dock/package/main.qml
@@ -3,12 +3,11 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import QtQuick 2.15
-import QtQuick.Controls 2.4
+import QtQuick.Controls
 import QtQuick.Layouts 2.15
 import QtQuick.Window 2.15
 
 import QtQml
-import Qt.labs.platform as LP
 
 import org.deepin.ds 1.0
 import org.deepin.ds.dock 1.0
@@ -57,12 +56,21 @@ Window {
         return appearance.opacity
     }
 
-    function requestShowDockMenu() {
+    function requestShowDockMenu(point) {
         // maybe has popup visible, close it.
         Panel.requestClosePopup()
         viewDeactivated()
         hideTimer.stop()
-        MenuHelper.openMenu(dockMenuLoader.item)
+
+        let localPoint = point ? Qt.point(point.x, point.y) : Qt.point(dockContainer.width / 2, dockContainer.height / 2)
+        Qt.callLater(function () {
+            let menu = dockMenuLoader.item
+            if (!menu)
+                return
+
+            let pos = MenuHelper.calculateMenuPosition(localPoint, menu, Panel.position)
+            MenuHelper.openMenu(menu, dockContainer, pos)
+        })
     }
 
     DLayerShellWindow.anchors: position2Anchors(positionForAnimation)
@@ -266,11 +274,12 @@ Window {
         }
     }
 
-    component EnumPropertyMenuItem: LP.MenuItem {
+    component EnumPropertyMenuItem: D.MenuItem {
         required property string name
         required property string prop
         required property int value
         text: name
+        checkable: true
 
         onTriggered: {
             Applet[prop] = value
@@ -280,12 +289,9 @@ Window {
         }
         checked: Applet[prop] === value
     }
-    component MutuallyExclusiveMenu: LP.Menu {
-        id: menu
-        LP.MenuItemGroup {
-            id: group
-            items: menu.items
-        }
+    component MutuallyExclusiveMenu: D.Menu {
+        popupType: Popup.Window
+        D.PopupHandle.enableBlurWindow: true
     }
 
     function updateAppItems()
@@ -298,8 +304,11 @@ Window {
     Loader {
         id: dockMenuLoader
         active: false
-        sourceComponent: LP.Menu {
+        sourceComponent: D.Menu {
             id: dockMenu
+            popupType: Popup.Window
+            D.PopupHandle.enableBlurWindow: true
+
             MutuallyExclusiveMenu {
                 visible: Panel.debugMode
                 title: qsTr("Indicator Style")
@@ -368,14 +377,15 @@ Window {
                     value: Dock.SmartHide
                 }
             }
-            LP.MenuItem {
+            D.MenuItem {
                 text: qsTr("Lock the Dock")
+                checkable: true
                 checked: Panel.locked
                 onTriggered: {
                     Panel.locked = !Panel.locked
                 }
             }
-            LP.MenuItem {
+            D.MenuItem {
                 text: qsTr("Dock Settings")
                 onTriggered: {
                     Panel.openDockSettings()
@@ -422,7 +432,7 @@ Window {
                 MenuHelper.closeCurrent()
                 dockMenuLoader.active = true
                 if (button === Qt.RightButton && lastActive !== dockMenuLoader.item) {
-                    requestShowDockMenu()
+                    requestShowDockMenu(eventPoint.position)
                 }
                 if (button === Qt.LeftButton) {
                     // try to close popup when clicked empty, because dock does not have focus.
@@ -434,6 +444,7 @@ Window {
 
         //Touch screen click
         TapHandler {
+            id: touchMenuTapHandler
             acceptedButtons: Qt.NoButton
             acceptedDevices: PointerDevice.TouchScreen
             onTapped: function(eventPoint, button) {
@@ -449,7 +460,7 @@ Window {
                 MenuHelper.closeCurrent()
                 dockMenuLoader.active = true
                 if (lastActive !== dockMenuLoader.item) {
-                    requestShowDockMenu()
+                    requestShowDockMenu(touchMenuTapHandler.point.position)
                 }
             }
         }

--- a/panels/dock/taskmanager/package/AppItem.qml
+++ b/panels/dock/taskmanager/package/AppItem.qml
@@ -3,12 +3,11 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import QtQuick 2.15
-import QtQuick.Controls 2.15
+import QtQuick.Controls
 
 import org.deepin.ds 1.0
 import org.deepin.ds.dock 1.0
 import org.deepin.dtk 1.0 as D
-import Qt.labs.platform 1.1 as LP
 
 Item {
     id: root
@@ -384,12 +383,15 @@ Item {
         id: contextMenuLoader
         active: false
         property bool trashEmpty: true
-        sourceComponent: LP.Menu {
+        sourceComponent: D.Menu {
             id: contextMenu
+            popupType: Popup.Window
+            D.PopupHandle.enableBlurWindow: true
+
             Instantiator {
                 id: menuItemInstantiator
                 model: JSON.parse(menus)
-                delegate: LP.MenuItem {
+                delegate: D.MenuItem {
                     text: modelData.name
                     enabled: (root.itemId === "dde-trash" && modelData.id === "clean-trash")
                             ? !contextMenuLoader.trashEmpty
@@ -476,11 +478,20 @@ Item {
         }
     }
 
-    function requestAppItemMenu() {
+    function requestAppItemMenu(point) {
         Panel.requestClosePopup()
         contextMenuLoader.trashEmpty = TaskManager.isTrashEmpty()
         contextMenuLoader.active = true
-        MenuHelper.openMenu(contextMenuLoader.item)
+
+        let localPoint = point ? Qt.point(point.x, point.y) : Qt.point(root.width / 2, root.height / 2)
+        Qt.callLater(function () {
+            let menu = contextMenuLoader.item
+            if (!menu)
+                return
+
+            let pos = MenuHelper.calculateMenuPosition(localPoint, menu, Panel.position)
+            MenuHelper.openMenu(menu, root, pos)
+        })
     }
 
     MouseArea {
@@ -502,11 +513,12 @@ Item {
         property bool isTouchLongPressed: false
 
         TapHandler {
+            id: touchMenuTapHandler
             acceptedDevices: PointerDevice.TouchScreen
             gesturePolicy: TapHandler.DragThreshold
             onLongPressed: {
                 mouseArea.isTouchLongPressed = true
-                requestAppItemMenu()
+                requestAppItemMenu(touchMenuTapHandler.point.position)
             }
         }
         onPressed: function (mouse) {
@@ -528,7 +540,7 @@ Item {
 
             let index = root.modelIndex;
             if (mouse.button === Qt.RightButton) {
-                requestAppItemMenu()
+                requestAppItemMenu(Qt.point(mouse.x, mouse.y))
             } else {
                 if (root.windows.length === 0) {
                     launchAnimation.start();


### PR DESCRIPTION
## Summary
- Use DTK popup-window menus for the dock blank-area context menu.
- Position the menu from the pointer or touch location and adjust for bottom/right dock edges.
- Enable popup blur through DTK PopupHandle.

## Test plan
- Tested on Wayland/Treeland with dock blank-area right-click menu and blur enabled.
- Confirmed X11 logic is not special-cased by the dock change.

Pms: BUG-295233