### PR TITLE
fix: delay drag activation to fix first drag icon not showing in treeland

### DIFF
--- a/panels/dock/tray/quickpanel/DragItem.qml
+++ b/panels/dock/tray/quickpanel/DragItem.qml
@@ -144,9 +144,11 @@ Item {
                     console.log("grab to image", result.url)
 
                     draggingImage = result.url
+                    Qt.callLater(function() { dragItem.Drag.active = true })
                 })
+            } else {
+                dragItem.Drag.active = false
             }
-            dragItem.Drag.active = active
         }
     }
 }


### PR DESCRIPTION
The issue was that on treeland, the first drag attempt did not display
the icon because `Drag.active` was set to `true` immediately without
waiting for the drag image to be fully captured. By moving `Drag.active
= true` into a `Qt.callLater()` callback after the image grab
completes, we ensure the drag image is ready before activating the drag.
Additionally, setting `Drag.active = false` when drag is not active
prevents premature drag activation.

Log: Fixed first drag icon not showing issue on treeland

Influence:
1. Test drag behavior on treeland to verify icon appears on first drag
2. Test drag behavior on other platforms (X11, Wayland) to ensure no
regression
3. Verify that drag activation timing is correct under various
conditions

fix: 修复 treeland 下首次拖拽图标不显示的问题

   问题在于 treeland 环境下，首次拖拽时未等待拖拽图像完全捕获就
立即设置了 `Drag.active = true`。通过在图像抓取完成后的回调中使用
`Qt.callLater()` 延迟设置 `Drag.active = true`，确保拖拽图像就绪后再激活
拖拽。同时，在非拖拽状态下设置 `Drag.active = false`，避免提前激活拖拽。

Log: 修复 treeland 下首次拖拽图标不显示的问题

Influence:
1. 在 treeland 上测试拖拽功能，验证首次拖拽显示图标
2. 在其他平台（X11、Wayland）上测试拖拽，确保无回归
3. 验证各种条件下拖拽激活时机的正确性

## Summary by Sourcery

Bug Fixes:
- Fix missing drag icon on the first drag attempt in treeland by aligning Drag.active timing with image capture completion.