### PR TITLE
fix(dock): sync platform theme to tray plugin processes

### DIFF
--- a/panels/dock/loadtrayplugins.cpp
+++ b/panels/dock/loadtrayplugins.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -97,6 +97,10 @@ void LoadTrayPlugins::setProcessEnv(QProcess *process)
     QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
     // TODO: use protocols to determine the environment instead of environment variables
     env.remove("DDE_CURRENT_COMPOSITOR");
+    // 告知插件进程: 由 dde-shell 的 dockplugin 合成器托管, 需要在创建
+    // DPlatformTheme 之前注册 DQWaylandPlatformInterface(见 tray-loader 的
+    // main.cpp), 否则活动色/主题/字体等属性无法同步到插件。
+    env.insert("DDE_TRAY_LOADER_REGISTER_PLATFORM_INTERFACE", "1");
 
     process->setProcessEnvironment(env);
 }


### PR DESCRIPTION
1. Set DDE_TRAY_LOADER_REGISTER_PLATFORM_INTERFACE=1 in the tray loader plugin process env
2. Tell the plugin it is hosted by dde-shell's dockplugin compositor, so it registers DQWaylandPlatformInterface before creating DPlatformTheme
3. Ensure active color, theme, and font properties sync correctly to tray plugins

Log: Sync platform theme properties to tray plugin processes hosted by dde-shell.
Influence: Tray plugin visuals now follow the system theme correctly.

fix(dock): 同步平台主题到托盘插件进程

1. 在托盘插件进程环境中设置 DDE_TRAY_LOADER_REGISTER_PLATFORM_INTERFACE=1
2. 告知插件由 dde-shell 的 dockplugin 合成器托管，须在创建 DPlatformTheme 前注册 DQWaylandPlatformInterface
3. 确保活动色、主题、字体等属性正确同步到托盘插件

Log: 同步平台主题属性到由 dde-shell 托管的托盘插件进程。
PMS: BUG-372253
Influence: 托盘插件外观将正确跟随系统主题。

## Summary by Sourcery

Bug Fixes:
- Ensure tray plugin processes hosted by the dock register the Wayland platform interface so active colors, themes, and fonts sync with the system.