### PR TITLE
fix(dock): correct hovered crystal color for dark mode in AppItemBack…

### DIFF
--- a/panels/dock/taskmanager/package/AppItemBackground.qml
+++ b/panels/dock/taskmanager/package/AppItemBackground.qml
@@ -75,7 +75,7 @@ AppletItemBackground {
         }
         normalDark: normal
         hovered {
-            crystal: Qt.rgba(0, 0, 0, 0.05)
+            crystal: Qt.rgba(1.0, 1.0, 1.0, 0.1)
         }
         hoveredDark: hovered
         pressed: hovered
@@ -106,14 +106,14 @@ AppletItemBackground {
     }
     outsideBorderColor: Palette {
         normal {
-            crystal: if (displayMode === Dock.Efficient) {
+            crystal: if (displayMode === Dock.Efficient && control.windowCount > 0) {
                     return Qt.rgba(0, 0, 0, 0.1)
             } else {
                     return ("transparent")
             }
         }
         normalDark {
-            crystal: if (displayMode === Dock.Efficient) {
+            crystal: if (displayMode === Dock.Efficient && control.windowCount > 0) {
                     return Qt.rgba(0, 0, 0, 0.05)
             } else {
                     return ("transparent")


### PR DESCRIPTION
…ground

1. Changed hovered crystal color from black (0,0,0,0.05) to white (1,1,1,0.1)
2. Ensures hover effect is visible on dark backgrounds in dark mode

Log: Fix hovered background color in AppItemBackground for dark mode visibility

fix(dock): 修正 AppItemBackground 深色模式下的悬停水晶颜色

1. 将悬停水晶颜色从黑色 (0,0,0,0.05) 改为白色 (1,1,1,0.1)
2. 确保深色模式下在深色背景上悬停效果可见

Log: 修复 AppItemBackground 深色模式下的悬停背景颜色可见性问题
PMS: BUG-364205

## Summary by Sourcery

Bug Fixes:
- Fix invisible hover crystal effect in AppItemBackground when used on dark backgrounds in dark mode.