### PR TITLE
fix: prevent crash on toplevel destruction

### DIFF
--- a/panels/dock/taskmanager/treelandwindow.cpp
+++ b/panels/dock/taskmanager/treelandwindow.cpp
@@ -22,8 +22,16 @@ ForeignToplevelHandle::ForeignToplevelHandle(struct ::treeland_foreign_toplevel_
     , QtWayland::treeland_foreign_toplevel_handle_v1(object)
     , m_pid(0)
     , m_isReady(false)
+    , m_identifier(0)
 {
     init(object);
+}
+
+ForeignToplevelHandle::~ForeignToplevelHandle()
+{
+    if (object()) {
+        destroy();
+    }
 }
 
 uint32_t ForeignToplevelHandle::id() const

--- a/panels/dock/taskmanager/treelandwindow.h
+++ b/panels/dock/taskmanager/treelandwindow.h
@@ -20,6 +20,7 @@ class ForeignToplevelHandle : public QWaylandClientExtensionTemplate<ForeignTopl
 
 public:
     explicit ForeignToplevelHandle(struct ::treeland_foreign_toplevel_handle_v1 *object);
+    ~ForeignToplevelHandle();
     bool isReady() const;
     uint32_t id() const;
     pid_t pid() const;


### PR DESCRIPTION
Added proper destructor to ForeignToplevelHandle class to
clean up the Wayland object when the instance is destroyed.
Previously, the destructor was missing, causing the underlying
treeland_foreign_toplevel_handle_v1 object to remain alive after the
ForeignToplevelHandle wrapper was destroyed, leading to use-after-free
crashes in the task manager.

The fix ensures that when a ForeignToplevelHandle is destroyed, its
associated Wayland protocol object is properly destroyed via the
`destroy()` method, preventing dangling pointers and toplevel crashes.

Log: Fixed crash when closing windows in the dock task manager

Influence:
1. Open and close multiple applications rapidly to trigger toplevel
destroy events
2. Test with applications that create and destroy windows frequently
3. Verify dock task manager remains stable during window management
operations
4. Test with different types of windows (normal, dialog, transient)

fix: 修复顶层窗口销毁时的崩溃问题

为 ForeignToplevelHandle 类添加了正确的析构函数，在实例销毁时清理
Wayland 对象。之前缺少析构函数，导致 ForeignToplevelHandle 包装类销毁
后，底层的 treeland_foreign_toplevel_handle_v1 对象仍然存在，导致任务管
理器出现释放后使用崩溃。

该修复确保了 ForeignToplevelHandle 被销毁时，其关联的 Wayland 协议对象通
过 `destroy()` 方法被正确销毁，防止悬空指针和顶层窗口崩溃。

Log: 修复关闭dock任务管理器中窗口时的崩溃问题

Influence:
1. 快速打开和关闭多个应用程序以触发顶层窗口销毁事件
2. 测试频繁创建和销毁窗口的应用程序
3. 验证窗口管理操作期间dock任务管理器的稳定性
4. 测试不同类型的窗口（普通窗口、对话框、临时窗口）
