### PR TITLE
fix(dock): eliminate several QML runtime/compile warnings

### DIFF
--- a/panels/dock/ShellSurfaceItemProxy.qml
+++ b/panels/dock/ShellSurfaceItemProxy.qml
@@ -114,6 +114,7 @@ Item {
     }
 
     Connections {
+        ignoreUnknownSignals: true
         target: shellSurface
         // TODO it's maybe a bug for qt, we force shellSurface's value to update
         function onAboutToDestroy()

--- a/panels/dock/taskmanager/package/AppItem.qml
+++ b/panels/dock/taskmanager/package/AppItem.qml
@@ -518,7 +518,7 @@ Item {
             if (mouse.button === Qt.LeftButton) {
                 appItem.grabToImage(function(result) {
                     root.Drag.imageSource = result.url;
-                })
+                }, Qt.size(appItem.width, appItem.height))
             }
             toolTip.close()
             closeItemPreview()

--- a/panels/dock/taskmanager/package/TaskManager.qml
+++ b/panels/dock/taskmanager/package/TaskManager.qml
@@ -40,16 +40,16 @@ ContainmentItem {
     readonly property real startPadding: Math.max(0, appTitleSpacing - (Panel.rootObject.dockItemMaxSize * (multitaskViewIconRatio - iconWidthToMaxSizeRatio) / 2))
 
     implicitWidth: {
-        let extra = useColumnLayout ? 0 : startPadding
+        if (useColumnLayout) return Panel.rootObject.dockSize
+        let extra = startPadding
         let w = appContainer.implicitWidth + extra
-        let maxW = Panel.itemAlignment === Dock.LeftAlignment ? Math.max(remainingSpacesForTaskManager, w) : Math.min(remainingSpacesForTaskManager, w)
-        return useColumnLayout ? Panel.rootObject.dockSize : maxW
+        return Panel.itemAlignment === Dock.LeftAlignment ? Math.max(remainingSpacesForTaskManager, w) : Math.min(remainingSpacesForTaskManager, w)
     }
     implicitHeight: {
-        let extra = useColumnLayout ? startPadding : 0
+        if (!useColumnLayout) return Panel.rootObject.dockSize
+        let extra = startPadding
         let h = appContainer.implicitHeight + extra
-        let maxH = Panel.itemAlignment === Dock.LeftAlignment ? Math.max(remainingSpacesForTaskManager, h) : Math.min(remainingSpacesForTaskManager, h)
-        return useColumnLayout ? maxH : Panel.rootObject.dockSize
+        return Panel.itemAlignment === Dock.LeftAlignment ? Math.max(remainingSpacesForTaskManager, h) : Math.min(remainingSpacesForTaskManager, h)
     }
     // Helper function to find the current index of an app by its appId in the visualModel
     function findAppIndex(appId) {
@@ -114,6 +114,14 @@ ContainmentItem {
                 duration: 200
             }
         }
+        add: Transition {
+            NumberAnimation {
+                properties: "scale,opacity"
+                from: 0
+                to: 1
+                duration: 200
+            }
+        }
         model: DelegateModel {
             id: visualModel
             model: taskmanager.Applet.dataModel
@@ -138,14 +146,6 @@ ContainmentItem {
                         return true 
                     }
                     return windows.length > 0 && launcherDndDropArea.launcherDndWinId !== windows[0]
-                }
-
-                ListView.onAdd: NumberAnimation {
-                    target: delegateRoot
-                    properties: "scale,opacity"
-                    from: 0
-                    to: 1
-                    duration: 200
                 }
 
                 states: [

--- a/panels/dock/tray/package/ActionLegacyTrayPluginDelegate.qml
+++ b/panels/dock/tray/package/ActionLegacyTrayPluginDelegate.qml
@@ -178,7 +178,7 @@ AppletItemButton {
         if (Qt.platform.pluginName !== "xcb") {
             root.grabToImage(function(result) {
                 root.Drag.imageSource = result.url;
-            })
+            }, Qt.size(root.width, root.height))
         }
 
         if (!Drag.active) {
@@ -194,7 +194,7 @@ AppletItemButton {
         if (Qt.platform.pluginName !== "xcb") {
             root.grabToImage(function(result) {
                 root.Drag.imageSource = result.url;
-            })
+            }, Qt.size(root.width, root.height))
         }
     }
 

--- a/panels/dock/tray/quickpanel/DragItem.qml
+++ b/panels/dock/tray/quickpanel/DragItem.qml
@@ -146,7 +146,7 @@ Item {
 
                     draggingImage = result.url
                     Qt.callLater(function() { dragItem.Drag.active = true })
-                })
+                }, Qt.size(dragItem.width, dragItem.height))
             } else {
                 dragItem.Drag.active = false
             }

--- a/panels/dock/tray/trayitempositionmanager.h
+++ b/panels/dock/tray/trayitempositionmanager.h
@@ -15,7 +15,7 @@ struct DropIndex {
     Q_PROPERTY(int index MEMBER index)
     Q_PROPERTY(bool isOnItem MEMBER isOnItem)
     Q_PROPERTY(bool isBefore MEMBER isBefore)
-    QML_ELEMENT
+    QML_NAMED_ELEMENT(dropIndex)
 public:
     int index;
     bool isOnItem = true;

--- a/panels/notification/center/OverlapNotify.qml
+++ b/panels/notification/center/OverlapNotify.qml
@@ -143,7 +143,7 @@ NotifyItem {
 
             OverlapIndicator {
                 id: indicator
-                enableAnimation: root.ListView.view.panelShown
+                enableAnimation: (root.ListView.view && root.ListView.view.panelShown) ?? false
                 clipItems: true
                 anchors {
                     bottom: parent.bottom


### PR DESCRIPTION
## Summary

Eliminate several QML runtime and compile warnings in dde-shell's dock and notification center by fixing the root cause rather than downgrading log levels. Covers 6 warnings across 7 files; no warning log is downgraded.

## Changes

1. **ShellSurfaceItemProxy**: add `ignoreUnknownSignals: true` so the `cursorShapeRequested` handler no longer warns for surfaces lacking the signal.
2. **TaskManager**: replace the deprecated `ListView.onAdd: NumberAnimation` object-to-signal-handler assignment with a declarative `add: Transition` (consistent with the existing `remove: Transition`).
3. **TaskManager**: break the `implicitWidth`/`implicitHeight` binding loop by returning the dock size directly in the spanning layout direction (return value unchanged, dead binding computation dropped).
4. **AppItem / DragItem / ActionLegacyTrayPluginDelegate**: pass an explicit target size to `grabToImage` to avoid the "Ignoring sourceSize request" warning.
5. **OverlapNotify**: guard the `panelShown` lookup so an undefined `ListView.view` no longer assigns `undefined` to a bool property.
6. **trayitempositionmanager**: register the `DropIndex` gadget as `dropIndex` (lowercase) so qmltyperegistrar stops warning about its value-type name; C++ struct name and QML property access unchanged.

## Test

- Dock shell surface cursor shape handling still works
- Task manager item add animation still plays
- Dock auto-size layout is unchanged
- Drag image rendering for dock and tray items
- Notification overlap animation initialization

## Related

- Multica issue: https://agent-dev.uniontech.com/dde/issues/6db96431-e98a-4bcf-9b78-8c54e0329d03
- PMS: TASK-394379