### PR TITLE
Revert "fix(dock): prevent dock from taking focus"

### DIFF
--- a/panels/dock/package/main.qml
+++ b/panels/dock/package/main.qml
@@ -72,7 +72,7 @@ Window {
     DLayerShellWindow.layer: DLayerShellWindow.LayerTop
     DLayerShellWindow.exclusionZone: Panel.hideMode === Dock.KeepShowing ? Applet.dockSize : 0
     DLayerShellWindow.scope: "dde-shell/dock"
-    DLayerShellWindow.keyboardInteractivity: DLayerShellWindow.KeyboardInteractivityNone
+    DLayerShellWindow.keyboardInteractivity: DLayerShellWindow.KeyboardInteractivityOnDemand
 
     D.DWindow.enabled: true
     D.DWindow.windowRadius: 0


### PR DESCRIPTION
This reverts commit d39009724a754d9800a527732dcc686d1cb0e732.

pms: TASK-394609

## Summary by Sourcery

Enhancements:
- Restore on-demand keyboard interaction for the dock so it can receive focus when needed.