### PR TITLE
fix: icon not updated on taskbar if icon name in desktop changed

### DIFF
--- a/panels/dock/taskmanager/dockglobalelementmodel.cpp
+++ b/panels/dock/taskmanager/dockglobalelementmodel.cpp
@@ -72,6 +72,14 @@ DockGlobalElementModel::DockGlobalElementModel(QAbstractItemModel *appsModel, Do
                     data = std::make_tuple(std::get<0>(data), std::get<1>(data), std::get<2>(data) + insertedCount);
                 }
             });
+
+            for (auto &data : m_data) {
+                if (std::get<1>(data) != m_appsModel || std::get<2>(data) != -1)
+                    continue;
+                const auto id = std::get<0>(data);
+                auto res = m_appsModel->match(m_appsModel->index(0, 0), TaskManager::DesktopIdRole, id, 1, Qt::MatchExactly);
+                std::get<2>(data) = res.isEmpty() ? -1 : res.first().row();
+            }
         },
         Qt::QueuedConnection);
 
@@ -234,7 +242,7 @@ DockGlobalElementModel::DockGlobalElementModel(QAbstractItemModel *appsModel, Do
                 });
 
                 if (it == m_data.end())
-                    return;
+                    continue;
                 auto pos = it - m_data.constBegin();
 
                 auto oldRoles = roles;
@@ -244,6 +252,30 @@ DockGlobalElementModel::DockGlobalElementModel(QAbstractItemModel *appsModel, Do
                     oldRoles.append(TaskManager::ItemIdRole);
                 }
                 Q_EMIT dataChanged(index(pos, 0), index(pos, 0), oldRoles);
+            }
+        },
+        Qt::QueuedConnection);
+
+    connect(
+        m_appsModel,
+        &QAbstractItemModel::dataChanged,
+        this,
+        [this](const QModelIndex &topLeft, const QModelIndex &bottomRight, const QList<int> &roles) {
+            int first = topLeft.row(), last = bottomRight.row();
+            for (int i = first; i <= last; i++) {
+                auto id = m_appsModel->index(i, 0).data(TaskManager::DesktopIdRole).toString();
+                if (id.isEmpty())
+                    continue;
+
+                auto it = std::find_if(m_data.begin(), m_data.end(), [&id](const auto &data) {
+                    return std::get<0>(data) == id;
+                });
+
+                if (it == m_data.end())
+                    continue;
+
+                auto pos = it - m_data.begin();
+                Q_EMIT dataChanged(index(pos, 0), index(pos, 0), roles);
             }
         },
         Qt::QueuedConnection);

--- a/panels/dock/taskmanager/rolecombinemodel.cpp
+++ b/panels/dock/taskmanager/rolecombinemodel.cpp
@@ -181,22 +181,27 @@ RoleCombineModel::RoleCombineModel(QAbstractItemModel* major, QAbstractItemModel
     connect(m_minor, &QAbstractItemModel::dataChanged, this,
         [this, majorRoles, func](const QModelIndex &topLeft, const QModelIndex &bottomRight, const QList<int> &roles){
             Q_UNUSED(roles)
+            QPair<int,int> minorPair;
             for (int i = topLeft.row(); i <= bottomRight.row(); i++) {
                 for (int j =  topLeft.column(); j <= bottomRight.column(); j++) {
-                    auto majorPos = m_indexMap.key(qMakePair(i, j), qMakePair(-1, -1));
-                    if (-1 == majorPos.first && -1 == majorPos.second)
-                        continue;
+                    minorPair = qMakePair(i, j);
+                    for (auto mapIt = m_indexMap.constBegin(); mapIt != m_indexMap.constEnd(); ++mapIt) {
+                        if (mapIt.value() != minorPair)
+                            continue;
 
-                    auto majorIndex = sourceModel()->index(majorPos.first, majorPos.second);
-                    if (!majorIndex.isValid())
-                        continue;
+                        auto majorPos = mapIt.key();
 
-                    auto minorIndex = func(majorIndex.data(majorRoles), m_minor);
-                    if (!minorIndex.isValid())
-                        continue;
+                        auto majorIndex = sourceModel()->index(majorPos.first, majorPos.second);
+                        if (!majorIndex.isValid())
+                            continue;
 
-                    m_indexMap[majorPos] = qMakePair(minorIndex.row(), minorIndex.column());
-                    Q_EMIT dataChanged(majorIndex, majorIndex, m_minorRolesMap.values());
+                        auto minorIndex = func(majorIndex.data(majorRoles), m_minor);
+                        if (!minorIndex.isValid())
+                            continue;
+
+                        m_indexMap[majorPos] = qMakePair(minorIndex.row(), minorIndex.column());
+                        Q_EMIT dataChanged(majorIndex, majorIndex, m_minorRolesMap.values());
+                    }
                 }
             }
     });

--- a/tests/panels/dock/taskmanager/combinemodela.cpp
+++ b/tests/panels/dock/taskmanager/combinemodela.cpp
@@ -4,10 +4,10 @@
 
 #include "combinemodela.h"
 
-DataA::DataA(int id, TestModelA* parent)
-    : m_id(id)
+DataA::DataA(int id, TestModelA* model)
+    : m_model(model)
+    , m_id(id)
 {
-    Q_UNUSED(parent)
 }
 
 DataA::DataA(int id, const QString &data, TestModelA* model)
@@ -31,9 +31,11 @@ void DataA::setData(const QString &data)
     if (data == m_data) return;
     m_data = data;
 
-    auto index = m_model->match(QModelIndex(), TestModelA::idRole, m_id);
-    if (index.size() > 0) {
-        Q_EMIT m_model->dataChanged(index.first(), index.last(), {TestModelA::dataRole});
+    for (int row = 0; row < m_model->rowCount(); ++row) {
+        if (m_model->index(row, 0).data(TestModelA::idRole).toInt() == m_id) {
+            Q_EMIT m_model->dataChanged(m_model->index(row, 0), m_model->index(row, 0), {TestModelA::dataRole});
+            break;
+        }
     }
 }
 
@@ -81,6 +83,18 @@ void TestModelA::addData(DataA *data)
     beginInsertRows(QModelIndex(), m_list.size(), m_list.size());
     m_list.append(data);
     endInsertRows();
+}
+
+bool TestModelA::setData(const QModelIndex &index, const QVariant &value, int role)
+{
+    if (!index.isValid() || index.row() >= m_list.size())
+        return false;
+
+    if (role != dataRole)
+        return false;
+
+    m_list[index.row()]->setData(value.toString());
+    return true;
 }
 
 void TestModelA::removeData(DataA *data)

--- a/tests/panels/dock/taskmanager/combinemodela.h
+++ b/tests/panels/dock/taskmanager/combinemodela.h
@@ -38,6 +38,7 @@ public:
     QHash<int, QByteArray> roleNames() const override;
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;
     QVariant data(const QModelIndex &index, int role) const override;
+    bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole) override;
 
     void addData(DataA *data);
     void removeData(DataA *data);

--- a/tests/panels/dock/taskmanager/combinemodelb.cpp
+++ b/tests/panels/dock/taskmanager/combinemodelb.cpp
@@ -4,10 +4,10 @@
 
 #include "combinemodelb.h"
 
-DataB::DataB(int id, TestModelB* parent)
-    : m_id(id)
+DataB::DataB(int id, TestModelB* model)
+    : m_model(model)
+    , m_id(id)
 {
-    Q_UNUSED(parent)
 }
 
 DataB::DataB(int id, const QString &data, TestModelB* model)
@@ -31,9 +31,11 @@ void DataB::setData(const QString &data)
     if (data == m_data) return;
     m_data = data;
 
-    auto index = m_model->match(QModelIndex(), TestModelB::idRole, m_id);
-    if (index.size() > 0) {
-        Q_EMIT m_model->dataChanged(index.first(), index.last(), {TestModelB::dataRole});
+    for (int row = 0; row < m_model->rowCount(); ++row) {
+        if (m_model->index(row, 0).data(TestModelB::idRole).toInt() == m_id) {
+            Q_EMIT m_model->dataChanged(m_model->index(row, 0), m_model->index(row, 0), {TestModelB::dataRole});
+            break;
+        }
     }
 }
 
@@ -81,6 +83,18 @@ void TestModelB::addData(DataB *data)
     beginInsertRows(QModelIndex(), m_list.size(), m_list.size());
     m_list.append(data);
     endInsertRows();
+}
+
+bool TestModelB::setData(const QModelIndex &index, const QVariant &value, int role)
+{
+    if (!index.isValid() || index.row() >= m_list.size())
+        return false;
+
+    if (role != dataRole)
+        return false;
+
+    m_list[index.row()]->setData(value.toString());
+    return true;
 }
 
 void TestModelB::removeData(DataB *data)

--- a/tests/panels/dock/taskmanager/combinemodelb.h
+++ b/tests/panels/dock/taskmanager/combinemodelb.h
@@ -37,6 +37,7 @@ public:
     QHash<int, QByteArray> roleNames() const override;
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;
     QVariant data(const QModelIndex &index, int role) const override;
+    bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole) override;
 
     void addData(DataB *data);
     void removeData(DataB *data);

--- a/tests/panels/dock/taskmanager/rolecombinemodeltests.cpp
+++ b/tests/panels/dock/taskmanager/rolecombinemodeltests.cpp
@@ -356,3 +356,58 @@ TEST(RoleCombineModel, ParentParameterHandlingFix)
     EXPECT_EQ(model.rowCount(), 1);
     EXPECT_TRUE(model.index(0, 0).isValid());
 }
+
+// 验证多个major行映射到同一minor行时，minor dataChanged能转发给所有major行
+TEST(RoleCombineModel, MinorDataChangedForwardToAllMappedMajorRows)
+{
+    TestModelA modelA;
+    TestModelB modelB;
+
+    RoleCombineModel model(&modelA, &modelB, TestModelA::idRole, [](QVariant data, QAbstractItemModel *model) -> QModelIndex {
+        auto matches = model->match(model->index(0, 0), TestModelB::idRole, data);
+        return matches.isEmpty() ? QModelIndex() : matches.first();
+    });
+
+    QSignalSpy spy(&model, &QAbstractItemModel::dataChanged);
+
+    // 添加两个major行，都映射到同一个minor行(id=0)
+    modelA.addData(new DataA(0, "window1", &modelA));
+    modelA.addData(new DataA(0, "window2", &modelA));
+
+    // 添加对应的minor数据
+    modelB.addData(new DataB(0, "appData", &modelB));
+
+    // 验证两个major行都映射到minor行0
+    auto roleNames = model.roleNames();
+    auto roleNamesA = modelA.roleNames();
+    auto roleNamesB = modelB.roleNames();
+    QHash<QByteArray, int> names2Role;
+    for (auto roleName : roleNames.keys()) {
+        names2Role.insert(roleNames.value(roleName), roleName);
+    }
+    int bDataRole = names2Role.value(roleNamesB.value(TestModelB::dataRole));
+
+    // Verify initial mapping works
+    ASSERT_EQ(model.rowCount(), 2) << "Model should have 2 rows";
+    ASSERT_TRUE(model.index(0, 0).isValid()) << "Major row 0 should be valid";
+    ASSERT_TRUE(model.index(1, 0).isValid()) << "Major row 1 should be valid";
+    ASSERT_NE(bDataRole, -1) << "bData role not found in combined model";
+
+    EXPECT_EQ(model.index(0, 0).data(bDataRole).toString(), "appData");
+    EXPECT_EQ(model.index(1, 0).data(bDataRole).toString(), "appData");
+
+    // 修改minor数据，触发dataChanged
+    spy.clear();
+
+    // Verify DataB::setData emits dataChanged on modelB
+    QSignalSpy spyB(&modelB, &QAbstractItemModel::dataChanged);
+    modelB.setData(modelB.index(0), "newAppData", TestModelB::dataRole);
+    EXPECT_EQ(spyB.count(), 1) << "modelB should emit dataChanged when setData is called";
+
+    // Now check if RoleCombineModel forwarded the signal
+    EXPECT_EQ(spy.count(), 2) << "Should emit dataChanged for both major rows mapping to the same minor row";
+
+    // 验证数据已更新
+    EXPECT_EQ(model.index(0, 0).data(bDataRole).toString(), "newAppData");
+    EXPECT_EQ(model.index(1, 0).data(bDataRole).toString(), "newAppData");
+}


### PR DESCRIPTION
修复 desktop 文件中 Icon 字段的值变化后,任务栏上对应图标不会更新的问题

根因（3 个问题）

1. DockGlobalElementModel 缺少 m_appsModel->dataChanged handler — 之前只连接了 m_activeAppModel->dataChanged，docked app（非运行状态）的图标变化被完全忽略。新增 handler 按 desktop ID 匹配转发。
2. DockGlobalElementModel 的 m_activeAppModel->dataChanged handler 中 return 应为 continue — 第一行找不到时直接返回，后续行收不到信号。
3. RoleCombineModel 的 m_indexMap.key() 只返回第一个匹配项 — 多个窗口映射到同一 app 时，只有第一个窗口收到 dataChanged。改为遍历所有映射项，所有匹配的窗口都收到信号。

注：如果在使用目前【最新】的 dde-application-manager 的话，可以使用 `dde-dconfig set -a org.deepin.dde.application-manager -r org.deepin.dde.am.appoverride -s /dde-file-manager/wayland -k Icon -v 'deepin-music'` 来测试，`dde-file-manager` 为要修改图标的 appid，`wayland` 可以为 x11 或 wayland。这种测试方式不需要实际修改 desktop 文件。

Log:

## Summary by Sourcery

Ensure taskbar dock icons and combined role models correctly propagate dataChanged signals when underlying app or desktop entries change, especially for multiple windows mapped to the same application.

Bug Fixes:
- Fix docked taskbar icons not updating when the corresponding desktop file Icon or DesktopId changes in the apps model.
- Fix active app handling in DockGlobalElementModel so dataChanged signals do not stop after the first unmatched entry.
- Fix RoleCombineModel so dataChanged on a minor row is forwarded to all major rows mapped to that minor row instead of only the first.

Enhancements:
- Improve DockGlobalElementModel mapping refresh logic for docked entries when rows are inserted in the apps model.
- Refine test helper models to emit dataChanged via setData with explicit role handling, better mirroring real model behavior.

Tests:
- Add coverage to RoleCombineModel to verify dataChanged on a minor row is propagated to all major rows mapped to it, including updated data values.