### PR TITLE
revert: "fix: correct dock context menu popup positioning"

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -73,7 +73,7 @@ Depends:
  dde-tray-loader (>= 1.99.8),
  libdde-shell (= ${binary:Version}),
  libdde-shell-dock (= ${binary:Version}),
- libdtk6declarative (>> 6.7.44),
+ libdtk6declarative,
  libqt6sql6-sqlite,
  libqt6svg6,
  qml6-module-qt-labs-platform,

--- a/panels/dock/MenuHelper.qml
+++ b/panels/dock/MenuHelper.qml
@@ -1,58 +1,31 @@
-// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 pragma Singleton
 import QtQuick
-import org.deepin.ds.dock 1.0
+import Qt.labs.platform
 
 Item {
-    id: root
-
-    property var activeMenu: null
+    property Menu activeMenu: null
     
     signal menuClosed()
     Connections {
-        target: root.activeMenu
+        target: activeMenu
         function onAboutToHide() {
-            root.activeMenu = null
-            root.menuClosed()
+            activeMenu = null
+            menuClosed()
         }
     }
-    function openMenu(menu, parentItem, point) {
-        if (!menu) {
-            return
-        }
-
+    function openMenu(menu: Menu) {
         if (activeMenu) {
             activeMenu.close()
         }
-
-        if (parentItem !== undefined && point !== undefined) {
-            menu.popup(parentItem, point.x, point.y)
-        } else {
-            menu.open()
-        }
+        menu.open()
         activeMenu = menu
     }
-    function calculateMenuPosition(point, menu, position) {
-        let menuWidth = Math.max(menu.implicitWidth, menu.width, 1)
-        let menuHeight = Math.max(menu.implicitHeight, menu.height, 1)
-        switch (position) {
-        case Dock.Right:
-            return Qt.point(point.x - menuWidth, point.y)
-        case Dock.Bottom:
-            return Qt.point(point.x, point.y - menuHeight)
-        case Dock.Left:
-        case Dock.Top:
-        default:
-            return point
-        }
-    }
-    function closeMenu(menu) {
-        if (menu) {
-            menu.close()
-        }
+    function closeMenu(menu: Menu) {
+        menu.close()
     }
     function closeCurrent() {
         if (activeMenu) {

--- a/panels/dock/package/main.qml
+++ b/panels/dock/package/main.qml
@@ -3,11 +3,12 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import QtQuick 2.15
-import QtQuick.Controls
+import QtQuick.Controls 2.4
 import QtQuick.Layouts 2.15
 import QtQuick.Window 2.15
 
 import QtQml
+import Qt.labs.platform as LP
 
 import org.deepin.ds 1.0
 import org.deepin.ds.dock 1.0
@@ -56,21 +57,12 @@ Window {
         return appearance.opacity
     }
 
-    function requestShowDockMenu(point) {
+    function requestShowDockMenu() {
         // maybe has popup visible, close it.
         Panel.requestClosePopup()
         viewDeactivated()
         hideTimer.stop()
-
-        let localPoint = point ? Qt.point(point.x, point.y) : Qt.point(dockContainer.width / 2, dockContainer.height / 2)
-        Qt.callLater(function () {
-            let menu = dockMenuLoader.item
-            if (!menu)
-                return
-
-            let pos = MenuHelper.calculateMenuPosition(localPoint, menu, Panel.position)
-            MenuHelper.openMenu(menu, dockContainer, pos)
-        })
+        MenuHelper.openMenu(dockMenuLoader.item)
     }
 
     DLayerShellWindow.anchors: position2Anchors(positionForAnimation)
@@ -274,12 +266,11 @@ Window {
         }
     }
 
-    component EnumPropertyMenuItem: D.MenuItem {
+    component EnumPropertyMenuItem: LP.MenuItem {
         required property string name
         required property string prop
         required property int value
         text: name
-        checkable: true
 
         onTriggered: {
             Applet[prop] = value
@@ -289,9 +280,12 @@ Window {
         }
         checked: Applet[prop] === value
     }
-    component MutuallyExclusiveMenu: D.Menu {
-        popupType: Popup.Window
-        D.PopupHandle.enableBlurWindow: true
+    component MutuallyExclusiveMenu: LP.Menu {
+        id: menu
+        LP.MenuItemGroup {
+            id: group
+            items: menu.items
+        }
     }
 
     function updateAppItems()
@@ -304,11 +298,8 @@ Window {
     Loader {
         id: dockMenuLoader
         active: false
-        sourceComponent: D.Menu {
+        sourceComponent: LP.Menu {
             id: dockMenu
-            popupType: Popup.Window
-            D.PopupHandle.enableBlurWindow: true
-
             MutuallyExclusiveMenu {
                 visible: Panel.debugMode
                 title: qsTr("Indicator Style")
@@ -377,15 +368,14 @@ Window {
                     value: Dock.SmartHide
                 }
             }
-            D.MenuItem {
+            LP.MenuItem {
                 text: qsTr("Lock the Dock")
-                checkable: true
                 checked: Panel.locked
                 onTriggered: {
                     Panel.locked = !Panel.locked
                 }
             }
-            D.MenuItem {
+            LP.MenuItem {
                 text: qsTr("Dock Settings")
                 onTriggered: {
                     Panel.openDockSettings()
@@ -432,7 +422,7 @@ Window {
                 MenuHelper.closeCurrent()
                 dockMenuLoader.active = true
                 if (button === Qt.RightButton && lastActive !== dockMenuLoader.item) {
-                    requestShowDockMenu(eventPoint.position)
+                    requestShowDockMenu()
                 }
                 if (button === Qt.LeftButton) {
                     // try to close popup when clicked empty, because dock does not have focus.
@@ -444,7 +434,6 @@ Window {
 
         //Touch screen click
         TapHandler {
-            id: touchMenuTapHandler
             acceptedButtons: Qt.NoButton
             acceptedDevices: PointerDevice.TouchScreen
             onTapped: function(eventPoint, button) {
@@ -460,7 +449,7 @@ Window {
                 MenuHelper.closeCurrent()
                 dockMenuLoader.active = true
                 if (lastActive !== dockMenuLoader.item) {
-                    requestShowDockMenu(touchMenuTapHandler.point.position)
+                    requestShowDockMenu()
                 }
             }
         }

--- a/panels/dock/taskmanager/package/AppItem.qml
+++ b/panels/dock/taskmanager/package/AppItem.qml
@@ -3,11 +3,12 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import QtQuick 2.15
-import QtQuick.Controls
+import QtQuick.Controls 2.15
 
 import org.deepin.ds 1.0
 import org.deepin.ds.dock 1.0
 import org.deepin.dtk 1.0 as D
+import Qt.labs.platform 1.1 as LP
 
 Item {
     id: root
@@ -383,15 +384,12 @@ Item {
         id: contextMenuLoader
         active: false
         property bool trashEmpty: true
-        sourceComponent: D.Menu {
+        sourceComponent: LP.Menu {
             id: contextMenu
-            popupType: Popup.Window
-            D.PopupHandle.enableBlurWindow: true
-
             Instantiator {
                 id: menuItemInstantiator
                 model: JSON.parse(menus)
-                delegate: D.MenuItem {
+                delegate: LP.MenuItem {
                     text: modelData.name
                     enabled: (root.itemId === "dde-trash" && modelData.id === "clean-trash")
                             ? !contextMenuLoader.trashEmpty
@@ -478,20 +476,11 @@ Item {
         }
     }
 
-    function requestAppItemMenu(point) {
+    function requestAppItemMenu() {
         Panel.requestClosePopup()
         contextMenuLoader.trashEmpty = TaskManager.isTrashEmpty()
         contextMenuLoader.active = true
-
-        let localPoint = point ? Qt.point(point.x, point.y) : Qt.point(root.width / 2, root.height / 2)
-        Qt.callLater(function () {
-            let menu = contextMenuLoader.item
-            if (!menu)
-                return
-
-            let pos = MenuHelper.calculateMenuPosition(localPoint, menu, Panel.position)
-            MenuHelper.openMenu(menu, root, pos)
-        })
+        MenuHelper.openMenu(contextMenuLoader.item)
     }
 
     MouseArea {
@@ -513,12 +502,11 @@ Item {
         property bool isTouchLongPressed: false
 
         TapHandler {
-            id: touchMenuTapHandler
             acceptedDevices: PointerDevice.TouchScreen
             gesturePolicy: TapHandler.DragThreshold
             onLongPressed: {
                 mouseArea.isTouchLongPressed = true
-                requestAppItemMenu(touchMenuTapHandler.point.position)
+                requestAppItemMenu()
             }
         }
         onPressed: function (mouse) {
@@ -540,7 +528,7 @@ Item {
 
             let index = root.modelIndex;
             if (mouse.button === Qt.RightButton) {
-                requestAppItemMenu(Qt.point(mouse.x, mouse.y))
+                requestAppItemMenu()
             } else {
                 if (root.windows.length === 0) {
                     launchAnimation.start();


### PR DESCRIPTION
This reverts commit b23697034635b8b7ae21c80955816fbb1974a623.

## 原因

引入 DTK popup window 菜单后，popup 窗口会主动夺取输入焦点，导致 dock 右键菜单出现 **一级菜单与二级菜单互抢焦点** 的问题：

- 二级（子）菜单弹出时会从一级菜单抢走焦点；
- 一级菜单因失去焦点而异常关闭 / 闪烁；
- 用户无法正常完成多级菜单的交互。

## 处理方案

先回退至原先的 `Qt.labs.platform` 菜单方案，恢复稳定的菜单交互行为。待焦点抢夺问题彻底定位并修复后，再重新引入 DTK popup window 菜单（含 `PopupHandle` 模糊效果）。

## 影响文件

- `panels/dock/MenuHelper.qml`
- `panels/dock/package/main.qml`
- `panels/dock/taskmanager/package/AppItem.qml`
- `debian/control`（回退 `libdtk6declarative (>> 6.7.44)` 版本约束）

## 验证

- [x] 编译通过
- [ ] dock 空白区域右键菜单交互正常
- [ ] taskmanager 应用项右键菜单交互正常
- [ ] 触摸屏长按弹出菜单交互正常