### PR TITLE
chore: update changelog to 2.0.47

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-shell (2.0.47) unstable; urgency=medium
+
+  * fix(debian): add Breaks and Replaces for libdde-shell-dev
+
+ -- zhangkun <zhangkun2@uniontech.com>  Thu, 18 Jun 2026 11:18:15 +0800
+
 dde-shell (2.0.46) unstable; urgency=medium
 
   * fix(dock): subtract startPadding from remainingSpacesForTaskManager


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 2.0.47

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 2.0.47
- 目标分支: master

## Summary by Sourcery

Chores:
- Bump Debian changelog entry to version 2.0.47 targeting master.