### PR TITLE
chore: update changelog to 2.0.47

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,11 @@
 dde-shell (2.0.47) unstable; urgency=medium
 
+  * Release 2.0.47
+
+ -- zhangkun <zhangkun2@uniontech.com>  Thu, 18 Jun 2026 14:29:07 +0800
+
+dde-shell (2.0.47) unstable; urgency=medium
+
   * fix(debian): add Breaks and Replaces for libdde-shell-dev
 
  -- zhangkun <zhangkun2@uniontech.com>  Thu, 18 Jun 2026 11:18:15 +0800


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 2.0.47

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 2.0.47
- 目标分支: master

## Summary by Sourcery

Documentation:
- Refresh Debian changelog entry to document changes for version 2.0.47.