### PR TITLE
fix: AppGroup::parseGroupId off-by-one slice error (mid(len+1) → mid(len))

### DIFF
--- a/applets/dde-apps/appgroup.cpp
+++ b/applets/dde-apps/appgroup.cpp
@@ -61,7 +61,7 @@ int AppGroup::parseGroupId(const QString & id)
 {
     using namespace std::string_view_literals;
     constexpr size_t len = "internal/folder/"sv.size();
-    return QStringView{id}.mid(len + 1).toInt();
+    return QStringView{id}.mid(len).toInt();
 }
 
 void AppGroup::setItemsPerPage(int number)


### PR DESCRIPTION
## 修复内容

`AppGroup::parseGroupId` 存在 off-by-one 切片错误：`mid(len + 1)` 应为 `mid(len)`。

### 根因

`"internal/folder/"` 长度为 16 字符（下标 0–15），folder 号从下标 16 开始。`mid(len + 1)` = `mid(17)` 多跳一位，跳过了 folder 号的首位数字：

| 输入 | `mid(17)` 旧（缺陷） | `mid(16)` 新（修复） |
|---|---|---|
| `internal/folder/0`   | `""` → 0（偶然正确） | `"0"` → 0 ✅ |
| `internal/folder/5`   | `""` → 0 ❌ | `"5"` → 5 ✅ |
| `internal/folder/123` | `"23"` → 23 ❌ | `"123"` → 123 ✅ |

### 变更

仅 1 行改动（`applets/dde-apps/appgroup.cpp:64`）：

```diff
-    return QStringView{id}.mid(len + 1).toInt();
+    return QStringView{id}.mid(len).toInt();
```

### 调用点

`parseGroupId` 共 2 处调用，均已确认输入为合法 `"internal/folder/..."` 形式：
- `appgroup.cpp:23` 构造函数：groupId 来自 `groupIdFromNumber()` → `"internal/folder/N"`
- `appgroupmanager.cpp:185` 拖拽落点：前置 `AppGroup::idIsFolder(dropId)` 守卫

无回归风险，变更最小且外科手术式。

Closes: DDE-143

## Summary by Sourcery

Bug Fixes:
- Correct folder group ID parsing to preserve the first digit of valid internal folder identifiers.