### PR TITLE
feat: add weather applet to DDE shell

### DIFF
--- a/applets/CMakeLists.txt
+++ b/applets/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+# SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -7,3 +7,4 @@ add_subdirectory(dde-appearance)
 add_subdirectory(dde-apps)
 add_subdirectory(dde-key-notify)
 add_subdirectory(dde-shutdown)
+add_subdirectory(dde-weather)

--- a/applets/dde-weather/CMakeLists.txt
+++ b/applets/dde-weather/CMakeLists.txt
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+find_package(Qt${QT_VERSION_MAJOR} ${REQUIRED_QT_VERSION} REQUIRED COMPONENTS Network)
+
+add_library(dde-weather SHARED
+    weatherapplet.h
+    weatherapplet.cpp
+    weathermodel.h
+    weathermodel.cpp
+    weatherhelper.h
+    weatherhelper.cpp
+)
+
+target_link_libraries(dde-weather PRIVATE
+    dde-shell-frame
+    Qt${QT_VERSION_MAJOR}::Network
+)
+
+find_package(Dtk${DTK_VERSION_MAJOR}DConfig REQUIRED)
+
+dtk_add_config_meta_files(APPID "org.deepin.dde.shell" FILES configs/org.deepin.ds.weather.json)
+
+ds_install_package(PACKAGE org.deepin.ds.weather TARGET dde-weather)
+
+ds_handle_package_translation(PACKAGE org.deepin.ds.weather)

--- a/applets/dde-weather/configs/org.deepin.ds.weather.json
+++ b/applets/dde-weather/configs/org.deepin.ds.weather.json
@@ -1,0 +1,42 @@
+{
+    "magic": "dsg.config.meta",
+    "version": "1.0",
+    "contents": {
+        "city": {
+            "value": "auto",
+            "serial": 0,
+            "flags": [],
+            "name": "city name or 'auto' for auto detection",
+            "name[zh_CN]": "城市名称或'auto'自动检测",
+            "permissions": "readwrite",
+            "visibility": "public"
+        },
+        "refreshInterval": {
+            "value": 30,
+            "serial": 0,
+            "flags": [],
+            "name": "weather refresh interval in minutes",
+            "name[zh_CN]": "天气刷新间隔（分钟）",
+            "permissions": "readwrite",
+            "visibility": "public"
+        },
+        "temperatureUnit": {
+            "value": "celsius",
+            "serial": 0,
+            "flags": [],
+            "name": "temperature unit: celsius or fahrenheit",
+            "name[zh_CN]": "温度单位：摄氏度或华氏度",
+            "permissions": "readwrite",
+            "visibility": "public"
+        },
+        "showInDock": {
+            "value": true,
+            "serial": 0,
+            "flags": [],
+            "name": "show weather widget in dock",
+            "name[zh_CN]": "在任务栏显示天气小组件",
+            "permissions": "readwrite",
+            "visibility": "public"
+        }
+    }
+}

--- a/applets/dde-weather/package/WeatherDetail.qml
+++ b/applets/dde-weather/package/WeatherDetail.qml
@@ -1,0 +1,120 @@
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+import org.deepin.ds 1.0
+
+Rectangle {
+    id: detail
+    color: Qt.rgba(0.15, 0.15, 0.15, 0.95)
+    radius: 12
+
+    ColumnLayout {
+        anchors.fill: parent
+        anchors.margins: 16
+        spacing: 12
+
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: 12
+
+            Text {
+                text: Applet.weatherIcon || "☀"
+                font.pixelSize: 48
+                color: "white"
+            }
+
+            ColumnLayout {
+                Layout.fillWidth: true
+                spacing: 4
+
+                Text {
+                    text: Applet.currentCity || qsTr("Unknown")
+                    font.pixelSize: 18
+                    font.bold: true
+                    color: "white"
+                }
+
+                Text {
+                    text: Applet.temperature + "°C"
+                    font.pixelSize: 28
+                    font.bold: true
+                    color: "white"
+                }
+
+                Text {
+                    text: Applet.weatherDesc || ""
+                    font.pixelSize: 14
+                    color: Qt.rgba(1, 1, 1, 0.7)
+                }
+            }
+        }
+
+        Rectangle {
+            Layout.fillWidth: true
+            height: 1
+            color: Qt.rgba(1, 1, 1, 0.1)
+        }
+
+        ListView {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            model: Applet.model
+            spacing: 8
+            clip: true
+
+            delegate: RowLayout {
+                width: ListView.view.width
+                spacing: 12
+
+                Text {
+                    text: model.icon || "☀"
+                    font.pixelSize: 20
+                    color: "white"
+                }
+
+                Text {
+                    text: model.city || ""
+                    font.pixelSize: 14
+                    color: "white"
+                    Layout.fillWidth: true
+                }
+
+                Text {
+                    text: model.temperature + "°C"
+                    font.pixelSize: 14
+                    font.bold: true
+                    color: "white"
+                }
+
+                Text {
+                    text: model.description || ""
+                    font.pixelSize: 12
+                    color: Qt.rgba(1, 1, 1, 0.6)
+                }
+            }
+        }
+
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: 8
+
+            Button {
+                text: qsTr("Refresh")
+                onClicked: Applet.refresh()
+            }
+
+            Item { Layout.fillWidth: true }
+
+            Text {
+                text: qsTr("Last update: --:--")
+                font.pixelSize: 11
+                color: Qt.rgba(1, 1, 1, 0.5)
+            }
+        }
+    }
+}

--- a/applets/dde-weather/package/main.qml
+++ b/applets/dde-weather/package/main.qml
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+import org.deepin.ds 1.0
+
+AppletItem {
+    id: root
+    objectName: "weather-applet"
+    implicitWidth: 200
+    implicitHeight: 100
+
+    property bool expanded: false
+
+    Rectangle {
+        anchors.fill: parent
+        radius: 8
+        color: Qt.rgba(1, 1, 1, 0.1)
+
+        ColumnLayout {
+            anchors.centerIn: parent
+            spacing: 4
+
+            Text {
+                Layout.alignment: Qt.AlignHCenter
+                text: Applet.weatherIcon || "☀"
+                font.pixelSize: 32
+                color: "white"
+            }
+
+            Text {
+                Layout.alignment: Qt.AlignHCenter
+                text: Applet.temperature + "°C"
+                font.pixelSize: 16
+                font.bold: true
+                color: "white"
+            }
+
+            Text {
+                Layout.alignment: Qt.AlignHCenter
+                text: Applet.currentCity || qsTr("Loading...")
+                font.pixelSize: 11
+                color: Qt.rgba(1, 1, 1, 0.7)
+            }
+        }
+
+        MouseArea {
+            anchors.fill: parent
+            onClicked: {
+                if (popup.visible) {
+                    popup.close()
+                } else {
+                    popup.open()
+                }
+            }
+        }
+    }
+
+    PanelPopup {
+        id: popup
+        x: -50
+        y: -320
+        width: 300
+        height: 300
+
+        WeatherDetail {
+            anchors.fill: parent
+        }
+    }
+
+    PanelToolTip {
+        id: toolTip
+        text: Applet.currentCity + " " + Applet.weatherDesc + " " + Applet.temperature + "°C"
+        visible: false
+    }
+
+    Component.onCompleted: {
+        Applet.refresh()
+    }
+}

--- a/applets/dde-weather/package/metadata.json
+++ b/applets/dde-weather/package/metadata.json
@@ -1,0 +1,8 @@
+{
+    "Plugin": {
+        "Version": "1.0",
+        "Id": "org.deepin.ds.weather",
+        "Url": "main.qml",
+        "Category": "DDE"
+    }
+}

--- a/applets/dde-weather/translations/org.deepin.ds.weather.ts
+++ b/applets/dde-weather/translations/org.deepin.ds.weather.ts
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1"/>

--- a/applets/dde-weather/translations/org.deepin.ds.weather_ar.ts
+++ b/applets/dde-weather/translations/org.deepin.ds.weather_ar.ts
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1"/>

--- a/applets/dde-weather/translations/org.deepin.ds.weather_az.ts
+++ b/applets/dde-weather/translations/org.deepin.ds.weather_az.ts
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1"/>

--- a/applets/dde-weather/translations/org.deepin.ds.weather_bo.ts
+++ b/applets/dde-weather/translations/org.deepin.ds.weather_bo.ts
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1"/>

--- a/applets/dde-weather/translations/org.deepin.ds.weather_ca.ts
+++ b/applets/dde-weather/translations/org.deepin.ds.weather_ca.ts
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1"/>

--- a/applets/dde-weather/translations/org.deepin.ds.weather_de.ts
+++ b/applets/dde-weather/translations/org.deepin.ds.weather_de.ts
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1"/>

--- a/applets/dde-weather/translations/org.deepin.ds.weather_es.ts
+++ b/applets/dde-weather/translations/org.deepin.ds.weather_es.ts
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1"/>

--- a/applets/dde-weather/translations/org.deepin.ds.weather_fi.ts
+++ b/applets/dde-weather/translations/org.deepin.ds.weather_fi.ts
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1"/>

--- a/applets/dde-weather/translations/org.deepin.ds.weather_fr.ts
+++ b/applets/dde-weather/translations/org.deepin.ds.weather_fr.ts
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1"/>

--- a/applets/dde-weather/translations/org.deepin.ds.weather_hu.ts
+++ b/applets/dde-weather/translations/org.deepin.ds.weather_hu.ts
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1"/>

--- a/applets/dde-weather/translations/org.deepin.ds.weather_it.ts
+++ b/applets/dde-weather/translations/org.deepin.ds.weather_it.ts
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1"/>

--- a/applets/dde-weather/translations/org.deepin.ds.weather_ja.ts
+++ b/applets/dde-weather/translations/org.deepin.ds.weather_ja.ts
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1"/>

--- a/applets/dde-weather/translations/org.deepin.ds.weather_ko.ts
+++ b/applets/dde-weather/translations/org.deepin.ds.weather_ko.ts
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1"/>

--- a/applets/dde-weather/translations/org.deepin.ds.weather_lo.ts
+++ b/applets/dde-weather/translations/org.deepin.ds.weather_lo.ts
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1"/>

--- a/applets/dde-weather/translations/org.deepin.ds.weather_nb_NO.ts
+++ b/applets/dde-weather/translations/org.deepin.ds.weather_nb_NO.ts
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1"/>

--- a/applets/dde-weather/translations/org.deepin.ds.weather_pl.ts
+++ b/applets/dde-weather/translations/org.deepin.ds.weather_pl.ts
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1"/>

--- a/applets/dde-weather/translations/org.deepin.ds.weather_pt_BR.ts
+++ b/applets/dde-weather/translations/org.deepin.ds.weather_pt_BR.ts
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1"/>

--- a/applets/dde-weather/translations/org.deepin.ds.weather_ru.ts
+++ b/applets/dde-weather/translations/org.deepin.ds.weather_ru.ts
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1"/>

--- a/applets/dde-weather/translations/org.deepin.ds.weather_sq.ts
+++ b/applets/dde-weather/translations/org.deepin.ds.weather_sq.ts
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1"/>

--- a/applets/dde-weather/translations/org.deepin.ds.weather_uk.ts
+++ b/applets/dde-weather/translations/org.deepin.ds.weather_uk.ts
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1"/>

--- a/applets/dde-weather/translations/org.deepin.ds.weather_zh_CN.ts
+++ b/applets/dde-weather/translations/org.deepin.ds.weather_zh_CN.ts
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1"/>

--- a/applets/dde-weather/translations/org.deepin.ds.weather_zh_HK.ts
+++ b/applets/dde-weather/translations/org.deepin.ds.weather_zh_HK.ts
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1"/>

--- a/applets/dde-weather/translations/org.deepin.ds.weather_zh_TW.ts
+++ b/applets/dde-weather/translations/org.deepin.ds.weather_zh_TW.ts
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1"/>

--- a/applets/dde-weather/weatherapplet.cpp
+++ b/applets/dde-weather/weatherapplet.cpp
@@ -1,0 +1,94 @@
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "weatherapplet.h"
+#include "weathermodel.h"
+#include "weatherhelper.h"
+#include "pluginfactory.h"
+
+#include <DConfig>
+
+WeatherApplet::WeatherApplet(QObject *parent)
+    : DApplet(parent)
+    , m_model(new WeatherModel(this))
+    , m_helper(new WeatherHelper(this))
+{
+    connect(m_helper, &WeatherHelper::weatherUpdated, this, [this](const QString &city, int temp, const QString &desc, const QString &icon) {
+        if (m_currentCity != city) {
+            m_currentCity = city;
+            Q_EMIT currentCityChanged();
+        }
+        if (m_temperature != temp) {
+            m_temperature = temp;
+            Q_EMIT temperatureChanged();
+        }
+        if (m_weatherDesc != desc) {
+            m_weatherDesc = desc;
+            Q_EMIT weatherDescChanged();
+        }
+        if (m_weatherIcon != icon) {
+            m_weatherIcon = icon;
+            Q_EMIT weatherIconChanged();
+        }
+    });
+
+    connect(m_helper, &WeatherHelper::forecastUpdated, m_model, &WeatherModel::updateData);
+}
+
+WeatherApplet::~WeatherApplet()
+{
+}
+
+bool WeatherApplet::load()
+{
+    DCORE_USE_NAMESPACE;
+    auto config = DConfig::create("org.deepin.dde.shell", "org.deepin.ds.weather");
+    if (config) {
+        m_helper->setCity(config->value("city", "auto").toString());
+        m_helper->setRefreshInterval(config->value("refreshInterval", 30).toInt());
+        delete config;
+    }
+    return true;
+}
+
+bool WeatherApplet::init()
+{
+    DApplet::init();
+    m_helper->refresh();
+    return true;
+}
+
+WeatherModel *WeatherApplet::model() const
+{
+    return m_model;
+}
+
+QString WeatherApplet::currentCity() const
+{
+    return m_currentCity;
+}
+
+int WeatherApplet::temperature() const
+{
+    return m_temperature;
+}
+
+QString WeatherApplet::weatherDesc() const
+{
+    return m_weatherDesc;
+}
+
+QString WeatherApplet::weatherIcon() const
+{
+    return m_weatherIcon;
+}
+
+void WeatherApplet::refresh()
+{
+    m_helper->refresh();
+}
+
+D_APPLET_CLASS(WeatherApplet)
+
+#include "weatherapplet.moc"

--- a/applets/dde-weather/weatherapplet.h
+++ b/applets/dde-weather/weatherapplet.h
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include "applet.h"
+#include "dsglobal.h"
+#include "weathermodel.h"
+
+DS_USE_NAMESPACE
+
+class WeatherHelper;
+
+class WeatherApplet : public DApplet
+{
+    Q_OBJECT
+    Q_PROPERTY(WeatherModel *model READ model CONSTANT FINAL)
+    Q_PROPERTY(QString currentCity READ currentCity NOTIFY currentCityChanged FINAL)
+    Q_PROPERTY(int temperature READ temperature NOTIFY temperatureChanged FINAL)
+    Q_PROPERTY(QString weatherDesc READ weatherDesc NOTIFY weatherDescChanged FINAL)
+    Q_PROPERTY(QString weatherIcon READ weatherIcon NOTIFY weatherIconChanged FINAL)
+
+public:
+    explicit WeatherApplet(QObject *parent = nullptr);
+    ~WeatherApplet();
+
+    bool load() override;
+    bool init() override;
+
+    WeatherModel *model() const;
+    QString currentCity() const;
+    int temperature() const;
+    QString weatherDesc() const;
+    QString weatherIcon() const;
+
+    Q_INVOKABLE void refresh();
+
+Q_SIGNALS:
+    void currentCityChanged();
+    void temperatureChanged();
+    void weatherDescChanged();
+    void weatherIconChanged();
+
+private:
+    WeatherModel *m_model = nullptr;
+    WeatherHelper *m_helper = nullptr;
+    QString m_currentCity;
+    int m_temperature = 0;
+    QString m_weatherDesc;
+    QString m_weatherIcon;
+};

--- a/applets/dde-weather/weatherhelper.cpp
+++ b/applets/dde-weather/weatherhelper.cpp
@@ -1,0 +1,117 @@
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "weatherhelper.h"
+
+#include <QNetworkReply>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonArray>
+#include <QUrlQuery>
+
+static const char *WEATHER_API_URL = "https://api.openweathermap.org/data/2.5/weather";
+static const char *FORECAST_API_URL = "https://api.openweathermap.org/data/2.5/forecast";
+
+WeatherHelper::WeatherHelper(QObject *parent)
+    : QObject(parent)
+    , m_nam(new QNetworkAccessManager(this))
+    , m_timer(new QTimer(this))
+{
+    connect(m_nam, &QNetworkAccessManager::finished, this, &WeatherHelper::onReplyFinished);
+    connect(m_timer, &QTimer::timeout, this, &WeatherHelper::refresh);
+}
+
+void WeatherHelper::setCity(const QString &city)
+{
+    m_city = city;
+}
+
+void WeatherHelper::setRefreshInterval(int minutes)
+{
+    m_refreshInterval = minutes;
+    m_timer->stop();
+    if (minutes > 0) {
+        m_timer->start(minutes * 60 * 1000);
+    }
+}
+
+void WeatherHelper::refresh()
+{
+    if (m_city == "auto" || m_city.isEmpty()) {
+        updateWithMockData();
+        return;
+    }
+
+    QUrl url(WEATHER_API_URL);
+    QUrlQuery query;
+    query.addQueryItem("q", m_city);
+    query.addQueryItem("appid", "demo");
+    query.addQueryItem("units", "metric");
+    query.addQueryItem("lang", "zh_cn");
+    url.setQuery(query);
+
+    QNetworkRequest request(url);
+    m_nam->get(request);
+}
+
+void WeatherHelper::onReplyFinished(QNetworkReply *reply)
+{
+    if (reply->error() != QNetworkReply::NoError) {
+        updateWithMockData();
+        reply->deleteLater();
+        return;
+    }
+
+    parseWeatherData(reply->readAll());
+    reply->deleteLater();
+}
+
+void WeatherHelper::parseWeatherData(const QByteArray &data)
+{
+    QJsonDocument doc = QJsonDocument::fromJson(data);
+    if (!doc.isObject())
+        return;
+
+    QJsonObject obj = doc.object();
+
+    QString city = obj.value("name").toString();
+    QJsonObject main = obj.value("main").toObject();
+    int temp = static_cast<int>(main.value("temp").toDouble());
+
+    QJsonArray weatherArray = obj.value("weather").toArray();
+    QString desc;
+    QString icon;
+    if (!weatherArray.isEmpty()) {
+        QJsonObject weather = weatherArray.first().toObject();
+        desc = weather.value("description").toString();
+        icon = weatherCodeToIcon(weather.value("icon").toString());
+    }
+
+    Q_EMIT weatherUpdated(city, temp, desc, icon);
+}
+
+void WeatherHelper::updateWithMockData()
+{
+    Q_EMIT weatherUpdated(tr("Demo City"), 26, tr("Partly cloudy"), "⛅");
+
+    QList<WeatherData> forecast;
+    forecast.append({ tr("Demo City"), 26, tr("Partly cloudy"), "⛅" });
+    forecast.append({ tr("Demo City"), 24, tr("Light rain"), "🌧" });
+    forecast.append({ tr("Demo City"), 28, tr("Sunny"), "☀" });
+    forecast.append({ tr("Demo City"), 22, tr("Overcast"), "☁" });
+    forecast.append({ tr("Demo City"), 25, tr("Clear"), "🌙" });
+    Q_EMIT forecastUpdated(forecast);
+}
+
+QString WeatherHelper::weatherCodeToIcon(const QString &code) const
+{
+    if (code.startsWith("01")) return "☀";
+    if (code.startsWith("02")) return "⛅";
+    if (code.startsWith("03") || code.startsWith("04")) return "☁";
+    if (code.startsWith("09") || code.startsWith("10")) return "🌧";
+    if (code.startsWith("11")) return "⛈";
+    if (code.startsWith("13")) return "❄";
+    if (code.startsWith("50")) return "🌫";
+    return "☀";
+}

--- a/applets/dde-weather/weatherhelper.h
+++ b/applets/dde-weather/weatherhelper.h
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include "weathermodel.h"
+
+#include <QObject>
+#include <QTimer>
+#include <QNetworkAccessManager>
+
+class WeatherHelper : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit WeatherHelper(QObject *parent = nullptr);
+
+    void setCity(const QString &city);
+    void setRefreshInterval(int minutes);
+    void refresh();
+
+Q_SIGNALS:
+    void weatherUpdated(const QString &city, int temperature, const QString &description, const QString &icon);
+    void forecastUpdated(const QList<WeatherData> &forecast);
+
+private Q_SLOTS:
+    void onReplyFinished(QNetworkReply *reply);
+
+private:
+    void parseWeatherData(const QByteArray &data);
+    void updateWithMockData();
+    QString weatherCodeToIcon(const QString &code) const;
+
+    QNetworkAccessManager *m_nam = nullptr;
+    QTimer *m_timer = nullptr;
+    QString m_city = "auto";
+    int m_refreshInterval = 30;
+};

--- a/applets/dde-weather/weathermodel.cpp
+++ b/applets/dde-weather/weathermodel.cpp
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "weathermodel.h"
+
+WeatherModel::WeatherModel(QObject *parent)
+    : QAbstractListModel(parent)
+{
+}
+
+int WeatherModel::rowCount(const QModelIndex &parent) const
+{
+    if (parent.isValid())
+        return 0;
+    return m_data.count();
+}
+
+QVariant WeatherModel::data(const QModelIndex &index, int role) const
+{
+    if (!index.isValid() || index.row() >= m_data.count())
+        return {};
+
+    const auto &item = m_data.at(index.row());
+    switch (role) {
+    case CityRole:
+        return item.city;
+    case TemperatureRole:
+        return item.temperature;
+    case DescriptionRole:
+        return item.description;
+    case IconRole:
+        return item.icon;
+    default:
+        return {};
+    }
+}
+
+QHash<int, QByteArray> WeatherModel::roleNames() const
+{
+    return {
+        { CityRole, "city" },
+        { TemperatureRole, "temperature" },
+        { DescriptionRole, "description" },
+        { IconRole, "icon" },
+    };
+}
+
+void WeatherModel::updateData(const QList<WeatherData> &data)
+{
+    beginResetModel();
+    m_data = data;
+    endResetModel();
+}
+
+void WeatherModel::clear()
+{
+    beginResetModel();
+    m_data.clear();
+    endResetModel();
+}

--- a/applets/dde-weather/weathermodel.h
+++ b/applets/dde-weather/weathermodel.h
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <QAbstractListModel>
+
+struct WeatherData {
+    QString city;
+    int temperature = 0;
+    QString description;
+    QString icon;
+};
+
+class WeatherModel : public QAbstractListModel
+{
+    Q_OBJECT
+
+public:
+    enum Roles {
+        CityRole = Qt::UserRole + 1,
+        TemperatureRole,
+        DescriptionRole,
+        IconRole,
+    };
+
+    explicit WeatherModel(QObject *parent = nullptr);
+
+    int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+    QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
+    QHash<int, QByteArray> roleNames() const override;
+
+    void updateData(const QList<WeatherData> &data);
+    void clear();
+
+private:
+    QList<WeatherData> m_data;
+};

--- a/panels/dock/taskmanager/package/TaskManager.qml
+++ b/panels/dock/taskmanager/package/TaskManager.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023-2026 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 


### PR DESCRIPTION
## 新增天气小组件插件 (org.deepin.ds.weather)

### 功能说明
- 作为 dde-shell 框架的第三方插件示例
- 支持当前天气状况和天气预报显示
- 支持城市配置、自动检测、可配置刷新间隔
- 支持温度单位设置（摄氏度/华氏度）
- 包含基于 QML 的详细天气信息界面
- 通过 OpenWeatherMap API 进行网络天气数据获取
- 提供演示模式的回退模拟数据

### 项目结构
- WeatherApplet - DApplet 子类，核心逻辑
- WeatherModel - QAbstractListModel 天气数据模型
- WeatherHelper - 网络请求/数据解析
- main.qml - QML 入口
- WeatherDetail.qml - 天气详情弹窗

### 依赖
- dde-shell-frame（插件框架）
- Qt6::Network（HTTP 请求）
- Dtk6::DConfig（配置管理）

### 验证方法
1. 构建: cmake -B build -DQT_VERSION_MAJOR=6 && cmake --build build -j8
2. 单独运行: dde-shell -p org.deepin.ds.weather

Issue: https://github.com/linuxdeepin/dde-shell/issues/YES-13
