### PR TITLE
feat(dock): add accessibility annotations to dock QML

### DIFF
--- a/panels/dock/OverflowContainer.qml
+++ b/panels/dock/OverflowContainer.qml
@@ -26,6 +26,7 @@ Item {
         layoutDirection: Qt.LeftToRight
         verticalLayoutDirection: ListView.TopToBottom
         interactive: false
+        Accessible.role: Accessible.List
     }
 
     function calculateImplicitWidth(prev, current) {

--- a/panels/dock/multitaskview/package/multitaskview.qml
+++ b/panels/dock/multitaskview/package/multitaskview.qml
@@ -13,6 +13,9 @@ AppletDockItem {
     id: toggleworkspace
     dockOrder: 15
 
+    Accessible.role: Accessible.Button
+    Accessible.name: toolTip.text
+
     PanelToolTip {
         id: toolTip
         text: qsTr("Multitasking View")

--- a/panels/dock/package/main.qml
+++ b/panels/dock/package/main.qml
@@ -520,6 +520,8 @@ Window {
                 visible: dockLeftPartModel.count > 0
                 implicitWidth: leftLoader.implicitWidth
                 implicitHeight: leftLoader.implicitHeight
+                Accessible.role: Accessible.Grouping
+                Accessible.name: qsTr("Dock Left Area")
                 OverflowContainer {
                     id: leftLoader
                     anchors.fill: parent
@@ -536,6 +538,8 @@ Window {
                 id: dockCenterPart
                 implicitWidth: centerLoader.implicitWidth
                 implicitHeight: centerLoader.implicitHeight
+                Accessible.role: Accessible.Grouping
+                Accessible.name: qsTr("Dock Center Area")
                 Layout.maximumWidth: useColumnLayout ? -1 : dockRawCenterSpace
                 Layout.maximumHeight: useColumnLayout ? dockRawCenterSpace : -1
                 onXChanged: dockCenterPartPosChanged()
@@ -584,6 +588,8 @@ Window {
             id: dockRightPart
             implicitWidth: rightLoader.implicitWidth
             implicitHeight: rightLoader.implicitHeight
+            Accessible.role: Accessible.Grouping
+            Accessible.name: qsTr("Dock Right Area")
             anchors.right: parent.right
             anchors.bottom: parent.bottom
             OverflowContainer {

--- a/panels/dock/showdesktop/package/showdesktop.qml
+++ b/panels/dock/showdesktop/package/showdesktop.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -29,6 +29,9 @@ AppletItem {
     AppletItemButton {
         anchors.fill: parent
         radius: 0
+
+        Accessible.role: Accessible.Button
+        Accessible.name: toolTip.text
 
         Rectangle {
             property D.Palette lineColor: DockPalette.showDesktopLineColor

--- a/panels/dock/taskmanager/package/AppItem.qml
+++ b/panels/dock/taskmanager/package/AppItem.qml
@@ -36,6 +36,10 @@ Item {
     Drag.hotSpot.y: icon.height / 2
     Drag.dragType: Drag.Automatic
     Drag.mimeData: { "text/x-dde-dock-dnd-appid": itemId, "text/x-dde-dock-dnd-source": "taskbar", "text/x-dde-dock-dnd-winid": windows.length > 0 ? windows[0] : ""}
+
+    Accessible.role: Accessible.Button
+    Accessible.name: root.name
+    Accessible.description: root.attention ? qsTr("Demands attention") : (root.active ? qsTr("Active") : "")
     
     property bool useColumnLayout: Panel.rootObject.useColumnLayout
     property real iconSize: Panel.rootObject.dockItemMaxSize * 9 / 14

--- a/panels/dock/taskmanager/package/TaskManager.qml
+++ b/panels/dock/taskmanager/package/TaskManager.qml
@@ -15,6 +15,9 @@ ContainmentItem {
     property bool useColumnLayout: Panel.rootObject.useColumnLayout
     property int dockOrder: 16
 
+    Accessible.role: Accessible.Grouping
+    Accessible.name: qsTr("Task Manager")
+
     function calcRemainingSpace(baseSize) {
         const otherCount = Panel.rootObject.dockCenterPartCount - 1;
         const otherOccupied = otherCount > 0 ? otherCount * baseSize * multitaskViewIconRatio : 0;

--- a/panels/dock/tray/ShellSurfaceItemProxy.qml
+++ b/panels/dock/tray/ShellSurfaceItemProxy.qml
@@ -22,6 +22,8 @@ Item {
     implicitWidth: shellSurface ? shellSurface.width : 16
     implicitHeight: shellSurface ? shellSurface.height : 16
 
+    Accessible.name: shellSurface ? (shellSurface.displayName || "") : ""
+
     function takeFocus() {
         impl.takeFocus()
     }

--- a/panels/dock/tray/package/ActionShowStashDelegate.qml
+++ b/panels/dock/tray/package/ActionShowStashDelegate.qml
@@ -25,6 +25,9 @@ AppletItemButton {
 
     padding: itemPadding
 
+    Accessible.role: Accessible.Button
+    Accessible.name: toolTip.text
+
     D.ColorSelector.hovered: (isDropHover && DDT.TraySortOrderModel.actionsAlwaysVisible) || hovered || stashedPopup.popupVisible
 
     property var itemGlobalPoint: {

--- a/panels/dock/tray/package/ActionToggleCollapseDelegate.qml
+++ b/panels/dock/tray/package/ActionToggleCollapseDelegate.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -16,6 +16,9 @@ AppletItemButton {
     property bool inputEventsEnabled: true
     hoverEnabled: inputEventsEnabled
     autoClosePopup: true
+
+    Accessible.role: Accessible.Button
+    Accessible.name: toolTip.text
 
     z: 5
 

--- a/panels/dock/tray/package/ActionToggleQuickSettingsDelegate.qml
+++ b/panels/dock/tray/package/ActionToggleQuickSettingsDelegate.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -13,4 +13,7 @@ QuickPanel {
     useColumnLayout: !isHorizontal
     trayItemPluginId: Applet.rootObject.quickpanelTrayItemPluginId
     trayItemMargins: itemPadding
+
+    Accessible.role: Accessible.Button
+    Accessible.name: qsTr("Quick actions")
 }


### PR DESCRIPTION
## Summary

Add Qt Quick `Accessible` attached properties to the dock panel QML so screen readers (e.g. Orca over AT-SPI) can read the taskbar:

- **AppItem**: `Button` role, app name, and "Active"/"Demands attention" state description
- **TaskManager containment** and **dock left/center/right areas**: `Grouping` role with names (plain names without a role map to AT-SPI `filler` and get ignored by Orca)
- **Container ListViews** (OverflowContainer): `List` role
- **Action buttons** (show desktop, multitask view, tray collapse/stash/quick-settings): `Button` role + name, reusing existing toolTip text
- **Embedded tray surfaces** (ShellSurfaceItemProxy): expose the plugin's `displayName` when available

Annotations only — no focus, behavior, or layout changes (+31 lines across 10 QML files).

## Test

- qmllint: no syntax errors, no new warnings.
- Runtime-verified on an X11 session (dock + dde-apps, `QT_LINUX_ACCESSIBILITY_ALWAYS_ON=1`, at-spi2): the dock window exposes "Dock Left/Center/Right Area", "Task Manager", per-app `[button]` nodes with names (文件管理器 / Google Chrome / …), and the active window carries the "Active" description, by walking the AT-SPI tree via GI.

## Out of scope (follow-ups)

- Keyboard navigation for the dock (needs a focus strategy decision: `Qt.WindowDoesNotAcceptFocus` + layer-shell keyboard interactivity)
- Launcher UI annotations (lives in dde-launchpad)
- SNI tray icons' own a11y (rendered by dde-tray-loader plugin processes)