### PR TITLE
fix(dock): prevent menu hide after touch long-press

### DIFF
--- a/panels/dock/package/main.qml
+++ b/panels/dock/package/main.qml
@@ -388,6 +388,7 @@ Window {
         id: dockContainer
         width: dock.useColumnLayout ? dock.dockSize : parent.width
         height: dock.useColumnLayout ? parent.height : dock.dockSize
+        property bool touchLongPressed: false
         anchors {
             left: parent.left
             top: parent.top
@@ -437,6 +438,10 @@ Window {
             acceptedButtons: Qt.NoButton
             acceptedDevices: PointerDevice.TouchScreen
             onTapped: function(eventPoint, button) {
+                if (dockContainer.touchLongPressed) {
+                    dockContainer.touchLongPressed = false
+                    return
+                }
                 let lastActive = MenuHelper.activeMenu
                 MenuHelper.closeCurrent()
                 dockMenuLoader.active = true
@@ -445,12 +450,16 @@ Window {
                 viewDeactivated()
             }
             onLongPressed: {
+                dockContainer.touchLongPressed = true
                 let lastActive = MenuHelper.activeMenu
                 MenuHelper.closeCurrent()
                 dockMenuLoader.active = true
                 if (lastActive !== dockMenuLoader.item) {
                     requestShowDockMenu()
                 }
+            }
+            onCanceled: {
+                dockContainer.touchLongPressed = false
             }
         }
 


### PR DESCRIPTION
1. Add touchLongPressed flag to track touch long-press state
2. Skip mouse release handler when touch long-press was active
3. Reset flag on touch canceled to avoid stale state

Log: Fix right-click menu auto-hiding after touch long-press on taskbar

fix(dock): 修复长按任务栏后松手右键菜单自动隐藏的问题

1. 添加 touchLongPressed 标志位以跟踪触摸长按状态
2. 触摸长按激活时跳过鼠标释放事件的处理
3. 触摸取消时重置标志位，避免状态残留

Log: 修复长按任务栏应用和空白区域松开手指后右键菜单面板自动隐藏的问题
PMS: BUG-367313

## Summary by Sourcery

Bug Fixes:
- Fix dock right-click menu auto-hiding when lifting finger after a long-press on touch devices.