### PR TITLE
fix(dock): close legacy tray tooltip on popup destruction

### DIFF
--- a/panels/dock/tray/TrayItemSurfacePopup.qml
+++ b/panels/dock/tray/TrayItemSurfacePopup.qml
@@ -129,6 +129,13 @@ Item {
     }
 
     Connections {
+        target: toolTip.shellSurface
+        function onAboutToDestroy() {
+            toolTip.close()
+        }
+    }
+
+    Connections {
         target: DockCompositor
         function onPopupCreated(popupSurface) {
             let surfaceId = `${popupSurface.pluginId}::${popupSurface.itemKey}`


### PR DESCRIPTION
## What changed

Close a legacy tray tooltip directly when its `PluginPopup` emits
`aboutToDestroy`.

Fixes linuxdeepin/developer-center#13616.

## Root cause

Legacy tray tooltip content is owned by a plugin popup while the translucent
tooltip host is owned by `dde-shell`. The plugin loader correctly hides and
destroys its popup, but `ShellSurfaceItemProxy.onSurfaceDestroyed` is not emitted
for this teardown. `TrayItemSurfacePopup` therefore never closes the shared host,
leaving an empty translucent background after the text disappears.

`PluginPopup.aboutToDestroy` is the authoritative server-side lifecycle signal
and is emitted immediately before the popup object is deleted. Connecting the
tooltip to that signal closes the host at the correct boundary.

## Impact

Legacy tray items such as Volume and Clipboard dismiss their tooltip background
correctly. Native actions such as Quick Actions and Collapse Tray are unchanged.

## Validation

- Captured the complete plugin lifecycle: pointer leave, QWidget/QWindow hide,
  popup-map removal, and `PluginPopupSurface` destruction all completed.
- Confirmed the old `ShellSurfaceItemProxy.onSurfaceDestroyed` handler did not
  run for the plugin popup teardown.
- Built a clean Arch package from dde-shell 2.0.50 containing only this lifecycle
  connection.
- Live-tested Volume and Clipboard with the exact straight-down pointer exit;
  both now dismiss cleanly.
- Rebuilt without diagnostic logging and repeated the live test successfully.

## Summary by Sourcery

Bug Fixes:
- Close legacy tray tooltip hosts in response to plugin popup about-to-destroy events so tooltip backgrounds no longer remain visible after content is dismissed.