### PR TITLE
style: refine dock app item sizing and pressed state

### DIFF
--- a/panels/dock/taskmanager/package/AppItem.qml
+++ b/panels/dock/taskmanager/package/AppItem.qml
@@ -79,8 +79,10 @@ Item {
     }
 
     Control {
-        anchors.fill: parent
         id: appItem
+        width: root.useColumnLayout ? parent.width : hoverBackground.width
+        height: root.useColumnLayout ? hoverBackground.height : parent.height
+        anchors.centerIn: parent
         implicitWidth: root.titleActive ? (root.iconSize + hoverBackground.horizontalSpacing + titleLoader.width) : iconContainer.width
         visible: !root.Drag.active // When in dragging, hide app item
         background: AppItemBackground {
@@ -118,6 +120,10 @@ Item {
                         target: iconContainer
                         anchors.left: parent.left
                         anchors.horizontalCenter: undefined
+                    }
+                    PropertyChanges {
+                        target: iconContainer
+                        anchors.leftMargin: hoverBackground.horizontalSpacing
                     }
                 },
                 State {

--- a/panels/dock/taskmanager/package/AppItemBackground.qml
+++ b/panels/dock/taskmanager/package/AppItemBackground.qml
@@ -31,6 +31,12 @@ AppletItemBackground {
             crystal: ("transparent")
         }
         normalDark: normal
+        pressed {
+            crystal: Qt.rgba(1.0, 1.0, 1.0, 0.25)
+        }
+        pressedDark {
+            crystal: Qt.rgba(1.0, 1.0, 1.0, 0.25)
+        }
         hovered {
             crystal: Qt.rgba(1.0, 1.0, 1.0, 0.15)
         }


### PR DESCRIPTION
1. Fix AppItem Control sizing to properly align with hover background
2. Use explicit width/height properties instead of anchors.fill
3. Center AppItem within parent for consistent positioning
4. Adjust icon container left margin based on hover background spacing in title active state
5. Add pressed state visual feedback with semi-transparent white background

Log: Refined dock app item layout and added pressed state visual effect

Influence:
1. Verify dock app items display correctly in both title and icon-only modes
2. Test icon alignment with hover background spacing
3. Verify pressed state visual feedback appears when clicking app items
4. Test app item sizing across different dock positions and orientations
5. Verify drag and drop functionality remains unaffected

style: 优化 Dock 应用项目尺寸和按压状态

1. 修复 AppItem Control 尺寸以正确对齐悬停背景
2. 使用显式的宽高属性替代 anchors.fill
3. 将 AppItem 居中于父级，保持定位一致
4. 根据悬停背景间距调整标题激活状态下的图标容器左边距
5. 添加按压状态的视觉反馈，使用半透明白色背景

Log: 优化 Dock 应用项目布局并添加按压状态视觉效果

Influence:
1. 验证 Dock 应用项目在标题模式和图标模式下均正常显示
2. 测试图标与悬停背景间距的对齐效果
3. 验证点击应用项目时按压状态的视觉反馈
4. 测试应用项目在不同 Dock 位置和方向下的尺寸表现
5. 验证拖拽功能不受影响

PMS: BUG-375517 BUG-375531

## Summary by Sourcery

Refine dock app item layout and interaction feedback for consistent alignment and clearer pressed states.

Bug Fixes:
- Correct AppItem sizing and positioning so dock items align consistently with their hover backgrounds across layouts.

Enhancements:
- Refine title-mode icon spacing and add visual feedback for pressed app items.