### PR TITLE
fix: prevent dock tray popup flicker

### DIFF
--- a/frame/qml/PanelPopup.qml
+++ b/frame/qml/PanelPopup.qml
@@ -16,6 +16,10 @@ Item {
     property int popupY: 0
     property bool readyBinding: false
     property bool openPending: false
+    property bool contentReady: true
+    property bool contentOpenPending: false
+    property bool revealAfterRender: false
+    property bool revealPending: false
     property bool grabInactivePending: false
     property int grabInactiveTimeout: 200
     // WM_NAME, used for kwin.
@@ -54,6 +58,12 @@ Item {
         if (!popupWindow)
             return
 
+        if (!contentReady) {
+            contentOpenPending = true
+            return
+        }
+        contentOpenPending = false
+
         // The popup is being displayed. If you click on other plugin at this time,
         // the popup content of the previous plugin will be displayed first,
         // and the wrong popup size will cause the window size to change and flicker.
@@ -84,10 +94,15 @@ Item {
     function close()
     {
         openPending = false
+        contentOpenPending = false
+        revealPending = false
         grabInactivePending = false
         grabInactiveTimer.stop()
         if (!popupWindow)
             return
+
+        if (popupWindow.currentItem === control)
+            popupWindow.opacity = 1
 
         // avoid to closing window by other PanelPopup.
         if (!readyBinding)
@@ -97,6 +112,16 @@ Item {
         popupWindow.currentItem = null
     }
 
+    onContentReadyChanged: {
+        if (!contentReady || !contentOpenPending)
+            return
+
+        Qt.callLater(function () {
+            if (contentReady && contentOpenPending)
+                control.open()
+        })
+    }
+
     function finalizeOpen()
     {
         if (!popupWindow || !openPending || !readyBinding || popupWindow.currentItem !== control)
@@ -104,8 +129,16 @@ Item {
 
         openPending = false
         popupWindow.title = windowTitle
+        revealPending = revealAfterRender
+        // popupWindow is shared by all PanelPopup instances. Always initialize
+        // its opacity so a popup cannot inherit an interrupted reveal state.
+        popupWindow.opacity = revealPending ? 0 : 1
         popupWindow.show()
-        popupWindow.requestActivate()
+        if (revealPending) {
+            popupWindow.update()
+        } else {
+            popupWindow.requestActivate()
+        }
     }
 
     Timer {
@@ -154,6 +187,16 @@ Item {
         function onUpdateGeometryFinished()
         {
             control.finalizeOpen()
+        }
+
+        function onFrameSwapped()
+        {
+            if (!control.revealPending || !popupWindow || popupWindow.currentItem !== control)
+                return
+
+            control.revealPending = false
+            popupWindow.opacity = 1
+            popupWindow.requestActivate()
         }
 
         function onX11FocusOutByGrab()

--- a/panels/dock/ShellSurfaceItemProxy.qml
+++ b/panels/dock/ShellSurfaceItemProxy.qml
@@ -18,6 +18,7 @@ Item {
     property bool pressed: tapHandler.pressed
     property int cursorShape: Qt.ArrowCursor
     property alias shellSurfaceItem: impl
+    readonly property bool hasSurfaceContent: impl.surface ? impl.surface.hasContent : false
 
     implicitWidth: shellSurface ? shellSurface.width : 16
     implicitHeight: shellSurface ? shellSurface.height : 16

--- a/panels/dock/dockpositioner.cpp
+++ b/panels/dock/dockpositioner.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -36,7 +36,10 @@ DockPositioner::DockPositioner(DPanel *panel, QObject *parent)
     Q_ASSERT(m_panel);
     connect(m_panel, SIGNAL(positionChanged(Position)), this, SLOT(update()));
     connect(m_panel, SIGNAL(geometryChanged(QRect)), this, SLOT(update()));
-    connect(this, &DockPositioner::boundingChanged, this, &DockPositioner::update);
+    // The popup may be opened in the same event-loop turn as its anchor is
+    // assigned. Calculate anchor changes immediately so its first frame does
+    // not use the default (0, 0) position.
+    connect(this, &DockPositioner::boundingChanged, this, &DockPositioner::updatePosition);
 }
 
 DockPositioner::~DockPositioner()

--- a/panels/dock/tray/TrayItemSurfacePopup.qml
+++ b/panels/dock/tray/TrayItemSurfacePopup.qml
@@ -33,6 +33,8 @@ Item {
         height: popupContent.height
         popupX: DockPanelPositioner.x
         popupY: DockPanelPositioner.y
+        contentReady: popupContent.hasSurfaceContent
+        revealAfterRender: true
 
         Item {
             anchors.fill: parent


### PR DESCRIPTION
## BUG-375267
## Summary
- Calculate dock tray popup coordinates before the first frame.
- Wait for committed Wayland content and one rendered frame before revealing the popup.
- Reset shared popup window opacity during interrupted popup transitions.

## Test plan
- cmake --build build --target dde-shell dock-plugin dock-tray -j2
- ctest --test-dir build --output-on-failure -j2
- Verified on the remote UOS machine: the network tray popup opens at the correct position without a transparent first frame.

## Summary by Sourcery

Prevent dock tray popup flicker by positioning popups before display and revealing them only after their content has rendered.

Bug Fixes:
- Prevent dock tray popups from flickering or showing a transparent first frame when opening.
- Ensure popup anchors use their current coordinates before the popup is first displayed.
- Delay popup reveal until Wayland content is committed and a frame has rendered.

Enhancements:
- Reset shared popup opacity during interrupted transitions to prevent stale visual state from affecting subsequent popups.