### PR TITLE
chore: add itemData implementation for RoleGroupModel

### DIFF
--- a/panels/dock/taskmanager/rolegroupmodel.cpp
+++ b/panels/dock/taskmanager/rolegroupmodel.cpp
@@ -210,6 +210,25 @@ QVariant RoleGroupModel::data(const QModelIndex &index, int role) const
     }
 }
 
+QMap<int, QVariant> RoleGroupModel::itemData(const QModelIndex &index) const
+{
+    QMap<int, QVariant> roles;
+    for (int i = 0; i < Qt::UserRole; ++i) {
+        const QVariant value = data(index, i);
+        if (value.isValid())
+            roles.insert(i, value);
+    }
+
+    const auto names = roleNames();
+    for (auto it = names.cbegin(); it != names.cend(); ++it) {
+        const QVariant value = data(index, it.key());
+        if (value.isValid())
+            roles.insert(it.key(), value);
+    }
+
+    return roles;
+}
+
 QModelIndex RoleGroupModel::index(int row, int column, const QModelIndex &parent) const
 {
     if (parent.isValid()) {

--- a/panels/dock/taskmanager/rolegroupmodel.h
+++ b/panels/dock/taskmanager/rolegroupmodel.h
@@ -22,6 +22,7 @@ public:
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;
     int columnCount(const QModelIndex &parent = QModelIndex()) const override;
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
+    QMap<int, QVariant> itemData(const QModelIndex &index) const override;
 
     bool hasChildren(const QModelIndex &parent = QModelIndex()) const override;
     bool hasIndex(int row, int column, const QModelIndex &parent = QModelIndex()) const;


### PR DESCRIPTION
为 RoleGroupModel 补充 itemData() 实现. 这可以使调试 RoleGroupModel 时看到的信息稍佳清晰.

Log:

## Summary by Sourcery

Enhancements:
- Add an itemData() override in RoleGroupModel to return all valid role values for a given index, including both standard and custom roles.