### PR TITLE
fix(taskmanager): reject invalid drag in onEntered

### DIFF
--- a/panels/dock/taskmanager/package/TaskManager.qml
+++ b/panels/dock/taskmanager/package/TaskManager.qml
@@ -255,6 +255,7 @@ ContainmentItem {
                 launcherDndWinId = drag.getDataAsString("text/x-dde-dock-dnd-winid")
                 launcherDndDesktopId = desktopId
                 if (launcherDndDragSource !== "taskbar" && taskmanager.Applet.requestDockByDesktopId(desktopId) === false) {
+                    drag.accepted = false
                     resetDndState()
                 }
             }


### PR DESCRIPTION
1. Explicitly reject drag events when the dragged app cannot be docked
2. Set drag.accepted to false before resetting dnd state for clarity

Log: Reject invalid app drag in dock taskmanager onEntered handler
Influence: Prevents dock from accepting undockable drags

fix(taskmanager): 在 onEntered 中拒绝无效拖拽

1. 当拖拽的应用无法驻留时，显式拒绝拖拽事件
2. 在重置拖拽状态前将 drag.accepted 置为 false

Log: 在任务栏任务管理器 onEntered 中拒绝无效的应用拖拽
PMS: BUG-370799
Influence: 防止任务栏接受不可驻留的拖拽

## Summary by Sourcery

Bug Fixes:
- Ensure drag events are explicitly rejected when the dragged app cannot be docked in the task manager.