### PR TITLE
chore: update quickPlugins config permissions and serial

### DIFF
--- a/panels/dock/dconfig/org.deepin.ds.dock.tray.json
+++ b/panels/dock/dconfig/org.deepin.ds.dock.tray.json
@@ -4,13 +4,13 @@
     "contents":{
         "quickPlugins": {
             "value": ["network", "bluetooth", "wireless-casting", "grand-search", "eye-comfort-mode", "airplane-mode", "dnd-mode", "shot-start-plugin", "shot-start-record-plugin", "clipboard", "system-monitor", "media", "dde-brightness", "sound"],
-            "serial": 0,
+            "serial": 1,
             "flags": [],
             "name": "Quick plugins",
             "name[zh_CN]": "快捷面板插件",
             "description[zh_CN]": "指定了插件在快捷面板的显示顺序，从左到右，自上往下，其它的未指定的插件，按照插件的大小，放在最后面（例如：插件占两格，就放在所有两格插件的后面）。\n修改后重启任务栏（注销或者重启电脑亦可）生效）",
             "description":"",
-            "permissions":"readonly",
+            "permissions":"readwrite",
             "visibility":"private"
         },
         "stashedSurfaceIds": {


### PR DESCRIPTION
1. Change the quickPlugins permission from readonly to readwrite
2. Increment the config serial from 0 to 1 to reflect the change
3. This enables dynamic customization of quick panel plugins by users or
third-party extensions
4. The previous readonly restriction prevented modification of the quick
panel plugin order and configuration

Log: 快捷面板插件支持自定义配置

Influence:
1. Verify quickPlugins config can be modified via dconfig or D-Bus
2. Test that changes to the plugin list are persisted after reboot
3. Check that the quick panel still displays plugins in the specified
order
4. Test restoring default values if needed
5. Ensure the configuration change doesn't break existing plugin
functionality

chore: 更新快捷面板插件配置权限和序列号

1. 将 quickPlugins 的权限从 readonly 改为 readwrite
2. 将配置序列号从 0 递增到 1 以反映此次变更
3. 支持用户或第三方扩展动态自定义快捷面板插件
4. 之前的 readonly 限制阻止了快捷面板插件顺序和配置的修改

Log: 快捷面板插件支持自定义配置

Influence:
1. 验证可以通过 dconfig 或 D-Bus 修改 quickPlugins 配置
2. 测试插件列表的更改在重启后是否持久化
3. 检查快捷面板是否仍按指定顺序显示插件
4. 如需恢复默认值，测试重置功能
5. 确保配置更改不会破坏现有插件功能

## Summary by Sourcery

Enable writable quick panel plugin configuration while updating its serial to reflect the configuration change.

New Features:
- Allow users and third-party extensions to customize the quick panel plugin configuration.

Enhancements:
- Update the quick panel plugin configuration permissions and serial to support editable settings.