### PR TITLE
fix(dock): prevent dock from taking focus

### DIFF
--- a/panels/dock/package/main.qml
+++ b/panels/dock/package/main.qml
@@ -69,7 +69,7 @@ Window {
     DLayerShellWindow.layer: DLayerShellWindow.LayerTop
     DLayerShellWindow.exclusionZone: Panel.hideMode === Dock.KeepShowing ? Applet.dockSize : 0
     DLayerShellWindow.scope: "dde-shell/dock"
-    DLayerShellWindow.keyboardInteractivity: DLayerShellWindow.KeyboardInteractivityOnDemand
+    DLayerShellWindow.keyboardInteractivity: DLayerShellWindow.KeyboardInteractivityNone
 
     D.DWindow.enabled: true
     D.DWindow.windowRadius: 0


### PR DESCRIPTION
1. Disable keyboard interactivity for the layer-shell surface.
2. Keep application focus unchanged when interacting with the dock.

Log: Prevent the dock from acquiring keyboard focus.
Influence: Dock interaction no longer takes app focus.

fix(dock): 防止 Dock 获取焦点

1. 禁用 layer-shell 表面的键盘交互。
2. 与 Dock 交互时保持当前应用焦点不变。

Log: 防止 Dock 获取键盘焦点。
Influence: Dock 交互不再抢占应用焦点。

## Summary by Sourcery

Bug Fixes:
- Disable keyboard interactivity on the dock layer-shell surface so interacting with the dock no longer steals focus from the active application.