### PR TITLE
fix(debian): add Breaks and Replaces for libdde-shell-dev

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -87,6 +87,8 @@ Depends:
  ${shlibs:Depends},
 Breaks:
  dde-clipboard (<< 1:6.0.14),
+ libdde-shell-dev (<< 2.0.38)
+Replaces: libdde-shell-dev (<< 2.0.38)
 Description: An wrapper for developed based on dde-shell plugin system
 
 Package: dde-shell-example
@@ -109,8 +111,6 @@ Depends:
  qt6-declarative-dev,
  qt6-tools-dev,
  ${misc:Depends},
-Breaks:
- dde-shell (<< 2.0.39),
 Description: DDE Shell devel library
  DDE Shell is a plugin system that integrates plugins developed based on this plugin system into DDE.
 


### PR DESCRIPTION
1. Add versioned Breaks for libdde-shell-dev (<< 2.0.38)
2. Add Replaces directive for libdde-shell-dev (<< 2.0.38)
3. Prevent file conflicts during package upgrade

Log: 修复 dde-shell 与 libdde-shell-dev 的包冲突问题

fix(debian): 添加 libdde-shell-dev 的 Breaks 和 Replaces

1. 为 libdde-shell-dev 添加版本化的 Breaks (<< 2.0.38)
2. 添加 Replaces 指令以正确处理包升级
3. 防止包升级过程中的文件冲突

Log: fix package conflict between dde-shell and libdde-shell-dev
PMS: BUG-366859

## Summary by Sourcery

Update Debian packaging to declare versioned conflicts between dde-shell and libdde-shell-dev to avoid file clashes during upgrades.

Build:
- Add a versioned Breaks relationship on libdde-shell-dev (<< 2.0.38) in the Debian control file.
- Add a matching Replaces directive for libdde-shell-dev (<< 2.0.38) to ensure smooth package upgrades without file conflicts.