### PR TITLE
fix: cache appearance opacity in the shell

### DIFF
--- a/applets/dde-appearance/appearanceapplet.cpp
+++ b/applets/dde-appearance/appearanceapplet.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -39,11 +39,7 @@ bool AppearanceApplet::load()
 
 qreal AppearanceApplet::opacity() const
 {
-    if (!m_interface)
-        return -1;
-
-    // The minimum opacity is 0.2
-    return std::max(0.2, m_interface->opacity());
+    return m_opacity;
 }
 
 void AppearanceApplet::initDBusProxy()
@@ -56,11 +52,25 @@ void AppearanceApplet::initDBusProxy()
     if (!m_interface->isValid()) {
         qWarning() << "Failed to proxy Appearance, error:" << m_interface->lastError();
         m_interface.reset();
+        updateOpacity(-1);
         return;
     }
 
-    m_interface->setSync(false);
-    QObject::connect(m_interface.data(), &org::deepin::dde::Appearance1::OpacityChanged, this, &AppearanceApplet::opacityChanged);
+    QObject::connect(m_interface.data(), &org::deepin::dde::Appearance1::OpacityChanged,
+                     this, &AppearanceApplet::updateOpacity);
+    updateOpacity(m_interface->opacity());
+}
+
+void AppearanceApplet::updateOpacity(qreal opacity)
+{
+    if (opacity >= 0) {
+        // The minimum opacity is 0.2
+        opacity = std::max(0.2, opacity);
+    }
+    if (qFuzzyCompare(m_opacity, opacity))
+        return;
+
+    m_opacity = opacity;
     Q_EMIT opacityChanged();
 }
 

--- a/applets/dde-appearance/appearanceapplet.h
+++ b/applets/dde-appearance/appearanceapplet.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -24,8 +24,10 @@ signals:
     void opacityChanged();
 private:
     void initDBusProxy();
+    void updateOpacity(qreal opacity);
 private:
     QScopedPointer<org::deepin::dde::Appearance1> m_interface;
+    qreal m_opacity = -1;
 };
 
 }

--- a/panels/dock/taskmanager/taskmanager.cpp
+++ b/panels/dock/taskmanager/taskmanager.cpp
@@ -538,8 +538,8 @@ void TaskManager::modifyOpacityChanged()
     DS_NAMESPACE::DAppletBridge appearanceBridge("org.deepin.ds.dde-appearance");
     auto appearanceApplet = appearanceBridge.applet();
     if (appearanceApplet) {
-        double opacity = appearanceApplet->property("opacity").toReal();
         if (auto x11Monitor = qobject_cast<X11WindowMonitor*>(m_windowMonitor.data())) {
+            double opacity = appearanceApplet->property("opacity").toReal();
             x11Monitor->setPreviewOpacity(opacity);
         }
     } else {


### PR DESCRIPTION
Cache the Appearance1 opacity after proxy initialization and update it from OpacityChanged instead of issuing a D-Bus property request for every QML read. Only access the cached property when the task manager uses the X11 window monitor, avoiding unnecessary work on Wayland.

在代理初始化后缓存 Appearance1 透明度，并通过 OpacityChanged 更新，避免每次 QML 读取都发起 D-Bus 属性请求。任务管理器仅在使用 X11 窗口监视器时访问该缓存属性，避免 Wayland 下的无效操作。

Log: cache appearance opacity in the shell