### PR TITLE
fix(notification): fix crash when the app accessor model is destroyed

### DIFF
--- a/panels/notification/server/notificationsetting.cpp
+++ b/panels/notification/server/notificationsetting.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -58,6 +58,10 @@ void NotificationSetting::setAppAccessor(QAbstractItemModel *model)
     m_appAccessor = model;
     QObject::connect(m_appAccessor, &QAbstractItemModel::rowsInserted, this, &NotificationSetting::onAppsChanged);
     QObject::connect(m_appAccessor, &QAbstractItemModel::rowsRemoved, this, &NotificationSetting::onAppsChanged);
+    QObject::connect(m_appAccessor, &QObject::destroyed, this, [this](QObject *obj) {
+        if (m_appAccessor == obj)
+            m_appAccessor = nullptr;
+    });
 }
 
 QAbstractItemModel *NotificationSetting::appAccessor() const
@@ -275,6 +279,9 @@ QVariantMap NotificationSetting::appInfo(const QString &id) const
 
 void NotificationSetting::onAppsChanged()
 {
+    if (!m_appAccessor)
+        return;
+
     const auto old = appItems();
     const auto current = appItemsImpl();
 

--- a/tests/panels/notification/server/notifyserverapplet_test.cpp
+++ b/tests/panels/notification/server/notifyserverapplet_test.cpp
@@ -9,9 +9,11 @@
 #include <QThread>
 #include <QSignalSpy>
 #include <QVariant>
+#include <QStandardItemModel>
 
 #include "notifyserverapplet.h"
 #include "notificationmanager.h"
+#include "notificationsetting.h"
 
 using namespace notification;
 using ::testing::_;
@@ -369,6 +371,24 @@ TEST_F(NotifyServerAppletTest, AppValueEmptyAppIdTest) {
     
     QVariant result = applet->appValue(QString(), 0);
     (void)result; // Suppress unused warning
+}
+
+// Test that deleting the app model accessor does not leave a dangling pointer
+TEST_F(NotifyServerAppletTest, AppAccessorDestroyedTest) {
+    auto *setting = new NotificationSetting();
+    auto *model = new QStandardItemModel();
+    setting->setAppAccessor(model);
+    EXPECT_NE(setting->appAccessor(), nullptr);
+
+    delete model;
+    model = nullptr;
+
+    EXPECT_EQ(setting->appAccessor(), nullptr);
+    EXPECT_NO_THROW({
+        EXPECT_TRUE(setting->apps().isEmpty());
+    });
+
+    delete setting;
 }
 
 // Main function for tests


### PR DESCRIPTION
1. Connect the app accessor model's QObject::destroyed signal to reset m_appAccessor to nullptr, so it no longer becomes a dangling pointer after the model (owned by the dde-apps applet) is destroyed
2. Add a null check in onAppsChanged() to return early when the accessor is gone
3. Add AppAccessorDestroyedTest to cover the dangling-pointer scenario

Log: fix crash caused by dereferencing a dangling app accessor pointer

Influence:
1. Verify dde-shell no longer crashes when the dde-apps applet is reloaded/unloaded or the app model is rebuilt
2. Verify the notification server app list still updates correctly when apps are installed/uninstalled

fix(notification): 修复应用访问器模型销毁后崩溃的问题

1. 连接应用访问器模型的 QObject::destroyed 信号，将 m_appAccessor 置空， 避免模型（由 dde-apps 插件持有）销毁后成为悬空指针
2. 在 onAppsChanged() 中增加空指针判断，访问器已销毁时直接返回
3. 新增 AppAccessorDestroyedTest 覆盖悬空指针场景

Log: 修复解引用悬空应用访问器指针导致的崩溃

Influence:
1. 验证 dde-apps 插件重载/卸载或应用模型重建时 dde-shell 不再崩溃
2. 验证应用安装/卸载时通知服务的应用列表仍能正确更新

PMS: BUG-375591

## Summary by Sourcery

Prevent dangling application accessor references from crashing the notification service when the app model is destroyed.

Bug Fixes:
- Prevent notification service crashes when its application accessor model is destroyed by clearing the accessor reference and safely skipping application-change handling afterward.

Tests:
- Add coverage for application accessor destruction and subsequent safe application-list access.