### PR TITLE
chore: update changelog to 2.0.46

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,16 @@
+dde-shell (2.0.46) unstable; urgency=medium
+
+  * fix(dock): subtract startPadding from remainingSpacesForTaskManager
+  * fix(dock): Adjust the calculation logic of dockItemMaxSize
+  * fix(osd): re-establish selectIndex binding in onVisibleChanged for
+    reactive sync
+  * fix(dock): align delegate implicitHeight with icon ratio for
+    consistent spacing
+  * fix: bind hover and pressed states to background
+  * fix: bind taskmanager start timer to applet lifetime
+
+ -- zhangkun <zhangkun2@uniontech.com>  Wed, 17 Jun 2026 16:25:27 +0800
+
 dde-shell (2.0.45) unstable; urgency=medium
 
   * feat: add XdgActivation support for notifications


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 2.0.46

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 2.0.46
- 目标分支: master

## Summary by Sourcery

Chores:
- Bump recorded package version to 2.0.46 in debian/changelog.