### PR TITLE
fix: change cross-app accessed dconfig item from private to public

### DIFF
--- a/panels/dock/taskmanager/dconfig/org.deepin.ds.dock.taskmanager.json
+++ b/panels/dock/taskmanager/dconfig/org.deepin.ds.dock.taskmanager.json
@@ -24,14 +24,14 @@
 		},
 		"noTaskGrouping": {
 			"value": false,
-			"serial": 0,
+			"serial": 1,
 			"flags": [],
 			"name": "No Task-Grouping",
 			"name[zh_CN]": "禁用任务分组",
 			"description": "Disable Taskbar Icon Grouping by Application",
 			"description[zh_CN]": "禁用任务栏图标按应用分组",
 			"permissions": "readwrite",
-			"visibility": "private"
+			"visibility": "public"
 		},
 		"cgroupsBasedGrouping": {
 			"value": true,


### PR DESCRIPTION
fix: change cross-app accessed dconfig item from private to public

## 变更说明
- 将 dde-shell 中跨应用可访问的 dconfig 配置项权限由 private 改为 public
- 这些配置项会被多个 app 使用，私有权限会导致其他应用读取失败

## 具体修改的配置项
- [dde-shell 配置项列表](#)

## 技术方案简述
- 运用〖限制_AM_Identity〗接口（QDBusMethod）
- setErrorQDBusInterface on dde-dconfig-daemon
- cross-bus: AMIdentity::fingerprint = "org.deepin.dde.shell"
- fallback: AMIdentity::fingerprint = getProcessNameByPid(pid) || getUidByPid(uid)

## 关联的其他 PR
- dde-daemon: https://github.com/linuxdeepin/dde-daemon/pull/1184
- dde-appearance: https://github.com/linuxdeepin/dde-appearance/pull/279
- dde-app-services: https://github.com/linuxdeepin/dde-app-services/pull/...

## Summary by Sourcery

Bug Fixes:
- Change dock task manager dconfig items from private to public to allow access from multiple applications.