### PR TITLE
feat: add DConfig toggles for dock context menu and docked applications

### DIFF
--- a/panels/dock/dconfig/org.deepin.ds.dock.json
+++ b/panels/dock/dconfig/org.deepin.ds.dock.json
@@ -91,6 +91,17 @@
 			"description": "Enable or disable the show desktop area on the right side of the dock",
 			"permissions": "readwrite",
 			"visibility": "private"
+		},
+		"enableContextMenu": {
+			"value": true,
+			"serial": 0,
+			"flags": [],
+			"name": "Enable Dock Context Menu",
+			"name[zh_CN]": "启用任务栏右键菜单",
+			"description": "Enable or disable the context menu on the empty area of the dock.",
+			"description[zh_CN]": "启用或禁用任务栏空白区域的右键菜单和触摸长按菜单。",
+			"permissions": "readwrite",
+			"visibility": "private"
 		}
 	}
 }

--- a/panels/dock/dockpanel.cpp
+++ b/panels/dock/dockpanel.cpp
@@ -119,6 +119,7 @@ bool DockPanel::init()
     connect(SETTINGS, &DockSettings::itemAlignmentChanged, this, &DockPanel::itemAlignmentChanged);
     connect(SETTINGS, &DockSettings::indicatorStyleChanged, this, &DockPanel::indicatorStyleChanged);
     connect(SETTINGS, &DockSettings::lockedChanged, this, &DockPanel::lockedChanged);
+    connect(SETTINGS, &DockSettings::contextMenuEnabledChanged, this, &DockPanel::contextMenuEnabledChanged);
 
     connect(SETTINGS, &DockSettings::dockSizeChanged, this, [this, dockDaemonAdaptor](){
         Q_EMIT dockDaemonAdaptor->WindowSizeEfficientChanged(dockSize());
@@ -423,6 +424,11 @@ void DockPanel::setShowInPrimary(bool newShowInPrimary)
 bool DockPanel::locked() const
 {
     return SETTINGS->locked();
+}
+
+bool DockPanel::contextMenuEnabled() const
+{
+    return SETTINGS->contextMenuEnabled();
 }
 
 void DockPanel::setLocked(bool newLocked)

--- a/panels/dock/dockpanel.h
+++ b/panels/dock/dockpanel.h
@@ -35,6 +35,7 @@ class DockPanel : public DS_NAMESPACE::DPanel, public QDBusContext
     Q_PROPERTY(QString screenName READ screenName NOTIFY screenNameChanged FINAL)
     Q_PROPERTY(bool locked READ locked WRITE setLocked NOTIFY lockedChanged FINAL)
     Q_PROPERTY(bool isResizing READ isResizing WRITE setIsResizing NOTIFY isResizingChanged FINAL)
+    Q_PROPERTY(bool contextMenuEnabled READ contextMenuEnabled NOTIFY contextMenuEnabledChanged FINAL)
 
     Q_PROPERTY(qreal devicePixelRatio READ devicePixelRatio NOTIFY devicePixelRatioChanged FINAL)
 
@@ -93,6 +94,7 @@ public:
 
     bool locked() const;
     void setLocked(bool newLocked);
+    bool contextMenuEnabled() const;
 
     void setHideState(HideState newHideState);
     QScreen* dockScreen();
@@ -135,6 +137,7 @@ Q_SIGNALS:
     void leftEdgeClicked(const QString &minOrder);
     void devicePixelRatioChanged(qreal ratio);
     void lockedChanged(bool locked);
+    void contextMenuEnabledChanged(bool enabled);
 
     void contextDraggingChanged();
     void isResizingChanged(bool isResizing);

--- a/panels/dock/docksettings.cpp
+++ b/panels/dock/docksettings.cpp
@@ -27,6 +27,7 @@ const static QString keyIndicatorStyle          = "Indicator_Style";
 const static QString keyPluginsVisible           = "Plugins_Visible";
 const static QString keyShowInPrimary           = "Show_In_Primary";
 const static QString keyLocked                  = "Locked";
+const static QString keyEnableContextMenu       = "enableContextMenu";
 
 namespace dock {
 
@@ -156,6 +157,7 @@ DockSettings::DockSettings(QObject* parent)
     , m_alignment(dock::CenterAlignment)
     , m_style(dock::Fashion)
     , m_locked(false)
+    , m_contextMenuEnabled(true)
 {
     m_writeTimer->setSingleShot(true);
     m_writeTimer->setInterval(1000);
@@ -174,6 +176,7 @@ void DockSettings::init()
         m_pluginsVisible = m_dockConfig->value(keyPluginsVisible).toMap();
         m_showInPrimary = m_dockConfig->value(keyShowInPrimary).toBool();
         m_locked = m_dockConfig->value(keyLocked).toBool();
+        m_contextMenuEnabled = m_dockConfig->value(keyEnableContextMenu, true).toBool();
 
         // Log dock config on startup - merge shell_pos and shell_dock_mode into one log entry
         logDockConfig(m_dockPosition, m_alignment, QStringLiteral("on startup"));
@@ -217,6 +220,11 @@ void DockSettings::init()
                 if (locked == m_locked) return;
                 m_locked = locked;
                 Q_EMIT lockedChanged(m_locked);
+            } else if (keyEnableContextMenu == key) {
+                const auto enabled = m_dockConfig->value(keyEnableContextMenu, true).toBool();
+                if (enabled == m_contextMenuEnabled) return;
+                m_contextMenuEnabled = enabled;
+                Q_EMIT contextMenuEnabledChanged(m_contextMenuEnabled);
             }
         });
     } else {
@@ -329,6 +337,11 @@ bool DockSettings::showInPrimary() const
 bool DockSettings::locked() const
 {
     return m_locked;
+}
+
+bool DockSettings::contextMenuEnabled() const
+{
+    return m_contextMenuEnabled;
 }
 
 void DockSettings::setLocked(bool newLocked)

--- a/panels/dock/docksettings.h
+++ b/panels/dock/docksettings.h
@@ -28,6 +28,7 @@ class DockSettings : public QObject
     Q_PROPERTY(QVariantMap pluginsVisible READ pluginsVisible WRITE setPluginsVisible NOTIFY pluginsVisibleChanged FINAL)
     Q_PROPERTY(bool showInPrimary READ showInPrimary WRITE setShowInPrimary NOTIFY showInPrimaryChanged FINAL)
     Q_PROPERTY(bool locked READ locked WRITE setLocked NOTIFY lockedChanged FINAL)
+    Q_PROPERTY(bool contextMenuEnabled READ contextMenuEnabled NOTIFY contextMenuEnabledChanged FINAL)
 
 public:
     static DockSettings* instance();
@@ -40,6 +41,7 @@ public:
     QVariantMap pluginsVisible();
     bool showInPrimary() const;
     bool locked() const;
+    bool contextMenuEnabled() const;
 
     void setDockSize(const uint& size);
     void setHideMode(const HideMode& mode);
@@ -76,6 +78,7 @@ Q_SIGNALS:
 
     void showInPrimaryChanged(bool showInPrimary);
     void lockedChanged(bool locked);
+    void contextMenuEnabledChanged(bool enabled);
 
 private:
     QScopedPointer<DConfig> m_dockConfig;
@@ -90,5 +93,6 @@ private:
     QVariantMap m_pluginsVisible;
     bool m_showInPrimary;
     bool m_locked;
+    bool m_contextMenuEnabled;
 };
 }

--- a/panels/dock/package/main.qml
+++ b/panels/dock/package/main.qml
@@ -58,6 +58,9 @@ Window {
     }
 
     function requestShowDockMenu() {
+        if (!Panel.contextMenuEnabled)
+            return
+
         // maybe has popup visible, close it.
         Panel.requestClosePopup()
         viewDeactivated()
@@ -381,6 +384,18 @@ Window {
         }
     }
 
+    Connections {
+        target: Panel
+        function onContextMenuEnabledChanged() {
+            if (Panel.contextMenuEnabled)
+                return
+
+            if (MenuHelper.activeMenu === dockMenuLoader.item)
+                MenuHelper.closeCurrent()
+            dockMenuLoader.active = false
+        }
+    }
+
     Item {
         id: dockContainer
         width: dock.useColumnLayout ? dock.dockSize : parent.width
@@ -418,8 +433,10 @@ Window {
             onTapped: function(eventPoint, button) {
                 let lastActive = MenuHelper.activeMenu
                 MenuHelper.closeCurrent()
-                dockMenuLoader.active = true
-                if (button === Qt.RightButton && lastActive !== dockMenuLoader.item) {
+                if (button === Qt.RightButton && Panel.contextMenuEnabled) {
+                    dockMenuLoader.active = true
+                }
+                if (button === Qt.RightButton && Panel.contextMenuEnabled && lastActive !== dockMenuLoader.item) {
                     requestShowDockMenu()
                 }
                 if (button === Qt.LeftButton) {
@@ -441,7 +458,6 @@ Window {
                 }
                 let lastActive = MenuHelper.activeMenu
                 MenuHelper.closeCurrent()
-                dockMenuLoader.active = true
                 // try to close popup when clicked empty, because dock does not have focus.
                 Panel.requestClosePopup()
                 viewDeactivated()
@@ -450,8 +466,10 @@ Window {
                 dockContainer.touchLongPressed = true
                 let lastActive = MenuHelper.activeMenu
                 MenuHelper.closeCurrent()
-                dockMenuLoader.active = true
-                if (lastActive !== dockMenuLoader.item) {
+                if (Panel.contextMenuEnabled) {
+                    dockMenuLoader.active = true
+                }
+                if (Panel.contextMenuEnabled && lastActive !== dockMenuLoader.item) {
                     requestShowDockMenu()
                 }
             }

--- a/panels/dock/taskmanager/appitem.cpp
+++ b/panels/dock/taskmanager/appitem.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -27,6 +27,8 @@ AppItem::AppItem(QString id, QObject *parent)
     connect(this, &AbstractItem::dataChanged, this, &AppItem::checkAppItemNeedDeleteAndDelete);
 
     connect(this, &AppItem::currentActiveWindowChanged, this, &AbstractItem::iconChanged);
+    connect(TaskManagerSettings::instance(), &TaskManagerSettings::dockedApplicationsEnabledChanged,
+            this, [this] { Q_EMIT menusChanged(); });
 }
 
 AppItem::~AppItem()
@@ -105,10 +107,12 @@ QString AppItem::menus() const
     //     array.append(allWindowMenu);
     // }
 
-    QJsonObject dockMenu;
-    dockMenu["id"] = DOCK_ACTION_DOCK;
-    dockMenu["name"] = isDocked() ? tr("Undock") : tr("Dock");
-    array.append(dockMenu);
+    if (TaskManagerSettings::instance()->dockedApplicationsEnabled()) {
+        QJsonObject dockMenu;
+        dockMenu["id"] = DOCK_ACTION_DOCK;
+        dockMenu["name"] = isDocked() ? tr("Undock") : tr("Dock");
+        array.append(dockMenu);
+    }
 
     if (hasWindow()) {
         QJsonObject foreceQuit;

--- a/panels/dock/taskmanager/dconfig/org.deepin.ds.dock.taskmanager.json
+++ b/panels/dock/taskmanager/dconfig/org.deepin.ds.dock.taskmanager.json
@@ -106,6 +106,17 @@
 			"description": "List of app id that should prefer window icon when window split is disabled",
 			"permissions": "readwrite",
 			"visibility": "private"
+		},
+		"enableDockedApplications": {
+			"value": true,
+			"serial": 0,
+			"flags": [],
+			"name": "Enable Docked Applications",
+			"name[zh_CN]": "启用驻留任务栏应用",
+			"description": "Enable or disable docked applications on the taskbar. When disabled, docked applications that are not running are hidden and docking changes are rejected, while the saved docked application list is preserved.",
+			"description[zh_CN]": "启用或禁用任务栏驻留应用；关闭时隐藏未运行的驻留应用并禁止更改驻留状态，但保留已保存的驻留应用列表。",
+			"permissions": "readwrite",
+			"visibility": "private"
 		}
 		
 	}

--- a/panels/dock/taskmanager/desktopfileabstractparser.cpp
+++ b/panels/dock/taskmanager/desktopfileabstractparser.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -139,6 +139,11 @@ bool DesktopfileAbstractParser::isDocked()
 
 void DesktopfileAbstractParser::setDocked(bool docked)
 {
+    if (!TaskManagerSettings::instance()->dockedApplicationsEnabled()) {
+        qDebug() << "Docked application changes are disabled by DConfig";
+        return;
+    }
+
     if (!isValied().first && docked) {
         qDebug() << isValied().second;
         return;

--- a/panels/dock/taskmanager/desktopfileamparser.cpp
+++ b/panels/dock/taskmanager/desktopfileamparser.cpp
@@ -7,6 +7,7 @@
 #include "desktopfileamparser.h"
 #include "desktopfileabstractparser.h"
 #include "objectmanager1interface.h"
+#include "taskmanagersettings.h"
 
 #include <unistd.h>
 #include <sys/syscall.h>
@@ -43,7 +44,8 @@ DesktopFileAMParser::DesktopFileAMParser(QString id, QObject* parent)
     connect(&desktopobjectManager, &ObjectManager::InterfacesRemoved, this, [this] (const QDBusObjectPath& path, const QStringList& interfaces) {
         Q_UNUSED(interfaces)
         if (m_applicationInterface->path() == path.path()) {
-            getAppItem()->setDocked(false);
+            TaskManagerSettings::instance()->removeDockedElement(QStringLiteral("desktop/%1").arg(this->id()));
+            Q_EMIT dockedChanged();
             return;
         }
     });

--- a/panels/dock/taskmanager/dockglobalelementmodel.cpp
+++ b/panels/dock/taskmanager/dockglobalelementmodel.cpp
@@ -30,6 +30,7 @@ DockGlobalElementModel::DockGlobalElementModel(QAbstractItemModel *appsModel, Do
 {
     connect(TaskManagerSettings::instance(), &TaskManagerSettings::dockedElementsChanged, this, &DockGlobalElementModel::loadDockedElements);
     connect(TaskManagerSettings::instance(), &TaskManagerSettings::windowSplitChanged, this, &DockGlobalElementModel::groupItemsByApp);
+    connect(TaskManagerSettings::instance(), &TaskManagerSettings::dockedApplicationsEnabledChanged, this, &DockGlobalElementModel::loadDockedElements);
 
     connect(
         m_appsModel,
@@ -258,39 +259,41 @@ void DockGlobalElementModel::initDockedElements(bool unused)
 void DockGlobalElementModel::loadDockedElements()
 {
     QList<std::tuple<QString, QString>> newDocked;
-    for (auto elementInfo : TaskManagerSettings::instance()->dockedElements()) {
-        auto pair = elementInfo.split('/');
-        if (pair.size() != 2)
-            continue;
-
-        auto type = pair[0];
-        auto id = pair[1];
-
-        auto tmp = std::make_tuple(type, id);
-
-        // check desktop is installed
-        QAbstractItemModel *model = nullptr;
-        int row = 0;
-        if (type == "desktop") {
-            model = m_appsModel;
-            auto res = m_appsModel->match(m_appsModel->index(0, 0), TaskManager::DesktopIdRole, id, 1, Qt::MatchExactly).value(0);
-            if (!res.isValid())
+    if (TaskManagerSettings::instance()->dockedApplicationsEnabled()) {
+        for (auto elementInfo : TaskManagerSettings::instance()->dockedElements()) {
+            auto pair = elementInfo.split('/');
+            if (pair.size() != 2)
                 continue;
-            row = res.row();
-        }
 
-        newDocked.append(tmp);
-        if (m_dockedElements.contains(tmp))
-            continue;
+            auto type = pair[0];
+            auto id = pair[1];
 
-        auto isRunning = std::any_of(m_data.constBegin(), m_data.constEnd(), [this, &id](const auto &data) {
-            return std::get<0>(data) == id;
-        });
+            auto tmp = std::make_tuple(type, id);
 
-        if (!isRunning) {
-            beginInsertRows(QModelIndex(), m_data.size(), m_data.size());
-            m_data.append(std::make_tuple(id, model, row));
-            endInsertRows();
+            // check desktop is installed
+            QAbstractItemModel *model = nullptr;
+            int row = 0;
+            if (type == "desktop") {
+                model = m_appsModel;
+                auto res = m_appsModel->match(m_appsModel->index(0, 0), TaskManager::DesktopIdRole, id, 1, Qt::MatchExactly).value(0);
+                if (!res.isValid())
+                    continue;
+                row = res.row();
+            }
+
+            newDocked.append(tmp);
+            if (m_dockedElements.contains(tmp))
+                continue;
+
+            auto isRunning = std::any_of(m_data.constBegin(), m_data.constEnd(), [&id](const auto &data) {
+                return std::get<0>(data) == id;
+            });
+
+            if (!isRunning) {
+                beginInsertRows(QModelIndex(), m_data.size(), m_data.size());
+                m_data.append(std::make_tuple(id, model, row));
+                endInsertRows();
+            }
         }
     }
 
@@ -342,8 +345,10 @@ QString DockGlobalElementModel::getMenus(const QModelIndex &index) const
         menusArray.append(action);
     }
 
-    bool isDocked = (model == nullptr) || m_dockedElements.contains(std::make_tuple("desktop", id));
-    menusArray.append(QJsonObject{{"id", DOCK_ACTION_DOCK}, {"name", isDocked ? tr("Undock") : tr("Dock")}});
+    if (TaskManagerSettings::instance()->dockedApplicationsEnabled()) {
+        bool isDocked = (model == nullptr) || m_dockedElements.contains(std::make_tuple("desktop", id));
+        menusArray.append(QJsonObject{{"id", DOCK_ACTION_DOCK}, {"name", isDocked ? tr("Undock") : tr("Dock")}});
+    }
 
     if (model == m_activeAppModel) {
         if (TaskManagerSettings::instance()->isAllowedForceQuit()) {

--- a/panels/dock/taskmanager/globals.h
+++ b/panels/dock/taskmanager/globals.h
@@ -27,6 +27,7 @@ static inline const QString TASKMANAGER_CGROUPS_BASED_GROUPING_SKIP_CATEGORIES =
 static inline const QString TASKMANAGER_DOCKEDITEMS_KEY = "Docked_Items";
 constexpr auto TASKMANAGER_DOCKEDELEMENTS_KEY = "dockedElements";
 constexpr auto TASKMANAGER_WINDOW_ICON_WHITELIST_KEY = "windowIconWhitelist";
+constexpr auto TASKMANAGER_ENABLE_DOCKED_APPLICATIONS_KEY = "enableDockedApplications";
 
 // model roleNames
 constexpr auto MODEL_WINID = "winId";

--- a/panels/dock/taskmanager/taskmanager.cpp
+++ b/panels/dock/taskmanager/taskmanager.cpp
@@ -401,6 +401,7 @@ QString TaskManager::desktopIdToAppId(const QString& desktopId)
 
 bool TaskManager::requestDockByDesktopId(const QString& desktopID)
 {
+    if (!Settings->dockedApplicationsEnabled()) return false;
     if (desktopID.startsWith("internal/")) return false;
     QString appId = desktopIdToAppId(desktopID);
     // 检查应用是否已经在任务栏中，如果是则返回 false
@@ -412,12 +413,16 @@ bool TaskManager::requestDockByDesktopId(const QString& desktopID)
 
 bool TaskManager::requestUndockByDesktopId(const QString& desktopID)
 {
+    if (!Settings->dockedApplicationsEnabled()) return false;
     if (desktopID.startsWith("internal/")) return false;
     return RequestUndock(desktopIdToAppId(desktopID));
 }
 
 bool TaskManager::RequestDock(QString appID)
 {
+    if (!Settings->dockedApplicationsEnabled())
+        return false;
+
     auto desktopfileParser = DESKTOPFILEFACTORY::createById(appID, "amAPP");
 
     auto res = desktopfileParser->isValied();
@@ -451,6 +456,9 @@ bool TaskManager::IsDocked(QString appID)
 
 bool TaskManager::RequestUndock(QString appID)
 {
+    if (!Settings->dockedApplicationsEnabled())
+        return false;
+
     auto desktopfileParser = DESKTOPFILEFACTORY::createById(appID, "amAPP");
     auto res = desktopfileParser->isValied();
     if (!res.first) {
@@ -488,6 +496,9 @@ void TaskManager::activateWindow(uint32_t windowID)
 
 void TaskManager::saveDockElementsOrder(const QStringList &appIds)
 {
+    if (!Settings->dockedApplicationsEnabled())
+        return;
+
     const QStringList &dockedElements = TaskManagerSettings::instance()->dockedElements();
     QStringList newDockedElements;
     for (const auto &appId : appIds) {

--- a/panels/dock/taskmanager/taskmanagersettings.cpp
+++ b/panels/dock/taskmanager/taskmanagersettings.cpp
@@ -43,6 +43,7 @@ TaskManagerSettings* TaskManagerSettings::instance()
 TaskManagerSettings::TaskManagerSettings(QObject *parent)
     : QObject(parent)
     , m_taskManagerDconfig(DConfig::create(QStringLiteral("org.deepin.dde.shell"), QStringLiteral("org.deepin.ds.dock.taskmanager"), QString(), this))
+    , m_dockedApplicationsEnabled(true)
 {
     connect(m_taskManagerDconfig, &DConfig::valueChanged, this, [this](const QString &key){
         if (TASKMANAGER_ALLOWFOCEQUIT_KEY == key) {
@@ -58,6 +59,12 @@ TaskManagerSettings::TaskManagerSettings(QObject *parent)
         } else if (TASKMANAGER_DOCKEDELEMENTS_KEY == key) {
             m_dockedElements = m_taskManagerDconfig->value(TASKMANAGER_DOCKEDELEMENTS_KEY, {}).toStringList();
             Q_EMIT dockedElementsChanged();
+        } else if (TASKMANAGER_ENABLE_DOCKED_APPLICATIONS_KEY == key) {
+            const bool enabled = m_taskManagerDconfig->value(TASKMANAGER_ENABLE_DOCKED_APPLICATIONS_KEY, true).toBool();
+            if (enabled == m_dockedApplicationsEnabled)
+                return;
+            m_dockedApplicationsEnabled = enabled;
+            Q_EMIT dockedApplicationsEnabledChanged(m_dockedApplicationsEnabled);
         }
     });
 
@@ -66,6 +73,7 @@ TaskManagerSettings::TaskManagerSettings(QObject *parent)
     m_windowSplit = m_taskManagerDconfig->value(TASKMANAGER_WINDOWSPLIT_KEY).toBool();
     m_cgroupsBasedGrouping = m_taskManagerDconfig->value(TASKMANAGER_CGROUPS_BASED_GROUPING_KEY, true).toBool();
     m_dockedElements = m_taskManagerDconfig->value(TASKMANAGER_DOCKEDELEMENTS_KEY, {}).toStringList();
+    m_dockedApplicationsEnabled = m_taskManagerDconfig->value(TASKMANAGER_ENABLE_DOCKED_APPLICATIONS_KEY, true).toBool();
     m_cgroupsBasedGroupingSkipAppIds = m_taskManagerDconfig->value(TASKMANAGER_CGROUPS_BASED_GROUPING_SKIP_APPIDS, {"deepin-terminal"}).toStringList();
     m_cgroupsBasedGroupingSkipCategories = m_taskManagerDconfig->value(TASKMANAGER_CGROUPS_BASED_GROUPING_SKIP_CATEGORIES, {"TerminalEmulator"}).toStringList();
     m_windowIconWhitelist = m_taskManagerDconfig->value(TASKMANAGER_WINDOW_ICON_WHITELIST_KEY, {"com.tencent.wechat"}).toStringList();
@@ -130,6 +138,11 @@ bool TaskManagerSettings::isDocked(const QString &elementId) const
     return m_dockedElements.contains(elementId);
 }
 
+bool TaskManagerSettings::dockedApplicationsEnabled() const
+{
+    return m_dockedApplicationsEnabled;
+}
+
 void TaskManagerSettings::migrateFromDockedItems()
 {
     if (m_taskManagerDconfig->isDefaultValue(TASKMANAGER_DOCKEDITEMS_KEY)) {
@@ -186,6 +199,9 @@ void TaskManagerSettings::setDockedElements(const QStringList &elements)
 
 void TaskManagerSettings::toggleDockedElement(const QString &element)
 {
+    if (!m_dockedApplicationsEnabled)
+        return;
+
     if (isDocked(element)) {
         removeDockedElement(element);
     } else {

--- a/panels/dock/taskmanager/taskmanagersettings.h
+++ b/panels/dock/taskmanager/taskmanagersettings.h
@@ -43,6 +43,7 @@ public:
     void removeDockedElement(const QString &element);
     QStringList dockedElements() const;
     bool isDocked(const QString &elementId) const;
+    bool dockedApplicationsEnabled() const;
 
     void logMergeAppModel(bool mergeAppModelOn);
 
@@ -57,6 +58,7 @@ Q_SIGNALS:
     void windowSplitChanged();
     void dockedItemsChanged();
     void dockedElementsChanged();
+    void dockedApplicationsEnabledChanged(bool enabled);
 
 private:
     DConfig* m_taskManagerDconfig;
@@ -65,6 +67,7 @@ private:
     bool m_showAttentionAnimation;
     bool m_windowSplit;
     bool m_cgroupsBasedGrouping;
+    bool m_dockedApplicationsEnabled;
     QStringList m_dockedElements;
     QStringList m_windowIconWhitelist;
     QStringList m_cgroupsBasedGroupingSkipAppIds;


### PR DESCRIPTION
1. Add DConfig "enableContextMenu" to control the dock empty area context menu and touch-and-hold menu. The setting is applied in QML to conditionally show/hide the menu.
2. Add DConfig "enableDockedApplications" to control docked applications on the taskbar. When disabled, non-running docked apps are hidden, docking changes are rejected, but the saved list is preserved. The setting propagates through C++ models and settings classes to block dock/undock requests and menu items.
3. Update DConfig JSON files for both dock and taskmanager with appropriate metadata and translations.
4. Add signals and properties for both settings in DockPanel, DockSettings, and TaskManagerSettings.
5. Refactor DockGlobalElementModel::loadDockedElements to conditionally load docked elements based on the setting.
6. Modify desktop file parsers and task manager to check the setting before allowing dock/undock operations.
7. Update QML to close open context menu if disabled during runtime.

Log: Added DConfig options to enable/disable dock empty area context menu and docked applications.

Influence:
1. Test dock empty area context menu with enableContextMenu set to true and false.
2. Test dock touch-and-hold menu on tablets with enableContextMenu.
3. Test docked applications with enableDockedApplications set to true and false.
4. Verify non-running docked applications are hidden when disabled.
5. Verify dock/undock operations are blocked when disabled.
6. Verify the saved docked application list is preserved when toggling the setting.
7. Test that opening dock menu is prevented when disabled at runtime.
8. Test that currently open dock menu is closed when setting is disabled.

feat: 添加任务栏右键菜单和驻留应用功能的DConfig开关

1. 添加DConfig配置项"enableContextMenu"，控制任务栏空白区域右键菜单及触 摸长按菜单的显示与隐藏，该设置在QML中条件启用。
2. 添加DConfig配置项"enableDockedApplications"，控制任务栏驻留应用。禁用 时，隐藏未运行的驻留应用并拒绝驻留状态更改，但保留已保存的驻留列表。该设
置通过C++模型和设置类传播，阻止驻留/取消驻留请求及菜单项。
3. 更新任务栏和任务管理器的DConfig JSON文件，包含元数据和翻译。
4. 在DockPanel、DockSettings和TaskManagerSettings中添加对应信号和属性。
5. 重构DockGlobalElementModel::loadDockedElements，根据设置条件加载驻留 元素。
6. 修改桌面文件解析器和任务管理器，在执行驻留/取消驻留操作前检查该设置。
7. 在QML中，若运行时禁用设置，则关闭已打开的任务栏菜单。

Log: 新增DConfig选项，用于启用或禁用任务栏空白区域右键菜单和驻留应用
功能。

Influence:
1. 测试enableContextMenu分别为true和false时，任务栏空白区域右键菜单是否 正常显示或隐藏。
2. 测试平板模式下enableContextMenu对触摸长按菜单的影响。
3. 测试enableDockedApplications分别为true和false时，驻留应用的状态。
4. 验证禁用后，未运行的驻留应用是否被隐藏。
5. 验证禁用后，驻留/取消驻留操作是否被阻止。
6. 验证切换设置时，已保存的驻留应用列表是否被保留。
7. 测试运行时禁用设置时，打开任务栏菜单是否被阻止。
8. 测试运行时禁用设置时，已打开的任务栏菜单是否被关闭。

PMS: TASK-393299