### PR TITLE
Bugfix/pms 370701

### DIFF
--- a/panels/notification/common/notifyentity.cpp
+++ b/panels/notification/common/notifyentity.cpp
@@ -440,6 +440,11 @@ QString NotifyEntity::convertHintsToString(const QVariantMap &map)
         if (it.value().typeId() == QMetaType::QStringList) {
             QStringList tmp = it.value().toStringList();
             value = tmp.join(LIST_VALUE_SEGMENT);
+        } else if (it.value().typeId() == qMetaTypeId<QDBusArgument>()) {
+            QImage img = decodeImageFromDBusArgument(it.value().value<QDBusArgument>());
+            if (!img.isNull()) {
+                value = decodeImageToBase64(img);
+            }
         } else {
             value = it.value().toString();
         }


### PR DESCRIPTION
fix: handle QDBusArgument type in hint conversion
Add support for QDBusArgument image data when converting notification
hints to strings, preventing serialization failures for notifications
containing image hints via D-Bus.

Log: Fixed notification hint serialization for image data

Influence:
1. Test notifications with image data sent via D-Bus
2. Verify hint string conversion for various data types
3. Ensure compatibility with existing notification handling
4. Test edge cases with empty or invalid QDBusArgument data

fix: 处理提示转换中的 QDBusArgument 类型

当将通知提示转换为字符串时，增加对 QDBusArgument 图像数据的支持，防止包
含通过 D-Bus 传递的图像提示的通知出现序列化失败的问题。

Log: 修复了图像数据的通知提示序列化问题

Influence:
1. 测试通过 D-Bus 发送带图像数据的通知
2. 验证各种数据类型的提示字符串转换
3. 确保与现有通知处理的兼容性
4. 测试空或无效 QDBusArgument 数据的边界情况

PMS: BUG-370701