### PR TITLE
feat: always show all quick panel plugins

### DIFF
--- a/panels/dock/tray/quickpanel/quickpanelproxymodel.cpp
+++ b/panels/dock/tray/quickpanel/quickpanelproxymodel.cpp
@@ -118,10 +118,7 @@ bool QuickPanelProxyModel::filterAcceptsRow(int sourceRow, const QModelIndex &so
     const auto index = this->sourceModel()->index(sourceRow, 0, sourceParent);
     if (!index.isValid())
         return false;
-    if (m_quickPlugins.isEmpty())
-        return true;
-    const auto &id = surfacePluginId(index);
-    return m_quickPlugins.contains(id);
+    return true;
 }
 
 void QuickPanelProxyModel::updateQuickPlugins()


### PR DESCRIPTION
Remove filtering logic in QuickPanelProxyModel that was hiding plugins
not in the
m_quickPlugins list. This change reverts to showing all available quick
plugins
unconditionally, ensuring no plugins are inadvertently excluded from
the panel.

Influence:
1. Verify all quick panel plugins are visible in the tray area
2. Ensure no plugins are missing or incorrectly filtered out
3. Test with various plugin configurations to confirm consistent display

feat: 始终显示所有快捷面板插件

移除 QuickPanelProxyModel 中的过滤逻辑，该逻辑会隐藏不在 m_quickPlugins
列表中的插件。此修改恢复无条件显示所有可用快捷插件，确保没有插件被意外排
除在面板之外。

Influence:
1. 验证所有快捷面板插件在托盘区域均可见
2. 确保没有插件被遗漏或错误过滤
3. 使用不同插件配置进行测试，确认显示一致性

## Summary by Sourcery

Enhancements:
- Remove QuickPanelProxyModel filtering so that all available quick plugins are displayed unconditionally in the tray quick panel.