### PR TITLE
fix: add X11BypassWindowManagerHint to panel popup window flags

### DIFF
--- a/frame/qml/PanelPopupWindow.qml
+++ b/frame/qml/PanelPopupWindow.qml
@@ -74,7 +74,7 @@ PopupWindow {
 
     width: 10
     height: 10
-    flags: (Qt.platform.pluginName === "xcb" ?  (Qt.Tool | Qt.WindowStaysOnTopHint) : Qt.Popup)
+    flags: (Qt.platform.pluginName === "xcb" ?  (Qt.Tool | Qt.WindowStaysOnTopHint | Qt.X11BypassWindowManagerHint) : Qt.Popup)
     font: D.DTK.fontManager.t6
     D.DWindow.enabled: true
     D.DWindow.windowRadius: D.DTK.platformTheme.windowRadius < 0 ? 4 : D.DTK.platformTheme.windowRadius


### PR DESCRIPTION
1. Add Qt.X11BypassWindowManagerHint flag to panel popup window on X11 platforms
2. Fix popup window positioning issues caused by window manager interference
3. Ensure popup window is placed correctly at the panel location
4. Maintain consistent behavior with other X11 popup windows in the environment

Log: Fixed panel popup window positioning issue on X11 platforms

Influence:
1. Verify panel popup window displays correctly on X11 with various window managers
2. Test popup window positioning and alignment with the panel
3. Confirm popup window appears above other windows
4. Test on Wayland to ensure no regression in window behavior
5. Verify popup window functionality across different desktop environments

fix: 为面板弹窗窗口添加X11BypassWindowManagerHint标志

1. 在X11平台上为面板弹窗窗口添加Qt.X11BypassWindowManagerHint标志
2. 修复窗口管理器干扰导致的弹窗定位问题
3. 确保弹窗窗口正确显示在面板位置
4. 保持与其他X11环境弹窗窗口行为的一致性

Log: 修复X11平台面板弹窗定位问题

Influence:
1. 在X11平台使用不同窗口管理器验证面板弹窗显示正常
2. 测试弹窗窗口与面板的对齐和定位
3. 确认弹窗窗口显示在其他窗口之上
4. 在Wayland平台测试确保窗口行为无回归
5. 在不同桌面环境下验证弹窗窗口功能

PMS: BUG-373349

## Summary by Sourcery

Adjust panel popup window flags on X11 to avoid window manager interference and ensure correct positioning at the panel.

Bug Fixes:
- Fix incorrect panel popup positioning on X11 caused by window manager handling of the window.

Enhancements:
- Align panel popup window behavior with other X11 popups by adding the X11BypassWindowManagerHint flag on X11 platforms.