### PR TITLE
fix(dde-apps): return empty list when firstNItems count <= 0

### DIFF
--- a/applets/dde-apps/itemspage.cpp
+++ b/applets/dde-apps/itemspage.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/applets/dde-apps/itemspage.cpp
+++ b/applets/dde-apps/itemspage.cpp
@@ -55,6 +55,8 @@ QStringList ItemsPage::items(int page) const
 QStringList ItemsPage::firstNItems(int count)
 {
     QStringList result;
+    if (count <= 0)
+        return result;
 
     for (const QStringList & pageItems : std::as_const(m_pages)) {
         for (const QString & item : pageItems) {

--- a/applets/dde-apps/itemspage.h
+++ b/applets/dde-apps/itemspage.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 


### PR DESCRIPTION
## 问题描述

`dde-shell` 的 `applets/dde-apps/itemspage.cpp` 方法 `ItemsPage::firstNItems(int count)` 存在**语义缺陷**：`count = 0`（及任意 `count <= 0`）时返回**首项**而非空列表，违反 `firstNItems(0)` 应返回空的直觉契约。

### 缺陷根因

循环内**先 `result.append(item)` 再判 `result.count() >= count`**：

- `count = 0` 时：第一次迭代 `append("a")` → `result.count()` 变 1 → `1 >= 0` 为 true → 返回 `["a"]`（首项），而非预期的空列表。
- 同理 `count < 0`（如 `-1`）也返回首项（`1 >= -1` 为 true）。

## 修复内容

在 `QStringList result;` 之后、循环之前新增早返逻辑，对 `count <= 0` 直接返回空列表：

```cpp
QStringList ItemsPage::firstNItems(int count)
{
    QStringList result;
    if (count <= 0)
        return result;

    for (const QStringList & pageItems : std::as_const(m_pages)) {
        for (const QString & item : pageItems) {
            result.append(item);
            if (result.count() >= count) {
                return result;
            }
        }
    }

    return result;
}
```

不采用「先判后 append」方案——会改变 `count` 恰好为页边界时的返回项数（少取一项），引入回归。

## 修复效果

- `firstNItems(0)` → `[]` ✅（修复前返回首项）
- `firstNItems(-1)` → `[]` ✅（修复前返回首项）
- `firstNItems(2/3/10)` 等正数行为完全不变 ✅（无回归）

## 影响范围

- 仅改 `applets/dde-apps/itemspage.cpp` 一处，2 行新增。
- `count > 0` 路径逻辑一字未改，无回归风险。
- 全仓库（C++ / QML）检索 `firstNItems` 调用点为 **0**，方法仅声明未使用，生产路径无触发风险，属 API 契约级修复。
- 不涉及 DBus 接口、Wayland 协议、DTK 控件、DConfig 配置，无需同步修改其他仓库。

## 审核

- 标准-代码审核bot：✅ Approved（已确认早返逻辑正确、`count > 0` 路径无回归、无副作用、代码风格与既有写法一致）。

Ref: DDE-144

## Summary by Sourcery

Ensure `firstNItems` honors empty-result semantics for non-positive item counts.

Bug Fixes:
- Return an empty list from `ItemsPage::firstNItems` when the requested count is zero or negative, while preserving positive-count behavior.

Chores:
- Update copyright years for the affected source files.