### PR TITLE
减小任务栏唤醒区域。

### DIFF
--- a/.github/workflows/deb-build.yml
+++ b/.github/workflows/deb-build.yml
@@ -1,0 +1,62 @@
+name: Build dde-shell deb packages
+
+on:
+  push:
+  workflow_dispatch:
+  pull_request:
+
+jobs:
+  container:
+    runs-on: ubuntu-latest
+    container: linuxdeepin/deepin:crimson
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install build dependencies
+        run: |
+          set -euxo pipefail
+
+          echo "deb [trusted=yes] http://mirrors.kernel.org/deepin/beige/ crimson main commercial community" > /etc/apt/sources.list
+          echo "deb-src [trusted=yes] http://mirrors.kernel.org/deepin/beige/ crimson main commercial community" >> /etc/apt/sources.list
+          rm -rf /etc/apt/sources.list.d
+
+          apt-get update
+          apt-get install -y devscripts equivs git
+
+          # Build and install treeland-protocols (required build dependency not from repo)
+          echo "Building treeland-protocols from source"
+          cd /tmp
+          if [ ! -d treeland-protocols ]; then
+            git clone --depth=1 --branch master --single-branch https://github.com/linuxdeepin/treeland-protocols.git
+          fi
+          cd treeland-protocols
+          mk-build-deps --install --remove --tool='apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends --yes' debian/control
+          dpkg-buildpackage -uc -us -b
+          apt-get install -y ../*.deb || dpkg -i ../*.deb || apt-get -f install -y
+
+          cd "$GITHUB_WORKSPACE"
+
+          # Install build-deps defined in dde-shell/debian/control
+          mk-build-deps --install --remove --tool='apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends --yes' debian/control
+
+      - name: Build dde-shell deb packages
+        run: |
+          set -euxo pipefail
+          dpkg-buildpackage -uc -us -b
+          echo "dde-shell deb packages built successfully!"
+          ls -la ../
+
+      - name: Collect deb artifacts
+        run: |
+          set -euxo pipefail
+          mkdir -p dist
+          mv ../*.deb dist/
+          ls -la dist
+
+      - name: Upload deb packages as artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dde-shell-deb-packages
+          path: dist/*.deb
+          if-no-files-found: error
+          retention-days: 30

--- a/panels/dock/waylanddockhelper.cpp
+++ b/panels/dock/waylanddockhelper.cpp
@@ -273,7 +273,7 @@ TreeLandDockWakeUpArea::TreeLandDockWakeUpArea(QScreen *screen, WaylandDockHelpe
     // force create windowHandle for layershell.
     winId();
     window()->setScreen(screen);
-    window()->resize(QSize(15, 15));
+    window()->resize(QSize(1, 1));
     setAttribute(Qt::WA_TranslucentBackground, true);
 
     auto window = ds::DLayerShellWindow::get(windowHandle());
@@ -315,7 +315,7 @@ void TreeLandDockWakeUpArea::updateDockWakeArea(Position pos)
     }
     }
 
-    window()->resize(QSize(15, 15));
+    window()->resize(QSize(1, 1));
     auto window = ds::DLayerShellWindow::get(windowHandle());
     window->setAnchors(anchors);
 }
@@ -337,9 +337,9 @@ void TreeLandDockWakeUpArea::resizeEvent(QResizeEvent *event)
     auto size = event->size();
     if (m_pos == Left || m_pos == Right) {
         size.setHeight(m_screen->size().height());
-        size.setWidth(15);
+        size.setWidth(1);
     } else {
-        size.setHeight(15);
+        size.setHeight(1);
         size.setWidth(m_screen->size().width());
     }
 

--- a/panels/dock/x11dockhelper.cpp
+++ b/panels/dock/x11dockhelper.cpp
@@ -22,7 +22,7 @@
 namespace dock {
 Q_LOGGING_CATEGORY(dockX11Log, "org.deepin.dde.shell.dock.x11")
 
-const uint16_t monitorSize = 15;
+const uint16_t monitorSize = 1;
 const uint32_t allWorkspace = 0xffffffff;
 
 // TODO: use taskmanager window data


### PR DESCRIPTION
任务栏设置：屏幕下方，一直隐藏。

当鼠标滑到屏幕靠下 **一个区域** 的时候，任务栏就会出现。

这逻辑没有问题，但是如果我要点击或者操作的地方在 **这个区域** ，就会很难受。

鼠标下滑出屏幕，或者鼠标贴底 **一条线** ，任务栏才会触发显示。换成这样的逻辑会不会好一些？

（鼠标贴底，其实操作上是没有难度，鼠标往下盲移就行了。）

换个说法就是，建议 把这个鼠标移动到 **区域** 触发，改成移动到 **底边** 触发，提高使用体验。

## Summary by Sourcery

Enhancements:
- Adjust Wayland and X11 dock helpers so the auto-hide wake region is constrained to a minimal 1‑pixel strip along the screen edge, improving usability for bottom-aligned docks.