### PR TITLE
fix: make X11 bypass window manager hint configurable

### DIFF
--- a/frame/qml/PanelPopup.qml
+++ b/frame/qml/PanelPopup.qml
@@ -18,6 +18,7 @@ Item {
     property bool openPending: false
     property bool grabInactivePending: false
     property int grabInactiveTimeout: 200
+    property bool useX11BypassWindowManagerHint: true
     // WM_NAME, used for kwin.
     property string windowTitle: "dde-shell/panelpopup"
     width: popup.childrenRect.width
@@ -42,6 +43,11 @@ Item {
         when: readyBinding
         target: popupWindow; property: "yOffset"
         value: control.popupY
+    }
+    Binding {
+        when: readyBinding
+        target: popupWindow; property: "useX11BypassWindowManagerHint"
+        value: control.useX11BypassWindowManagerHint
     }
 
     function open()

--- a/frame/qml/PanelPopupWindow.qml
+++ b/frame/qml/PanelPopupWindow.qml
@@ -18,6 +18,8 @@ PopupWindow {
     property int requestedWidth: 10
     property int requestedHeight: 10
     property bool geometryUpdatePending: false
+    // Individual popup instances can override this for window-manager compatibility.
+    property bool useX11BypassWindowManagerHint: true
     signal requestUpdateGeometry()
     signal updateGeometryFinished()
 
@@ -74,7 +76,10 @@ PopupWindow {
 
     width: 10
     height: 10
-    flags: (Qt.platform.pluginName === "xcb" ?  (Qt.Tool | Qt.WindowStaysOnTopHint | Qt.X11BypassWindowManagerHint) : Qt.Popup)
+    flags: (Qt.platform.pluginName === "xcb"
+            ? (Qt.Tool | Qt.WindowStaysOnTopHint
+               | (useX11BypassWindowManagerHint ? Qt.X11BypassWindowManagerHint : 0))
+            : Qt.Popup)
     font: D.DTK.fontManager.t6
     D.DWindow.enabled: true
     D.DWindow.windowRadius: D.DTK.platformTheme.windowRadius < 0 ? 4 : D.DTK.platformTheme.windowRadius


### PR DESCRIPTION
1. Add `useX11BypassWindowManagerHint` property to `PanelPopupWindow` with default value of `true`
2. Expose the same property on `PanelPopup` for per-instance override
3. Add a Binding to propagate the property from `PanelPopup` to the internal popup window
4. Conditionally apply `Qt.X11BypassWindowManagerHint` in window flags only when enabled
5. This allows individual popup instances to disable the hint for WM compatibility

Log: Popup windows can now optionally disable the X11 bypass window manager hint for compatibility with certain window managers

Influence:
1. Test panel popup windows on X11 with default settings to verify no regression
2. Test popup behavior with `useX11BypassWindowManagerHint` set to `false` to ensure window manager decorations and management work correctly
3. Verify popup positioning, focus behavior, and stacking with both values of the property
4. Test on Wayland to confirm no impact on existing behavior
5. Test popups across different panel plugins to ensure compatibility

fix: 使 X11 绕过窗口管理器提示可配置

1. 在 `PanelPopupWindow` 中添加 `useX11BypassWindowManagerHint` 属性，默 认值为 `true`
2. 在 `PanelPopup` 上暴露相同属性，支持按实例覆盖
3. 添加 Binding 将该属性从 `PanelPopup` 传播到内部弹出窗口
4. 仅当属性启用时，才在窗口标志中有条件地应用 `Qt.X11BypassWindowManagerHint`
5. 这允许单个弹出窗口实例禁用该提示以兼容特定窗口管理器

Log: 弹出窗口现在可以可选地禁用 X11 绕过窗口管理器提示，以便兼容某些窗口
管理器

Influence:
1. 在 X11 上使用默认设置测试面板弹出窗口，验证无回归
2. 将 `useX11BypassWindowManagerHint` 设置为 `false` 测试弹出行为，确保 窗口管理器装饰和管理正常工作
3. 验证两种属性值下的弹出窗口定位、焦点行为和层叠顺序
4. 在 Wayland 上测试，确认对现有行为无影响
5. 测试不同面板插件的弹出窗口以确保兼容性

PMS: TASK-394541

## Summary by Sourcery

Make the X11 bypass window-manager hint configurable for panel popup instances.

New Features:
- Add configurable X11 window-manager hint behavior to panel popups, with per-instance control over whether the bypass hint is used.

Enhancements:
- Preserve the existing default behavior while allowing popups to disable the X11 bypass hint for window-manager compatibility.