### PR TITLE
feat: add pid and AM-based appid query fallback for wayland session

### DIFF
--- a/panels/dock/taskmanager/treelandwindow.cpp
+++ b/panels/dock/taskmanager/treelandwindow.cpp
@@ -144,7 +144,10 @@ pid_t TreeLandWindow::pid()
 
 QStringList TreeLandWindow::identity()
 {
-    return {m_foreignToplevelHandle ? m_foreignToplevelHandle->appid() : ""};
+    return QStringList{
+        (m_foreignToplevelHandle ? m_foreignToplevelHandle->appid() : ""),
+        QString::number(pid())
+    };
 }
 
 QString TreeLandWindow::icon()


### PR DESCRIPTION
为 treeland 会话增加基于 pid 反查归属应用 appid 信息的逻辑.

PMS: BUG-360357

## Summary by Sourcery

Enhancements:
- Include the window process ID alongside the app ID in Treeland window identity queries to support PID-based fallback lookup.