### PR TITLE
fix: correct task manager space calculation for window split mode

### DIFF
--- a/panels/dock/taskmanager/package/TaskManager.qml
+++ b/panels/dock/taskmanager/package/TaskManager.qml
@@ -14,11 +14,14 @@ ContainmentItem {
     id: taskmanager
     property bool useColumnLayout: Panel.rootObject.useColumnLayout
     property int dockOrder: 16
-    readonly property real remainingSpacesForTaskManager: {
+
+    function calcRemainingSpace(baseSize) {
         const otherCount = Panel.rootObject.dockCenterPartCount - 1;
-        const otherOccupied = otherCount > 0 ? otherCount * Panel.rootObject.dockItemMaxSize * 0.8 : 0;
+        const otherOccupied = otherCount > 0 ? otherCount * baseSize * multitaskViewIconRatio : 0;
         return Panel.rootObject.dockRawCenterSpace - otherOccupied;
     }
+
+    readonly property real remainingSpacesForTaskManager: calcRemainingSpace(Panel.rootObject.dockItemMaxSize)
     readonly property int appTitleSpacing: Math.max(10, Math.round(Panel.rootObject.dockItemMaxSize * 9 / 14) / 3)
     // Start padding for the app container so that the visual gap
     // (multitask icon right edge → first app icon left edge) = appTitleSpacing.
@@ -80,11 +83,15 @@ ContainmentItem {
         id: textCalculator
         enabled: taskmanager.Applet.windowSplit && (Panel.position == Dock.Bottom || Panel.position == Dock.Top)
         dataModel: taskmanager.Applet.dataModel
-        iconSize: Panel.rootObject.dockItemMaxSize * 9 / 14
-        spacing: appContainer.spacing
+        iconSize: Panel.rootObject.dockSize * 9 / 14
+        spacing: Math.max(10, Math.round(textCalculator.iconSize) / 3)
         cellSize: textCalculator.iconSize
         itemPadding: Math.round(textCalculator.iconSize / 8)
-        remainingSpace: taskmanager.remainingSpacesForTaskManager - taskmanager.startPadding
+        remainingSpace: {
+            const dockIconSize = Panel.rootObject.dockSize;
+            const startPadding = Math.max(0, textCalculator.spacing - (dockIconSize * (multitaskViewIconRatio - iconWidthToMaxSizeRatio) / 2));
+            return calcRemainingSpace(dockIconSize) - startPadding;
+        }
         font.family: D.DTK.fontManager.t6.family
         font.pixelSize: Math.max(10, Math.min(20, Math.round(textCalculator.iconSize * 0.35)))
     }


### PR DESCRIPTION
1. Refactored `remainingSpacesForTaskManager` from a readonly property to a function `calcRemainingSpace(baseSize)` for reuse with dynamic base size
2. Updated `TextCalculator` to use `dockSize` instead of `dockItemMaxSize` for icon size, ensuring consistency with actual dock state
3. Fixed `TextCalculator.spacing` to be computed from icon size, matching updated visual requirements
4. Redefined `remainingSpace` in `TextCalculator` to use the new function with proper start padding calculation, accounting for multitask view icon ratio
5. Added proper start padding formula to balance visual gaps between multitask icon and first app icon

Log: Optimized task space calculation for window split mode layouts

Influence:
1. Test dock in bottom/top positions with window split mode enabled
2. Verify app icon sizes and spacing appear proportional to dock size
3. Check remaining space calculation when other dock center items exist
4. Validate visual gap between multitask icon and first app icon matches `appTitleSpacing`
5. Test with varying screen resolutions and dock scaling (dockSize changes)
6. Verify no regressions when window split mode is disabled

fix: 修正窗口分屏模式下任务管理器空间计算

1. 将 `remainingSpacesForTaskManager` 从只读属性重构为函数 `calcRemainingSpace(baseSize)`，支持动态基础大小复用
2. 更新 `TextCalculator` 使用 `dockSize` 而非 `dockItemMaxSize` 计算图标 大小，确保与实际停靠栏状态一致
3. 修正 `TextCalculator.spacing` 根据图标大小计算，匹配更新后的视觉需求
4. 重新定义 `TextCalculator` 中的 `remainingSpace`，使用新函数并加入正确 的起始填充计算，考虑多任务视图图标比例
5. 添加正确的起始填充公式，平衡多任务图标与首个应用图标之间的视觉间距

Log: 优化窗口分屏模式下任务栏空间计算

Influence:
1. 在底部/顶部位置并启用窗口分屏模式下测试停靠栏
2. 验证应用图标大小和间距是否与停靠栏大小成比例
3. 当存在其他停靠栏中心项时检查剩余空间计算
4. 验证多任务图标与首个应用图标之间的视觉间距是否匹配 `appTitleSpacing`
5. 使用不同屏幕分辨率和停靠栏缩放（dockSize 变化）进行测试
6. 验证禁用窗口分屏模式时没有回归问题

PMS: BUG-368031

## Summary by Sourcery

Adjust task manager space and icon calculations to align dock layout with window split mode visuals.

New Features:
- Support dynamic base size calculation for remaining dock center space via a reusable calcRemainingSpace function.

Bug Fixes:
- Correct remaining space computation for the task manager when other dock center items are present, using proper icon ratio and start padding.
- Fix icon size and spacing calculations in TextCalculator to be proportional to the current dock size and multitask icon ratio.

Enhancements:
- Refine start padding and app title spacing to maintain consistent visual gaps between the multitask icon and the first app icon across dock positions.