### PR TITLE
fix: prioritize notification-specific image hints in appIcon

### DIFF
--- a/panels/notification/bubble/bubbleitem.cpp
+++ b/panels/notification/bubble/bubbleitem.cpp
@@ -195,11 +195,16 @@ QString BubbleItem::appName() const
 
 QString BubbleItem::appIcon() const
 {
+    // image-data / icon_data hints carry the notification-specific image
+    const QString iconFromHints = imagePathOfNotification(m_entity.hints(), m_entity.appIcon(), m_entity.appName());
+    if (!iconFromHints.isEmpty())
+        return iconFromHints;
+
     if (!m_entity.appIcon().isEmpty()) {
         return m_entity.appIcon();
     }
 
-    return imagePathOfNotification(m_entity.hints(), m_entity.appIcon(), m_entity.appName());
+    return {};
 }
 
 QString BubbleItem::summary() const


### PR DESCRIPTION
1. Changed appIcon() to check image/icon data hints from notification hints first
2. Return icon from hints earlier if available, avoiding fallback to generic app icon
3. Simplified fallback to return empty string when no hints or app icon present

Log: Fixed app icon display to prioritize notification-specific image data over generic app icon

Influence:
1. Test notifications with custom image hints to verify correct icon display
2. Test notifications without image hints to ensure fallback to app icon works
3. Verify behavior with empty app icon and no hints
4. Check backward compatibility with existing notification formats

fix: 在appIcon中优先显示通知特定的图像提示

1. 修改appIcon()方法，优先从通知提示中检查图像/图标数据
2. 如果有提示中的图标，则提前返回，避免回退到通用应用图标
3. 当没有提示或应用图标时，简化处理为返回空字符串

Log: 修复通知图标显示，优先使用通知特定的图像数据而非通用应用图标

Influence:
1. 测试带有自定义图像提示的通知，验证正确显示图标
2. 测试没有图像提示的通知，确保正确回退到应用图标
3. 验证应用图标为空且无提示时的表现
4. 检查与现有通知格式的向后兼容性

PMS: BUG-367549

## Summary by Sourcery

Bug Fixes:
- Ensure notification bubbles use image-data/icon_data hints for icons before falling back to the generic app icon.