### PR TITLE
chore: update changelog to 2.0.49

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-shell (2.0.49) unstable; urgency=medium
+
+  * fix: correct task manager space calculation for window split mode
+  * feat: add pid and AM-based appid query fallback for wayland session
+
+ -- zhangkun <zhangkun2@uniontech.com>  Tue, 30 Jun 2026 14:58:40 +0800
+
 dde-shell (2.0.48) unstable; urgency=medium
 
   * revert: "fix: correct dock context menu popup positioning"


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 2.0.49

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 2.0.49
- 目标分支: master

## Summary by Sourcery

Build:
- Refresh debian/changelog to reflect version 2.0.49 targeting master.