### PR TITLE
fix: fix launcher not showing after popup menu on x11

### DIFF
--- a/frame/qml/PanelPopup.qml
+++ b/frame/qml/PanelPopup.qml
@@ -142,10 +142,13 @@ Item {
             if (control.grabInactivePending || popupWindow.x11GrabFocusTransition) {
                 return
             }
-            // TODO why activeChanged is not emit.
-            if (!popupWindow.active) {
+            Qt.callLater(function() {
+                if (!popupWindow
+                        || popupWindow.active) {
+                    return
+                }
                 control.close()
-            }
+            })
         }
 
         function onUpdateGeometryFinished()


### PR DESCRIPTION
1. When a popup menu is open and the launcher is triggered via shortcut
on X11, the launcher does not display on the first attempt
2. The issue occurs because popupWindow.active state changes
asynchronously and the immediate check in activeChanged handler can miss
the transition
3. Wrap the active state check in Qt.callLater to defer the evaluation
until after the event loop processes the state change
4. Add a null check for popupWindow to handle potential destruction
during the delayed callback

Log: Fixed launcher not displaying on first shortcut trigger after popup
menu on X11

Influence:
1. Open a popup menu, then press the launcher shortcut and verify the
launcher displays immediately
2. Repeat the operation multiple times to confirm consistent behavior
3. Test without popup menu open to ensure no regression in normal
launcher activation
4. Verify on X11 session with different window manager configurations

fix: 修复x11下弹出菜单后启动器首次不显示的问题

1. 在X11环境下，弹出菜单后通过快捷键启动小启动器时，第一次操作小启动器不
显示
2. 问题原因在于popupWindow.active状态是异步变化的，在activeChanged处理器
中立即检查会错过状态转换
3. 将active状态检查包装在Qt.callLater中，延迟到事件循环处理完状态变化后
再评估
4. 增加popupWindow的空指针检查，处理延迟回调期间窗口可能被销毁的情况

Log: 修复X11下弹出菜单后首次通过快捷键启动器不显示的问题

Influence:
1. 打开弹出菜单后，按下启动器快捷键，验证启动器立即显示
2. 重复多次操作，确认行为一致性
3. 在不打开弹出菜单的情况下测试，确保正常启动器激活功能无回归
4. 在不同的窗口管理器配置下验证X11会话中的表现

## Summary by Sourcery

Bug Fixes:
- Fix launcher sometimes not appearing on first shortcut trigger after a popup menu on X11 due to a missed active-state transition.