### PR TITLE
fix: improve tray applet lifecycle management and model safety

### DIFF
--- a/panels/dock/dockdbusproxy.cpp
+++ b/panels/dock/dockdbusproxy.cpp
@@ -63,24 +63,13 @@ DockDBusProxy::DockDBusProxy(DockPanel* parent)
         });
     }
 
-    // Communicate with the other module
-    auto getOtherApplet = [ = ] {
-        {
-            DAppletBridge bridge("org.deepin.ds.dock.tray");
-            m_trayApplet = bridge.applet();
-        }
-
-        return m_trayApplet;
-    };
-
     // TODO: DQmlGlobal maybe missing a  signal which named `appletListChanged`?
-    QTimer *timer = new QTimer;
+    QTimer *timer = new QTimer(this);
     timer->setInterval(1000);
-    connect(timer, &QTimer::timeout, this, [ = ] {
-        if (getOtherApplet()) {
+    connect(timer, &QTimer::timeout, this, [this, timer] {
+        if (trayApplet()) {
             timer->stop();
             timer->deleteLater();
-            connect(m_trayApplet, SIGNAL(pluginsChanged()), this, SIGNAL(pluginsChanged()));
             // Log the initial plugin list after 30s delay to ensure the list has fully loaded
             QTimer::singleShot(30000, this, [this]() {
                 logInitialPluginState();
@@ -93,6 +82,25 @@ DockDBusProxy::DockDBusProxy(DockPanel* parent)
 DockPanel* DockDBusProxy::parent() const
 {
     return static_cast<DockPanel*>(QObject::parent());
+}
+
+QObject *DockDBusProxy::trayApplet()
+{
+    DAppletBridge bridge("org.deepin.ds.dock.tray");
+    QObject *currentApplet = bridge.applet();
+    if (m_trayApplet.data() == currentApplet) {
+        return m_trayApplet.data();
+    }
+
+    if (m_trayApplet) {
+        QObject::disconnect(m_trayApplet.data(), SIGNAL(pluginsChanged()), this, SIGNAL(pluginsChanged()));
+    }
+
+    m_trayApplet = currentApplet;
+    if (m_trayApplet) {
+        QObject::connect(m_trayApplet.data(), SIGNAL(pluginsChanged()), this, SIGNAL(pluginsChanged()), Qt::UniqueConnection);
+    }
+    return m_trayApplet.data();
 }
 
 QString DockDBusProxy::getAppID(const QString &desktopfile)
@@ -251,8 +259,8 @@ QStringList DockDBusProxy::GetLoadedPlugins()
 DockItemInfos DockDBusProxy::plugins()
 {
     DockItemInfos iteminfos;
-    if (m_trayApplet) {
-        QMetaObject::invokeMethod(m_trayApplet, "dockItemInfos", Qt::DirectConnection, qReturnArg(iteminfos));
+    if (auto *tray = trayApplet()) {
+        QMetaObject::invokeMethod(tray, "dockItemInfos", Qt::DirectConnection, qReturnArg(iteminfos));
     }
 
     for (auto *dockApplet : dockApplets(parent())) {
@@ -326,9 +334,9 @@ void DockDBusProxy::setItemOnDock(const QString &settingKey, const QString &item
         }
     }
 
-    if (m_trayApplet) {
+    if (auto *tray = trayApplet()) {
         Q_EMIT pluginVisibleChanged(itemKey, visible);
-        QMetaObject::invokeMethod(m_trayApplet, "setItemOnDock", Qt::QueuedConnection, settingKey, itemKey, visible);
+        QMetaObject::invokeMethod(tray, "setItemOnDock", Qt::QueuedConnection, settingKey, itemKey, visible);
         logCurrentVisiblePluginList(itemKey, visible);
     }
 }

--- a/panels/dock/dockdbusproxy.h
+++ b/panels/dock/dockdbusproxy.h
@@ -15,6 +15,7 @@
 #include <QObject>
 #include <QDBusContext>
 #include <QDBusArgument>
+#include <QPointer>
 #include <QTimer>
 
 /** this class used for old dock api compatible
@@ -87,12 +88,13 @@ Q_SIGNALS:
 
 private:
     DockPanel* parent() const;
+    QObject *trayApplet();
     QString getAppID(const QString &desktopfile);
     void updateDockPluginsVisible(const QVariantMap &pluginsVisible);
     void logInitialPluginState();
     void logCurrentVisiblePluginList(const QString &changedItemKey = QString(), bool changedVisible = true);
 
     DS_NAMESPACE::DAppletProxy *m_oldDockApplet;
-    DS_NAMESPACE::DAppletProxy *m_trayApplet;
+    QPointer<QObject> m_trayApplet;
 };
 }

--- a/panels/dock/taskmanager/dockitemmodel.cpp
+++ b/panels/dock/taskmanager/dockitemmodel.cpp
@@ -129,7 +129,14 @@ int DockItemModel::rowCount(const QModelIndex &parent) const
 QVariant DockItemModel::data(const QModelIndex &index, int role) const
 {
     auto sourceModel = this->sourceModel();
-    auto data = sourceModel->data(sourceModel->index(index.row(), index.column()), role);
+    if (!sourceModel || !index.isValid())
+        return {};
+
+    const auto sourceIndex = sourceModel->index(index.row(), index.column());
+    if (!sourceIndex.isValid())
+        return {};
+
+    auto data = sourceModel->data(sourceIndex, role);
     if (role == TaskManager::IconNameRole) {
         if (data.toString().isEmpty()) {
             return DEFAULT_APP_ICONNAME;
@@ -141,7 +148,11 @@ QVariant DockItemModel::data(const QModelIndex &index, int role) const
 
 QModelIndex DockItemModel::mapToSource(const QModelIndex &proxyIndex) const
 {
-    return sourceModel()->index(proxyIndex.row(), proxyIndex.column());
+    auto sourceModel = this->sourceModel();
+    if (!sourceModel || !proxyIndex.isValid())
+        return {};
+
+    return sourceModel->index(proxyIndex.row(), proxyIndex.column());
 }
 
 QModelIndex DockItemModel::mapFromSource(const QModelIndex &sourceIndex) const


### PR DESCRIPTION
1. Refactor tray applet retrieval into a dedicated `trayApplet()` method that accepts a `QPointer<QObject>` instead of raw pointers, safely managing the connection lifecycle and handling applet recreation
2. Remove the repeated timer-based polling logic that created a new bridge connection each time
3. Properly disconnect and reconnect the `pluginsChanged` signal when the tray applet instance changes, using `Qt::UniqueConnection` to avoid duplicate connections
4. Add null checks and index validation in `DockItemModel::data()` and `mapToSource()` to prevent potential crashes from invalid model indices or missing source models
5. Change the timer to be parented to `this` for proper cleanup

Log: Fixed potential issues with tray applet lifecycle management and model access safety

Influence:
1. Verify the dock tray area displays correctly with various applications running
2. Test applet updates when applications add/remove tray icons dynamically
3. Validate the dock list remains stable during frequent tray updates
4. Test with edge cases: empty model, invalid indices
5. Verify the initial plugin list logging still works after the timer refactor

fix: 改进托盘小程序生命周期管理和模型安全性

1. 将托盘小程序获取重构为专用的 `trayApplet()` 方法，使用 `QPointer<QObject>` 替代原始指针，安全管理连接生命周期并处理小程序重建
2. 移除重复的基于定时器的轮询逻辑，该逻辑每次都会创建新的桥接连接
3. 当托盘小程序实例变化时正确断开和重新连接 `pluginsChanged` 信号，使用 `Qt::UniqueConnection` 避免重复连接
4. 在 `DockItemModel::data()` 和 `mapToSource()` 中添加空指针检查和索引 验证，防止无效模型索引或缺失源模型导致的潜在崩溃
5. 将定时器设置为 `this` 的子对象以确保正确的清理

Log: 修复托盘小程序生命周期管理和模型访问安全性的潜在问题

Influence:
1. 验证在各种应用运行时，dock 托盘区域显示是否正确
2. 测试应用动态添加/移除托盘图标时的小程序更新
3. 验证在频繁托盘更新期间 dock 列表是否保持稳定
4. 测试边界情况：空模型、无效索引
5. 验证定时器重构后初始插件列表日志记录功能是否正常

PMS: TASK-393637

## Summary by Sourcery

Improve tray applet lifecycle handling and dock model safety.

Bug Fixes:
- Prevent crashes and inconsistent behavior when the tray applet instance is recreated or unavailable.
- Guard dock item model access against null source models and invalid indices.

Enhancements:
- Introduce a dedicated trayApplet() helper that manages tray applet retrieval and signal connections with QPointer and unique connections.
- Simplify tray initialization by removing repeated timer-based polling and ensuring the timer is properly parented for cleanup.