### PR TITLE
fix: pass QJsonParseError to QJsonDocument::fromJson in fromJsonString

### DIFF
--- a/frame/pluginmetadata.cpp
+++ b/frame/pluginmetadata.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -123,7 +123,7 @@ DPluginMetaData DPluginMetaData::fromJsonFile(const QString &file)
 DPluginMetaData DPluginMetaData::fromJsonString(const QByteArray &data)
 {
     QJsonParseError error;
-    const QJsonObject metaData = QJsonDocument::fromJson(data).object();
+    const QJsonObject metaData = QJsonDocument::fromJson(data, &error).object();
     if (error.error) {
         qCWarning(dsLog) << "error parsing json data"  << error.errorString();
         return DPluginMetaData();


### PR DESCRIPTION
## Summary

Pass `&error` to `QJsonDocument::fromJson` in `DPluginMetaData::fromJsonString` so the `QJsonParseError` error branch becomes reachable. Fixes a dead-code defect where malformed JSON was silently swallowed and the `qCWarning` diagnostic never fired.

## Change

- `frame/pluginmetadata.cpp`: `QJsonDocument::fromJson(data)` → `QJsonDocument::fromJson(data, &error)` in `fromJsonString`.

## Behavior

- Valid JSON: no change.
- Malformed JSON: now hits the error branch, logs `qCWarning` with the parse error string, and returns an invalid `DPluginMetaData` (previously returned invalid via the missing-`Id` path, silently).

## Testing

- Existing `DPluginMetaData.FromJsonStringMalformed` unit test still passes — it asserts an invalid result both before and after the fix, so no test update is needed. The previously-unreachable error branch is now reachable for coverage.

## Related

- Multica issue: [DDE-132](https://agent-dev.uniontech.com/dde/issues/a3ffc5c2-29cf-456a-9276-659a9820f01b)

## Summary by Sourcery

Make JSON parsing errors reachable so malformed plugin metadata is rejected with diagnostic logging.

Bug Fixes:
- Ensure malformed JSON is reported and rejected with a parse warning in DPluginMetaData::fromJsonString.

Chores:
- Update the plugin metadata source copyright year range.