### PR TITLE
fix: keep default generic name for launcher search functionality

### DIFF
--- a/applets/dde-apps/amappitem.cpp
+++ b/applets/dde-apps/amappitem.cpp
@@ -40,16 +40,19 @@ AMAppItem::AMAppItem(const QDBusObjectPath &path, const ObjectInterfaceMap &sour
     if (appInfo.isEmpty())
         return;
 
-    auto name = getLocaleOrDefaultValue(qdbus_cast<QStringMap>(appInfo.value(u8"Name")), locale, DEFAULT_KEY);
-    auto genericName = getLocaleOrDefaultValue(qdbus_cast<QStringMap>(appInfo.value(u8"GenericName")), locale, DEFAULT_KEY);
+    const auto nameMap = qdbus_cast<QStringMap>(appInfo.value(u8"Name"));
+    const auto genericNameMap = qdbus_cast<QStringMap>(appInfo.value(u8"GenericName"));
+    const auto localizedName = getLocaleOrDefaultValue(nameMap, locale, DEFAULT_KEY);
+    const auto localizedGenericName = getLocaleOrDefaultValue(genericNameMap, locale, DEFAULT_KEY);
     auto xDeepinVendor = appInfo.value(u8"X_Deepin_Vendor").toString();
-    AppItem::setGenericName(genericName);
+    // Keep the default generic name for launchpad's English search while NameRole remains localized.
+    AppItem::setGenericName(genericNameMap.value(DEFAULT_KEY));
     AppItem::setVendor(xDeepinVendor);
 
-    if (QStringLiteral("deepin") == xDeepinVendor && !genericName.isEmpty()) {
-        AppItem::setAppName(genericName);
+    if (QStringLiteral("deepin") == xDeepinVendor && !localizedGenericName.isEmpty()) {
+        AppItem::setAppName(localizedGenericName);
     } else {
-        AppItem::setAppName(name);
+        AppItem::setAppName(localizedName);
     }
 
     auto iconName = getLocaleOrDefaultValue(qdbus_cast<QStringMap>(appInfo.value(u8"Icons")), DESKTOP_ENTRY_ICON_KEY, "");
@@ -156,24 +159,23 @@ void AMAppItem::onPropertyChanged(const QDBusMessage &msg)
 
     if (contains(QLatin1String("Name")) || contains(QLatin1String("GenericName"))
         || contains(QLatin1String("X_Deepin_Vendor"))) {
-        const QString name = getLocaleOrDefaultValue(
-                contains(QLatin1String("Name"))
-                        ? qdbus_cast<QStringMap>(value(QLatin1String("Name")))
-                        : Application::name(),
-                locale,
-                DEFAULT_KEY);
-        const QString genericName = getLocaleOrDefaultValue(
-                contains(QLatin1String("GenericName"))
-                        ? qdbus_cast<QStringMap>(value(QLatin1String("GenericName")))
-                        : Application::genericName(),
-                locale,
-                DEFAULT_KEY);
+        const QStringMap nameMap = contains(QLatin1String("Name"))
+                ? qdbus_cast<QStringMap>(value(QLatin1String("Name")))
+                : Application::name();
+        const QStringMap genericNameMap = contains(QLatin1String("GenericName"))
+                ? qdbus_cast<QStringMap>(value(QLatin1String("GenericName")))
+                : Application::genericName();
+        const QString localizedName = getLocaleOrDefaultValue(nameMap, locale, DEFAULT_KEY);
+        const QString localizedGenericName = getLocaleOrDefaultValue(genericNameMap, locale, DEFAULT_KEY);
         const QString vendor = contains(QLatin1String("X_Deepin_Vendor"))
                 ? value(QLatin1String("X_Deepin_Vendor")).toString()
                 : Application::x_Deepin_Vendor();
-        AppItem::setGenericName(genericName);
+        // Keep the default generic name for launchpad's English search while NameRole remains localized.
+        AppItem::setGenericName(genericNameMap.value(DEFAULT_KEY));
         AppItem::setVendor(vendor);
-        AppItem::setAppName(vendor == QLatin1String("deepin") && !genericName.isEmpty() ? genericName : name);
+        AppItem::setAppName(vendor == QLatin1String("deepin") && !localizedGenericName.isEmpty()
+                                     ? localizedGenericName
+                                     : localizedName);
     }
 
     if (contains(QLatin1String("Icons"))) {


### PR DESCRIPTION
The AMAppItem previously used localized generic names when setting the generic
name for application items, which broke the launchpad's English search functionality. The issue was that localized generic names (e.g., Chinese) were
stored as the generic name, preventing English text searches from matching
applications.

The fix separates the handling of generic names: the default (non- localized)
generic name is now preserved for the generic name role to maintain search
functionality, while localized names continue to be used for the display app
name. This ensures both search and display requirements are satisfied independently.

Changes:
1. Preserve the default generic name for GenericNameRole to maintain launchpad
   English search compatibility
2. Continue using the localized generic name for deepin vendor app display names
3. Refactor name map extraction to avoid redundant locale processing
4. Update both constructor and property change handler consistently

Log: Fixed launchpad search by preserving default generic names

Influence:
1. Verify launchpad can search applications by English generic name
2. Test localized display names for deepin vendor applications
3. Verify application name and generic name display in launcher
4. Test property change updates for application name fields

fix: 修复启动器搜索功能保留默认通用名称

AMAppItem 之前在使用本地化通用名称设置应用项目时，破坏了启动器的英文搜索
功能。问题在于本地化通用名称（如中文）被存储为通用名称，导致英文文本搜索
无法匹配到应用。

此修复将通用名称的处理分离：保留默认（非本地化）通用名称用于通用名称角色
以维持搜索功能，同时继续使用本地化名称作为显示名称。这可确保搜索和显示需
求能够独立满足。

变更内容：
1. 保留默认通用名称用于 GenericNameRole，以维持启动器英文搜索兼容性
2. 继续使用本地化通用名称作为 deepin 厂商应用的显示名称
3. 重构名称映射提取，避免重复的本地化处理
4. 构造函数和属性变更处理程序保持一致的更新逻辑

Log: 修复启动器搜索功能，保留默认通用名称

Influence:
1. 验证启动器可以通过英文通用名称搜索应用
2. 测试 deepin 厂商应用的本地化显示名称
3. 验证应用名称和通用名称在启动器中的显示
4. 测试应用名称字段的属性变更更新

PMS: BUG-375179

## Summary by Sourcery

Preserve default generic names for launcher search while continuing to show localized application names.

Bug Fixes:
- Preserve the default generic application name so launcher searches continue to match English generic names.
- Keep localized generic names for deepin application display names while retaining localized regular names for other applications.

Enhancements:
- Align initial application loading and property-change handling around shared localized and default name semantics.