### PR TITLE
fix: 修复 SNI 懒加载托盘图标右键菜单无法显示的问题

### DIFF
--- a/panels/dock/tray/SurfacePopup.qml
+++ b/panels/dock/tray/SurfacePopup.qml
@@ -104,6 +104,18 @@ Item {
         sizeFollowsWindow: false
     }
 
+    // 监听菜单 surface 尺寸变化，内容异步到达后重新请求几何更新。
+    Connections {
+        target: menuSurfaceLayer
+        enabled: menu.readyBinding && menu.menuVisible
+        function onWidthChanged() {
+            menu.menuWindow.requestUpdateGeometry()
+        }
+        function onHeightChanged() {
+            menu.menuWindow.requestUpdateGeometry()
+        }
+    }
+
     Connections {
         target: DockCompositor
         function onPopupCreated(popupSurface) {

--- a/panels/dock/tray/SurfaceSubPopup.qml
+++ b/panels/dock/tray/SurfaceSubPopup.qml
@@ -65,6 +65,18 @@ Item {
         }
     }
 
+    // 监听子菜单 surface 尺寸变化，内容异步到达后重新请求几何更新。
+    Connections {
+        target: popupSurfaceLayer
+        enabled: popup.readyBinding && popup.menuVisible
+        function onWidthChanged() {
+            popup.menuWindow.requestUpdateGeometry()
+        }
+        function onHeightChanged() {
+            popup.menuWindow.requestUpdateGeometry()
+        }
+    }
+
     Connections {
         target: DockCompositor
         function onPopupCreated(popupSurface) {

--- a/panels/dock/tray/TrayItemSurfacePopup.qml
+++ b/panels/dock/tray/TrayItemSurfacePopup.qml
@@ -109,6 +109,18 @@ Item {
                     popupMenu.shellSurface.updatePluginGeometry(Qt.rect(popupMenu.menuWindow.x, popupMenu.menuWindow.y, 0, 0))
                 }
             }
+
+            // 监听菜单 surface 尺寸变化，内容异步到达后重新请求几何更新。
+            Connections {
+                target: popupMenuContent
+                enabled: popupMenu.readyBinding && popupMenu.menuVisible
+                function onWidthChanged() {
+                    popupMenu.menuWindow.requestUpdateGeometry()
+                }
+                function onHeightChanged() {
+                    popupMenu.menuWindow.requestUpdateGeometry()
+                }
+            }
         }
     }
 


### PR DESCRIPTION
部分 SNI 应用（如 Snipaste）的 DBusMenu 菜单采用懒加载：右键菜单先以空状态（无菜单项、surface 极小/空白）创建并显示，AboutToShow 调用返回后内容才异步到达、surface 尺寸随之变化，但弹窗不会重新布局/绘制，内容始终无法显示。

修复：在 TrayItemSurfacePopup（常规托盘区）、SurfacePopup（stashed收纳托盘区）和 SurfaceSubPopup（子菜单）中监听菜单 surface 的宽高变化，内容异步到达、尺寸变化时重新请求几何更新，使弹窗按新内容重新布局与绘制。

本修复需配合 dde-tray-loader 的对应修复（右击托盘图标时主动触发 DBus AboutToShow 拉取懒加载菜单内容），确保菜单内容能被拉取到。


AI辅助声明：本修复方案由deepseek-v4-flash协助生成，并已在本地完成实际测试验证。

Snipaste下载地址：https://zh.snipaste.com/download.html
测试使用的Snipaste版本：https://download.snipaste.com/archives/Snipaste-2.11.3-x86_64.AppImage

## Summary by Sourcery

修复托盘菜单异步加载内容后的几何更新，确保懒加载菜单能够正确显示。

Bug Fixes:
- 修复懒加载托盘菜单及子菜单内容异步加载后无法显示的问题。

Enhancements:
- 支持常规托盘区和收纳托盘区菜单在 surface 尺寸变化后重新布局与绘制。