### PR TITLE
refactor: move ShellSurfaceItemProxy to dock plugin level

### DIFF
--- a/panels/dock/CMakeLists.txt
+++ b/panels/dock/CMakeLists.txt
@@ -97,6 +97,7 @@ ds_install_package(PACKAGE org.deepin.ds.dock TARGET dockpanel)
 ds_handle_package_translation(PACKAGE org.deepin.ds.dock)
 
 # sub plugins
+#add_subdirectory(cardleft)
 add_subdirectory(showdesktop)
 add_subdirectory(taskmanager)
 add_subdirectory(tray)
@@ -140,6 +141,7 @@ qt_add_qml_module(dock-plugin
     SHARED
     SOURCES ${plugin_sources}
     QML_FILES DockCompositor.qml OverflowContainer.qml MenuHelper.qml DockPalette.qml
+    ShellSurfaceItemProxy.qml
     AppletItemButton.qml
     AppletItemBackground.qml
     AppletDockItem.qml

--- a/panels/dock/ShellSurfaceItemProxy.qml
+++ b/panels/dock/ShellSurfaceItemProxy.qml
@@ -18,7 +18,7 @@ Item {
     property bool pressed: tapHandler.pressed
     property int cursorShape: Qt.ArrowCursor
     property alias shellSurfaceItem: impl
-    
+
     implicitWidth: shellSurface ? shellSurface.width : 16
     implicitHeight: shellSurface ? shellSurface.height : 16
 

--- a/panels/dock/tray/CMakeLists.txt
+++ b/panels/dock/tray/CMakeLists.txt
@@ -26,7 +26,6 @@ qt_add_qml_module(dock-tray
         SurfacePopup.qml
         SurfaceSubPopup.qml
         TrayItemSurfacePopup.qml
-        ShellSurfaceItemProxy.qml
 
     OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/plugins/org/deepin/ds/dock/tray/
 )

--- a/panels/dock/tray/package/ActionLegacyTrayPluginDelegate.qml
+++ b/panels/dock/tray/package/ActionLegacyTrayPluginDelegate.qml
@@ -82,7 +82,7 @@ AppletItemButton {
             parent: surfaceItem.shellSurfaceItem
         }
 
-        DDT.ShellSurfaceItemProxy {
+        ShellSurfaceItemProxy {
             id: surfaceItem
             anchors.fill: parent
             shellSurface: pluginItem.plugin

--- a/panels/dock/tray/quickpanel/DragItem.qml
+++ b/panels/dock/tray/quickpanel/DragItem.qml
@@ -8,6 +8,7 @@ import QtQuick.Window
 
 import org.deepin.ds 1.0
 import org.deepin.dtk 1.0
+import org.deepin.ds.dock 1.0
 import org.deepin.ds.dock.tray 1.0
 import org.deepin.ds.dock.tray.quickpanel 1.0
 

--- a/panels/dock/tray/quickpanel/PluginItem.qml
+++ b/panels/dock/tray/quickpanel/PluginItem.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -6,6 +6,7 @@ import QtQuick
 import QtQuick.Controls
 
 import org.deepin.dtk 1.0
+import org.deepin.ds.dock 1.0
 import org.deepin.ds.dock.tray 1.0
 
 Control {

--- a/panels/dock/tray/quickpanel/SubPluginPage.qml
+++ b/panels/dock/tray/quickpanel/SubPluginPage.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -7,6 +7,7 @@ import QtQuick.Controls
 import QtQuick.Layouts
 
 import org.deepin.dtk 1.0
+import org.deepin.ds.dock 1.0
 import org.deepin.ds.dock.tray 1.0
 
 Item {


### PR DESCRIPTION
ShellSurfaceItemProxy has been relocated from the tray submodule to the dock plugin level to enable reuse across different dock submodules, including the cardleft plugin. The file is added to dock-plugin QML module and referenced via the org.deepin.ds.dock import.

Log: ShellSurfaceItemProxy moved to dock plugin for cross-submodule sharing

Influence:
1. Verify tray plugin ShellSurfaceItemProxy still works correctly
2. Test that the import path change doesn't break existing functionality
3. Verify quickpanel components load properly with new imports
4. Test cardleft plugin functionality after enabling it in CMakeLists
5. Verify no QML module resolution errors occur
6. Check SPDX license header updates are correct

refactor: 将 ShellSurfaceItemProxy 移至 dock 插件层级

将 ShellSurfaceItemProxy 从 tray 子模块迁移至 dock 插件层级，使其可被 cardleft 等多个子模块复用。文件已添加到 dock-plugin QML 模块，并通过
org.deepin.ds.dock 导入引用。

Log: ShellSurfaceItemProxy 移至 dock 插件以实现跨子模块共享

Influence:
1. 验证 tray 插件的 ShellSurfaceItemProxy 功能正常
2. 测试导入路径变更后现有功能未受影响
3. 验证 quickpanel 组件加载新导入后正常
4. 测试在 CMakeLists 中启用 cardleft 插件后的功能
5. 确保无 QML 模块解析错误
6. 检查 SPDX 许可头部更新是否正确

PMS: TASK-392671

## Summary by Sourcery

Move the ShellSurfaceItemProxy QML component from the tray submodule into the shared dock plugin module and update tray quickpanel and delegate usages to import and reference it from org.deepin.ds.dock.

Enhancements:
- Centralize ShellSurfaceItemProxy in the dock plugin QML module for reuse across dock submodules.
- Simplify ShellSurfaceItemProxy usage in the tray plugin by referencing it directly instead of via the DDT namespace.
- Extend SPDX copyright year range in quickpanel QML files.

Build:
- Register ShellSurfaceItemProxy.qml in the dock-plugin qt_add_qml_module and remove it from the dock-tray module.
- Keep the cardleft subplugin disabled by commenting out its add_subdirectory entry.