### PR TITLE
feat: refactor notification center into separate plugin and applet modules

### DIFF
--- a/panels/notification/center/CMakeLists.txt
+++ b/panels/notification/center/CMakeLists.txt
@@ -1,11 +1,23 @@
-# SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+# SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-qt_add_qml_module(notificationcenterpanel
+# The QML module is its own plugin.  Its implementation does not link to the
+# dde-shell applet entry point.
+qt_add_qml_module(notificationcenterpanelplugin
+    SHARED
     PLUGIN_TARGET notificationcenterpanelplugin
     URI org.deepin.ds.notificationcenter
     VERSION 1.0
+    SOURCES
+        notifyaccessor.h
+        notifyaccessor.cpp
+        notifymodel.h
+        notifymodel.cpp
+        notifyitem.h
+        notifyitem.cpp
+        notifystagingmodel.h
+        notifystagingmodel.cpp
     QML_FILES
         NotifyCenter.qml
         NotifyStaging.qml
@@ -20,26 +32,11 @@ qt_add_qml_module(notificationcenterpanel
         AnimationSettingButton.qml
         BoundingRectangle.qml
         NotifyHeaderTitleText.qml
-    SOURCES
-        notificationcenterpanel.h
-        notificationcenterpanel.cpp
-        notificationcenterproxy.h
-        notificationcenterproxy.cpp
-        notificationcenterdbusadaptor.h
-        notificationcenterdbusadaptor.cpp
-        notifyaccessor.h
-        notifyaccessor.cpp
-        notifymodel.h
-        notifymodel.cpp
-        notifyitem.h
-        notifyitem.cpp
-        notifystagingmodel.h
-        notifystagingmodel.cpp
     OUTPUT_DIRECTORY
         ${PROJECT_BINARY_DIR}/plugins/org/deepin/ds/notificationcenter/
 )
 
-qt_add_resources(notificationcenterpanel "ds_notificationcenterpanel_icons"
+qt_add_resources(notificationcenterpanelplugin "ds_notificationcenterpanel_icons"
     PREFIX "/dsg/built-in-icons"
     BASE "icons"
     FILES
@@ -50,7 +47,7 @@ qt_add_resources(notificationcenterpanel "ds_notificationcenterpanel_icons"
         icons/more.dci
 )
 
-target_link_libraries(notificationcenterpanel
+target_link_libraries(notificationcenterpanelplugin
     PRIVATE
         dde-shell-frame
         ds-notification-shared
@@ -58,10 +55,26 @@ target_link_libraries(notificationcenterpanel
         Qt${QT_VERSION_MAJOR}::DBus
 )
 
-install(TARGETS notificationcenterpanelplugin DESTINATION "${QML_INSTALL_DIR}/org/deepin/ds/notificationcenter/")
-install(DIRECTORY ${PROJECT_BINARY_DIR}/plugins/org/deepin/ds/notificationcenter/ DESTINATION ${QML_INSTALL_DIR}/org/deepin/ds/notificationcenter/
-    FILES_MATCHING PATTERN "qmldir" PATTERN "*.qmltypes"  PATTERN "*.qml" PATTERN "*.js"
+add_library(notificationcenterapplet SHARED
+    notificationcenterpanel.h
+    notificationcenterpanel.cpp
+    notificationcenterproxy.h
+    notificationcenterproxy.cpp
+    notificationcenterdbusadaptor.h
+    notificationcenterdbusadaptor.cpp
 )
 
-ds_install_package(PACKAGE org.deepin.ds.notificationcenter TARGET notificationcenterpanel)
+target_link_libraries(notificationcenterapplet
+    PRIVATE
+        dde-shell-frame
+        ds-notification-shared
+        Qt${QT_VERSION_MAJOR}::DBus
+)
+
+install(TARGETS notificationcenterpanelplugin DESTINATION "${QML_INSTALL_DIR}/org/deepin/ds/notificationcenter/")
+install(DIRECTORY ${PROJECT_BINARY_DIR}/plugins/org/deepin/ds/notificationcenter/ DESTINATION ${QML_INSTALL_DIR}/org/deepin/ds/notificationcenter/
+    FILES_MATCHING PATTERN "qmldir" PATTERN "*.qmltypes" PATTERN "*.qml" PATTERN "*.js"
+)
+
+ds_install_package(PACKAGE org.deepin.ds.notificationcenter TARGET notificationcenterapplet)
 ds_handle_package_translation(PACKAGE org.deepin.ds.notificationcenter)

--- a/panels/notification/center/notificationcenterpanel.cpp
+++ b/panels/notification/center/notificationcenterpanel.cpp
@@ -1,13 +1,11 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "notificationcenterpanel.h"
 
-#include "dataaccessorproxy.h"
 #include "notificationcenterdbusadaptor.h"
 #include "notificationcenterproxy.h"
-#include "notifyaccessor.h"
 
 #include <pluginfactory.h>
 #include <pluginloader.h>
@@ -70,25 +68,6 @@ bool NotificationCenterPanel::init()
 
     DPanel::init();
 
-    auto accessor = notification::DataAccessorProxy::instance();
-    notifycenter::NotifyAccessor::instance()->setDataAccessor(accessor);
-
-    bool valid = false;
-    DAppletBridge bridge("org.deepin.ds.notificationserver");
-    if (auto server = bridge.applet()) {
-        valid = QObject::connect(server,
-                                 SIGNAL(notificationStateChanged(qint64, int)),
-                                 notifycenter::NotifyAccessor::instance(),
-                                 SLOT(onNotificationStateChanged(qint64, int)),
-                                 Qt::QueuedConnection);
-        notifycenter::NotifyAccessor::instance()->setDataUpdater(server);
-        notifycenter::NotifyAccessor::instance()->setEnabled(visible());
-    }
-    if (!valid) {
-        qWarning(notifyLog) << "NotifyConnection is invalid, and can't receive RecordAdded signal.";
-        return false;
-    }
-
     return true;
 }
 
@@ -109,7 +88,6 @@ void NotificationCenterPanel::setVisible(bool newVisible)
             QMetaObject::invokeMethod(applet, "removeExpiredNotifications", Qt::DirectConnection);
         }
     }
-    notifycenter::NotifyAccessor::instance()->setEnabled(m_visible);
     setBubblePanelEnabled(!m_visible);
     emit visibleChanged();
 }

--- a/panels/notification/center/notifyaccessor.cpp
+++ b/panels/notification/center/notifyaccessor.cpp
@@ -11,7 +11,8 @@
 
 #include <DConfig>
 
-#include "dataaccessor.h"
+#include "dataaccessorproxy.h"
+
 #include <wayland/xdgactivation.h>
 
 DCORE_USE_NAMESPACE
@@ -39,9 +40,9 @@ public:
 };
 
 NotifyAccessor::NotifyAccessor(QObject *parent)
-    : m_pinnedApps(InvalidPinnedApps)
+    : QObject(parent)
+    , m_pinnedApps(InvalidPinnedApps)
 {
-    Q_UNUSED(parent)
     if (!qEnvironmentVariableIsEmpty("DS_NOTIFICATION_DEBUG")) {
         const int value = qEnvironmentVariableIntValue("DS_NOTIFICATION_DEBUG");
         m_debugging = value;
@@ -57,7 +58,7 @@ NotifyAccessor *NotifyAccessor::instance()
 
     if (!instance) {
         instance = new NotifyAccessor(qGuiApp);
-        instance->setDataAccessor(new DataAccessor());
+        instance->setDataAccessor(notification::DataAccessorProxy::instance());
     }
     return instance;
 }
@@ -77,9 +78,18 @@ void NotifyAccessor::setDataAccessor(DataAccessor *accessor)
     m_accessor = accessor;
 }
 
+QObject *NotifyAccessor::dataUpdater() const
+{
+    return m_dataUpdater;
+}
+
 void NotifyAccessor::setDataUpdater(QObject *updater)
 {
+    if (m_dataUpdater == updater)
+        return;
+
     m_dataUpdater = updater;
+    emit dataUpdaterChanged();
 }
 
 bool NotifyAccessor::enabled() const
@@ -89,7 +99,11 @@ bool NotifyAccessor::enabled() const
 
 void NotifyAccessor::setEnabled(bool enabled)
 {
+    if (m_enabled == enabled)
+        return;
+
     m_enabled = enabled;
+    emit enabledChanged();
 }
 
 NotifyEntity NotifyAccessor::fetchEntity(qint64 id) const
@@ -229,6 +243,7 @@ void NotifyAccessor::onNotificationStateChanged(qint64 id, int processedType)
 {
     if (!enabled())
         return;
+
     if (processedType == NotifyEntity::Processed) {
         emit entityReceived(id);
         emit stagingEntityClosed(id);

--- a/panels/notification/center/notifyaccessor.h
+++ b/panels/notification/center/notifyaccessor.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -26,11 +26,15 @@ class NotifyAccessor : public QObject
     QML_ELEMENT
     QML_SINGLETON
     Q_PROPERTY(bool debugging READ debugging NOTIFY debuggingChanged)
+    Q_PROPERTY(bool enabled READ enabled WRITE setEnabled NOTIFY enabledChanged FINAL)
+    Q_PROPERTY(QObject *dataUpdater READ dataUpdater WRITE setDataUpdater NOTIFY dataUpdaterChanged FINAL)
 public:
     static NotifyAccessor *instance();
     static NotifyAccessor *create(QQmlEngine *, QJSEngine *);
 
     void setDataAccessor(DataAccessor *accessor);
+
+    QObject *dataUpdater() const;
     void setDataUpdater(QObject *updater);
 
     bool enabled() const;
@@ -40,6 +44,7 @@ public:
     void pinApplication(const QString &appName, bool pin);
     bool applicationPin(const QString &appName) const;
     Q_INVOKABLE void openNotificationSetting();
+    Q_INVOKABLE void onNotificationStateChanged(qint64 id, int processedType);
 
     NotifyEntity fetchEntity(qint64 id) const;
     int fetchEntityCount(const QString &appName) const;
@@ -59,9 +64,10 @@ signals:
     void stagingEntityClosed(qint64 id);
 
     void debuggingChanged();
+    void enabledChanged();
+    void dataUpdaterChanged();
 
 private slots:
-    void onNotificationStateChanged(qint64 id, int processedType);
     void onReceivedRecord(const QString &id);
 
 private:

--- a/panels/notification/center/package/main.qml
+++ b/panels/notification/center/package/main.qml
@@ -133,6 +133,29 @@ Window {
         }
     }
 
+    // Keep the QML module's accessor state synchronized with the panel.
+    Binding {
+        target: NotifyAccessor
+        property: "enabled"
+        value: Panel.visible
+    }
+
+    Binding {
+        target: NotifyAccessor
+        property: "dataUpdater"
+        value: DS.applet("org.deepin.ds.notificationserver")
+    }
+
+    // Notification state belongs to the QML module.  Keeping this connection
+    // here avoids a binary dependency from the dde-shell applet to the QML
+    // plugin.
+    Connections {
+        target: DS.applet("org.deepin.ds.notificationserver")
+        function onNotificationStateChanged(id, processedType) {
+            NotifyAccessor.onNotificationStateChanged(id, processedType)
+        }
+    }
+
     // close Panel when click dock.
     Connections {
         target: DS.applet("org.deepin.ds.dock")


### PR DESCRIPTION
Split the notification center panel into a QML plugin module for QML
types and a separate applet library for the C++ applet entry point. This
decouples the QML module from the applet entry point, allowing cleaner
separation of concerns and enabling the QML types to be correctly
registered as a shared plugin without linking to the applet's binary.
The accessor state synchronization is moved to QML bindings to avoid
binary dependency from the applet to the plugin. Data accessor usage is
updated to the proxy pattern.

Log: Refactored notification center architecture: QML types in separate
plugin, applet as shared library, accessor state sync moved to QML

Influence:
1. Test notification panel display and interaction after rebuild
2. Verify notification state changes are handled correctly (e.g.,
received, staged, closed)
3. Test pinning/unpinning applications and checking pin state
4. Test opening notification settings
5. Verify QML module loads without the applet entry point linked
6. Test with notificationserver running and not running
7. Verify accessor enabled state syncs with panel visibility
8. Test build system changes don't break installation paths

feat: 重构通知中心，分离为独立插件和应用模块

将通知中心面板拆分为独立的 QML 插件模块（用于 QML 类型）和应用模块（用于
C++ 应用入口点）。这样解耦了 QML 模块与应用入口点，使得职责分离更清晰，
并允许 QML 类型作为共享插件正确注册，而无需链接到应用的二进制文件。访问
器状态同步移至 QML 绑定，避免了应用对插件的二进制依赖。数据访问器的使用
更新为代理模式。

Log: 重构通知中心架构：QML 类型在独立插件中，应用为共享库，访问器状态同
步移至 QML

Influence:
1. 重新构建后测试通知面板显示和交互
2. 验证通知状态变化（如收到、暂存、关闭）处理是否正确
3. 测试固定/取消固定应用及检查固定状态
4. 测试打开通知设置功能
5. 验证 QML 模块在未链接应用入口点时可以正常加载
6. 测试 notificationserver 在运行和未运行时的场景
7. 验证访问器启用状态与面板可见性的同步
8. 测试构建系统修改未破坏安装路径
