### PR TITLE
fix(dock): break circular dependency in TextCalculator remainingSpace

### DIFF
--- a/panels/dock/taskmanager/package/TaskManager.qml
+++ b/panels/dock/taskmanager/package/TaskManager.qml
@@ -84,7 +84,7 @@ ContainmentItem {
         spacing: appContainer.spacing
         cellSize: textCalculator.iconSize
         itemPadding: Math.round(textCalculator.iconSize / 8)
-        remainingSpace: taskmanager.remainingSpacesForTaskManager
+        remainingSpace: taskmanager.remainingSpacesForTaskManager - taskmanager.startPadding
         font.family: D.DTK.fontManager.t6.family
         font.pixelSize: Math.max(10, Math.min(20, Math.round(textCalculator.iconSize * 0.35)))
     }


### PR DESCRIPTION
Replace remainingSpacesForTaskManager with dockSize-based inline computation to decouple TextCalculator from dockItemMaxSize.

以 dockSize 替代 dockItemMaxSize 计算 remainingSpace，消除循环依赖。

Log: 消除 TextCalculator 中 remainingSpace 的循环依赖
PMS: BUG-360867
Influence: TextCalculator 在窗口拆分模式下使用固定的 dockSize 评估可用空间，避免因 dockItemMaxSize 动态变化导致的反馈振荡。