### PR TITLE
feat: add fashion dock mode with card plugin support

### DIFF
--- a/panels/dock/CMakeLists.txt
+++ b/panels/dock/CMakeLists.txt
@@ -97,7 +97,7 @@ ds_install_package(PACKAGE org.deepin.ds.dock TARGET dockpanel)
 ds_handle_package_translation(PACKAGE org.deepin.ds.dock)
 
 # sub plugins
-#add_subdirectory(cardleft)
+add_subdirectory(cardleft)
 add_subdirectory(showdesktop)
 add_subdirectory(taskmanager)
 add_subdirectory(tray)

--- a/panels/dock/DockCompositor.qml
+++ b/panels/dock/DockCompositor.qml
@@ -18,6 +18,7 @@ Item {
     property alias dockPosition: pluginManager.dockPosition
     property alias dockColorTheme: pluginManager.dockColorTheme
     property alias dockSize: pluginManager.dockSize
+    property alias fashionMode: pluginManager.fashionMode
     property var moveXEmbedWindowHandler: null
 
     function notifyXEmbedWindowMoveResult(wid, success) {
@@ -30,6 +31,7 @@ Item {
     property ListModel trayPluginSurfaces: ListModel {}
     property ListModel quickPluginSurfaces: ListModel {}
     property ListModel fixedPluginSurfaces: ListModel {}
+    property ListModel cardPluginSurfaces: ListModel {}
 
     property var compositor: waylandCompositor
     property var panelScale: 1.0
@@ -62,6 +64,7 @@ Item {
         let ret = findSurfaceFromModel(trayPluginSurfaces, surfaceId)
         if (ret === null) ret = findSurfaceFromModel(quickPluginSurfaces, surfaceId)
         if (ret === null) ret = findSurfaceFromModel(fixedPluginSurfaces, surfaceId)
+        if (ret === null) ret = findSurfaceFromModel(cardPluginSurfaces, surfaceId)
         return ret
     }
 
@@ -92,6 +95,8 @@ Item {
                     quickPluginSurfaces.append({shellSurface: dockPluginSurface})
                 } else if (dockPluginSurface.pluginType === Dock.Fixed) {
                     fixedPluginSurfaces.append({shellSurface: dockPluginSurface})
+                } else if (dockPluginSurface.pluginType === Dock.Card) {
+                    cardPluginSurfaces.append({shellSurface: dockPluginSurface})
                 }
                 dockCompositor.pluginSurfacesUpdated()
             }
@@ -104,6 +109,8 @@ Item {
                     removeDockPluginSurface(quickPluginSurfaces, dockPluginSurface)
                 } else if (dockPluginSurface.pluginType === Dock.Fixed) {
                     removeDockPluginSurface(fixedPluginSurfaces, dockPluginSurface)
+                } else if (dockPluginSurface.pluginType === Dock.Card) {
+                    removeDockPluginSurface(cardPluginSurfaces, dockPluginSurface)
                 }
                 dockCompositor.pluginSurfacesUpdated()
             }

--- a/panels/dock/cardleft/CMakeLists.txt
+++ b/panels/dock/cardleft/CMakeLists.txt
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+ds_install_package(PACKAGE org.deepin.ds.dock.cardleft)

--- a/panels/dock/cardleft/package/CardLeftDockArea.qml
+++ b/panels/dock/cardleft/package/CardLeftDockArea.qml
@@ -1,0 +1,518 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Window 2.15
+import QtWayland.Compositor
+
+import org.deepin.ds 1.0
+import org.deepin.ds.dock 1.0
+import org.deepin.dtk 1.0 as D
+
+AppletDockItem {
+    id: root
+
+    readonly property bool fashionMode: Panel.fashionMode
+    readonly property int dockSize: Panel.rootObject.dockSize
+    readonly property int hoverInset: 3
+    readonly property real taskbarRadius: Panel.rootObject.fashionDock.backgroundRadius
+    readonly property real hoverBackgroundRadius: taskbarRadius - hoverInset
+    readonly property int adaptiveCardLeftWidth: 150 + Math.max(0, dockSize / 4)
+    readonly property int rightContentPadding: Math.max(10, Math.round(adaptiveCardLeftWidth * 0.07))
+    readonly property int verticalInset: Math.max(5, Math.round(dockSize * 0.16))
+    readonly property int pageContentHeight: Math.max(24, dockSize - verticalInset * 2)
+
+    dockOrder: 5
+    shouldVisible: fashionMode && pageCount > 0
+    readonly property int pageCount: sortedCards.count
+    property bool contentHovered: false
+    readonly property bool effectiveHovered: rootHoverHandler.hovered || contentHovered
+
+    // The card the user was looking at is persisted so it can be restored after
+    // the dock restarts.  The surface id ("pluginId::itemKey") is stored instead
+    // of the page index, because every card comes from its own plugin process
+    // and the surfaces may be created in a different order on each startup.
+    property bool currentRestored: false
+    // Reordering the pages moves the current card around, and removing a card
+    // shifts the pages after it.  Such index changes must not be persisted,
+    // only the ones caused by the user switching cards.
+    property bool modelChanging: false
+
+    // Card surfaces show up in whatever order their plugin processes manage to
+    // connect to the compositor, so they are sorted by the order each plugin
+    // reports before being displayed.
+    readonly property int sourceCount: DockCompositor.cardPluginSurfaces.count
+
+    visible: shouldVisible
+    implicitWidth: adaptiveCardLeftWidth
+    implicitHeight: dockSize
+    clip: true
+
+    function updateContentHovered() {
+        const item = swipeView.currentItem
+        contentHovered = !!item && item.surfaceHovered
+    }
+
+    function surfaceIdOf(surface) {
+        return surface ? `${surface.pluginId}::${surface.itemKey}` : ""
+    }
+
+    function cardSurfaceId(index) {
+        if (index < 0 || index >= sortedCards.count) {
+            return ""
+        }
+
+        return surfaceIdOf(sortedCards.get(index).shellSurface)
+    }
+
+    function cardIndexOf(surfaceId) {
+        if (!surfaceId) {
+            return -1
+        }
+
+        for (let i = 0; i < sortedCards.count; ++i) {
+            if (cardSurfaceId(i) === surfaceId) {
+                return i
+            }
+        }
+        return -1
+    }
+
+    // Cards are sorted by the order their plugin reports, ascending, so the
+    // smallest one is shown first.  A plugin that does not care reports a very
+    // large value and lands at the back, and so does a card whose order has not
+    // arrived yet, since it is reported right after the surface is created.
+    // The sort is stable, cards sharing an order stay in creation order.
+    function desiredSurfaces() {
+        const source = DockCompositor.cardPluginSurfaces
+        const cards = []
+
+        for (let i = 0; i < source.count; ++i) {
+            const surface = source.get(i).shellSurface
+            if (!surface) {
+                continue
+            }
+
+            cards.push({ surface: surface, order: surface.cardOrder, created: i })
+        }
+
+        cards.sort((a, b) => a.order - b.order || a.created - b.created)
+        return cards.map(entry => entry.surface)
+    }
+
+    // Brings sortedCards in line with the compositor model.  The rows are
+    // inserted, removed and moved one by one instead of being rebuilt, so the
+    // delegates - and with them the wayland surface items - are kept alive.
+    function syncSortedCards() {
+        const desired = desiredSurfaces()
+
+        for (let i = sortedCards.count - 1; i >= 0; --i) {
+            if (desired.indexOf(sortedCards.get(i).shellSurface) < 0) {
+                sortedCards.remove(i)
+            }
+        }
+
+        for (let target = 0; target < desired.length; ++target) {
+            const surface = desired[target]
+            let current = -1
+            for (let i = target; i < sortedCards.count; ++i) {
+                if (sortedCards.get(i).shellSurface === surface) {
+                    current = i
+                    break
+                }
+            }
+
+            if (current < 0) {
+                sortedCards.insert(target, { shellSurface: surface })
+            } else if (current !== target) {
+                sortedCards.move(current, target, 1)
+            }
+        }
+
+        syncCurrentCard()
+    }
+
+    // Restores the card persisted by the previous session, and keeps that card
+    // visible while cards are added to, removed from or reordered in the model.
+    function syncCurrentCard() {
+        modelChanging = false
+
+        const savedIndex = cardIndexOf(Panel.cardCurrent)
+        if (savedIndex >= 0) {
+            currentRestored = true
+            if (swipeView.currentIndex !== savedIndex) {
+                swipeView.setCurrentIndex(savedIndex)
+            }
+            return
+        }
+
+        // Either nothing has been persisted yet, or the persisted card is not
+        // available.  During startup its plugin process may still be coming up,
+        // so only fall back to the current card once the deadline has passed.
+        if (!Panel.cardCurrent || currentRestored) {
+            currentRestored = true
+            saveCurrentCard()
+        }
+    }
+
+    function saveCurrentCard() {
+        // Saving before the restore finished would overwrite the persisted card
+        // with whichever card surface happens to be created first.
+        if (!currentRestored || modelChanging) {
+            return
+        }
+
+        const id = cardSurfaceId(swipeView.currentIndex)
+        if (id) {
+            Panel.cardCurrent = id
+        }
+    }
+
+    onSourceCountChanged: {
+        if (sourceCount === 0) {
+            // All card plugins are gone (e.g. their processes were restarted),
+            // restore again instead of persisting the first card that returns.
+            currentRestored = false
+        }
+
+        modelChanging = true
+        syncTimer.restart()
+    }
+    Component.onCompleted: syncTimer.restart()
+
+    // Sorted view of DockCompositor.cardPluginSurfaces, see syncSortedCards().
+    ListModel {
+        id: sortedCards
+    }
+
+    // The card surfaces are created one by one by independent plugin processes.
+    // Coalesce the updates, and let the SwipeView pick up the model change
+    // before touching currentIndex, otherwise setCurrentIndex() would be
+    // clamped to the old page count.
+    Timer {
+        id: syncTimer
+
+        interval: 50
+        repeat: false
+        onTriggered: root.syncSortedCards()
+    }
+
+    // Stop waiting for a card that never appears (e.g. its plugin was removed),
+    // otherwise the current card would never be persisted again.
+    Timer {
+        id: restoreTimeout
+
+        interval: 10000
+        running: !root.currentRestored
+        onTriggered: {
+            root.currentRestored = true
+            root.saveCurrentCard()
+        }
+    }
+
+    HoverHandler {
+        id: rootHoverHandler
+        acceptedDevices: PointerDevice.Mouse | PointerDevice.TouchPad | PointerDevice.Stylus
+    }
+
+    AppletItemBackground {
+        x: root.hoverInset
+        y: root.hoverInset
+        width: parent.width - root.hoverInset
+        height: parent.height - root.hoverInset * 2
+        radius: root.hoverBackgroundRadius
+        enabled: false
+        opacity: root.effectiveHovered ? 1 : 0
+        D.ColorSelector.hovered: root.effectiveHovered
+
+        Behavior on opacity {
+            NumberAnimation {
+                duration: 150
+                easing.type: Easing.OutCubic
+            }
+        }
+    }
+
+    Item {
+        anchors.right: parent.right
+        anchors.rightMargin: 8
+        anchors.verticalCenter: parent.verticalCenter
+        visible: root.effectiveHovered && root.pageCount > 1
+        width: pageIndicator.implicitHeight
+        height: pageIndicator.implicitWidth
+
+        PageIndicator {
+            id: pageIndicator
+
+            anchors.centerIn: parent
+            rotation: 90
+            count: swipeView.count
+            currentIndex: swipeView.currentIndex
+            padding: 0
+            spacing: 4
+
+            delegate: Rectangle {
+                required property int index
+
+                implicitWidth: 2
+                implicitHeight: 2
+                radius: width / 2
+                color: Panel.colorTheme === Dock.Dark
+                    ? Qt.rgba(0, 0, 0, index === pageIndicator.currentIndex ? 0.6 : 0.2)
+                    : Qt.rgba(1, 1, 1, index === pageIndicator.currentIndex ? 0.6 : 0.2)
+            }
+        }
+    }
+
+    SwipeView {
+        id: swipeView
+
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.verticalCenter: parent.verticalCenter
+        anchors.leftMargin: 8
+        anchors.rightMargin: root.rightContentPadding
+        height: root.pageContentHeight
+        orientation: Qt.Vertical
+        interactive: count > 1
+        clip: true
+
+        onCurrentItemChanged: {
+            root.updateContentHovered()
+            surfaceGeometryUpdateTimer.restart()
+        }
+
+        onCurrentIndexChanged: {
+            // The popups belong to the card that was on screen, drop them when
+            // the user swipes to another one.
+            cardToolTip.close()
+            cardMenu.close()
+            root.saveCurrentCard()
+        }
+
+        Repeater {
+            model: sortedCards
+
+            delegate: Item {
+                id: surfaceHost
+
+                property var plugin: model.shellSurface
+                readonly property bool surfaceHovered: SwipeView.isCurrentItem && surfaceItem.hovered
+
+                ShellSurfaceItemProxy {
+                    id: surfaceItem
+                    width: parent.width
+                    height: parent.height
+                    shellSurface: surfaceHost.plugin
+                }
+
+                function updateSurfaceGeometry() {
+                    if (!plugin || !SwipeView.isCurrentItem || !surfaceHost.Window.window) {
+                        return
+                    }
+
+                    const window = surfaceHost.Window.window
+                    const windowPosition = surfaceHost.mapToItem(window.contentItem, 0, 0)
+                    const globalPosition = Qt.point(windowPosition.x + window.x,
+                                                    windowPosition.y + window.y)
+
+                    plugin.updatePluginGeometry(Qt.rect(Math.round(windowPosition.x),
+                                                        Math.round(windowPosition.y),
+                                                        Math.round(width),
+                                                        Math.round(height)))
+                    plugin.setGlobalPos(Qt.point(Math.round(globalPosition.x),
+                                                 Math.round(globalPosition.y)))
+                    surfaceItem.fixPosition()
+                }
+
+                Component.onCompleted: updateSurfaceGeometry()
+                onWidthChanged: geometryUpdateTimer.restart()
+                onHeightChanged: geometryUpdateTimer.restart()
+                onVisibleChanged: {
+                    geometryUpdateTimer.restart()
+                    root.updateContentHovered()
+                }
+                onSurfaceHoveredChanged: root.updateContentHovered()
+
+                Timer {
+                    id: geometryUpdateTimer
+                    interval: 50
+                    repeat: false
+                    onTriggered: surfaceHost.updateSurfaceGeometry()
+                }
+
+                // A plugin reports its order right after its card surface is
+                // created, so the card starts out unordered and has to be
+                // sorted into place once the value arrives.
+                Connections {
+                    target: surfaceHost.plugin
+                    ignoreUnknownSignals: true
+
+                    function onCardOrderChanged() {
+                        root.modelChanging = true
+                        syncTimer.restart()
+                    }
+                }
+            }
+        }
+    }
+
+    Item {
+        anchors.fill: parent
+        z: 1
+
+        WheelHandler {
+            target: null
+            enabled: swipeView.count > 1
+            acceptedDevices: PointerDevice.Mouse | PointerDevice.TouchPad
+
+            onWheel: function(wheel) {
+                const deltaY = wheel.angleDelta.y !== 0 ? wheel.angleDelta.y : wheel.pixelDelta.y
+                if (deltaY === 0) {
+                    return
+                }
+
+                const step = deltaY < 0 ? 1 : -1
+                const nextIndex = (swipeView.currentIndex + step + swipeView.count) % swipeView.count
+                swipeView.setCurrentIndex(nextIndex)
+                wheel.accepted = true
+            }
+        }
+    }
+
+    Connections {
+        target: swipeView.contentItem
+        ignoreUnknownSignals: true
+
+        function onContentYChanged() {
+            surfaceGeometryUpdateTimer.restart()
+        }
+
+    }
+
+    Timer {
+        id: surfaceGeometryUpdateTimer
+
+        interval: 50
+        repeat: false
+        onTriggered: {
+            const item = swipeView.currentItem
+            if (item) {
+                item.updateSurfaceGeometry()
+            }
+        }
+    }
+
+    // Card surfaces are not tray items, so their popups are not routed by the
+    // tray's per-item handlers and have to be shown here.  Both the tooltip and
+    // the menu reuse the shared panel windows, whose WaylandOutputs are set up
+    // by the tray applet.
+    PanelToolTip {
+        id: cardToolTip
+
+        property alias shellSurface: cardToolTipContent.shellSurface
+
+        toolTipX: DockPanelPositioner.x
+        toolTipY: DockPanelPositioner.y
+
+        ShellSurfaceItemProxy {
+            id: cardToolTipContent
+
+            anchors.centerIn: parent
+            autoClose: true
+            onSurfaceDestroyed: cardToolTip.close()
+        }
+    }
+
+    PanelMenu {
+        id: cardMenu
+
+        property alias shellSurface: cardMenuContent.shellSurface
+
+        width: cardMenuContent.width
+        height: cardMenuContent.height
+        menuX: DockPositioner.x
+        menuY: DockPositioner.y
+
+        Item {
+            anchors.fill: parent
+
+            ShellSurfaceItemProxy {
+                id: cardMenuContent
+
+                anchors.centerIn: parent
+                autoClose: true
+                onSurfaceDestroyed: cardMenu.close()
+            }
+
+            // Hand the final placement back to the plugin, it positions its own
+            // menu window relative to it.
+            Connections {
+                target: cardMenu.menuWindow
+                enabled: cardMenu.readyBinding
+
+                function onUpdateGeometryFinished() {
+                    if (!cardMenu.shellSurface) {
+                        return
+                    }
+
+                    cardMenu.shellSurface.updatePluginGeometry(
+                        Qt.rect(cardMenu.menuWindow.x, cardMenu.menuWindow.y, 0, 0))
+                }
+            }
+        }
+    }
+
+    Connections {
+        target: DockCompositor
+
+        function onPopupCreated(popupSurface) {
+            const isTooltip = popupSurface.popupType === Dock.TrayPopupTypeTooltip
+            const isMenu = popupSurface.popupType === Dock.TrayPopupTypeMenu
+            if (!isTooltip && !isMenu) {
+                return
+            }
+
+            const surfaceId = `${popupSurface.pluginId}::${popupSurface.itemKey}`
+            if (!DockCompositor.findSurfaceFromModel(DockCompositor.cardPluginSurfaces, surfaceId)) {
+                return
+            }
+
+            if (isTooltip) {
+                cardToolTip.shellSurface = popupSurface
+                // The plugin anchors the tooltip at the horizontal center of its
+                // card, DockPanelPositioner turns that into the final placement.
+                cardToolTip.DockPanelPositioner.bounding = Qt.binding(function () {
+                    return Qt.rect(cardToolTip.shellSurface.x, cardToolTip.shellSurface.y,
+                                   cardToolTip.width, cardToolTip.height)
+                })
+                cardToolTip.open()
+                return
+            }
+
+            // The menu is anchored at the cursor, and replaces whatever popup is
+            // currently open.
+            cardToolTip.close()
+            cardMenu.shellSurface = popupSurface
+            cardMenu.DockPositioner.bounding = Qt.binding(function () {
+                return Qt.rect(cardMenu.shellSurface.x, cardMenu.shellSurface.y,
+                               cardMenu.width, cardMenu.height)
+            })
+            Panel.requestClosePopup()
+            cardMenu.open()
+            // Let the menu surface handle key events, e.g. arrow keys.
+            cardMenuContent.takeFocus()
+        }
+    }
+
+    // The popups belong to the card that is currently on screen, hide them as
+    // soon as the whole card area goes away.
+    onShouldVisibleChanged: {
+        if (!shouldVisible) {
+            cardToolTip.close()
+            cardMenu.close()
+        }
+    }
+}

--- a/panels/dock/cardleft/package/metadata.json
+++ b/panels/dock/cardleft/package/metadata.json
@@ -1,0 +1,8 @@
+{
+    "Plugin": {
+        "Version": "1.0",
+        "Id": "org.deepin.ds.dock.cardleft",
+        "Url": "CardLeftDockArea.qml",
+        "Parent": "org.deepin.ds.dock"
+    }
+}

--- a/panels/dock/constants.h
+++ b/panels/dock/constants.h
@@ -36,6 +36,7 @@ enum IndicatorStyle {
 enum ItemAlignment {
     CenterAlignment      = 0,
     LeftAlignment        = 1,
+    FashionAlignment      = 2,
 };
 
 enum ColorTheme {
@@ -79,6 +80,7 @@ enum TrayPluginType {
     Tray = 1,
     Fixed,
     Quick,
+    Card,
 };
 
 enum TrayPluginSizePolicy {
@@ -108,6 +110,14 @@ const QString MSG_SUPPORT_FLAG_CHANGED = QStringLiteral("supportFlagChanged");
 const QString MSG_ITEM_ACTIVE_STATE = QStringLiteral("itemActiveState");
 
 /**
+ * @brief 插件卡片的排序值；插件在卡片 surface 创建后主动上报给任务栏
+ * 任务栏按该值升序排列卡片，值最小的卡片显示在第一个，值相同则保持创建顺序。
+ * MSG_DATA 类型为 int。任务栏不解释具体数值，也不感知插件 id，
+ * 因此独立发布的插件也能参与排序。
+ */
+const QString MSG_CARD_ORDER = QStringLiteral("cardOrder");
+
+/**
  * @brief 插件请求任务栏更新插件的 tooltips
  * 任务栏收到请求后会主动调用 itemTips() 方法。
  * 一般用于一个插件里面含有多个图标，鼠标 hover 到不同图标上时显示不同 tooltips 的场景。
@@ -134,6 +144,13 @@ enum OverFlowState {
  * 插件根据任务栏size做出大小调整，例如时间日期插件
  */
 const QString MSG_DOCK_PANEL_SIZE_CHANGED = QStringLiteral("dockPanelSizeChanged");
+
+/**
+ * @brief 任务栏是否处于时尚模式；插件 surface 创建时和模式变化时，任务栏主动发给插件
+ * MSG_DATA 类型为 bool。插件可以据此对时尚模式做单独的布局调整，
+ * 例如时间日期插件在时尚模式下把时间和日期并排显示成一行。
+ */
+const QString MSG_DOCK_FASHION_MODE = QStringLiteral("dockFashionMode");
 
 /**
  * @brief 最小弹窗高度，根据快捷面板的高度动态变化

--- a/panels/dock/dconfig/org.deepin.ds.dock.json
+++ b/panels/dock/dconfig/org.deepin.ds.dock.json
@@ -82,6 +82,17 @@
                         "permissions": "readwrite",
                         "visibility": "private"
 		},
+		"cardCurrent": {
+			"value": "",
+			"serial": 0,
+			"flags": [],
+			"name": "cardCurrent",
+			"name[zh_CN]": "当前显示的卡片",
+			"description": "The surface id (pluginId::itemKey) of the card shown in the card area, restored on startup.",
+			"description[zh_CN]": "卡片区域当前显示的卡片标识（pluginId::itemKey），任务栏重启后据此恢复。",
+			"permissions": "readwrite",
+			"visibility": "private"
+		},
 		"enableShowDesktop": {
 			"value": true,
 			"serial": 0,
@@ -100,6 +111,17 @@
 			"name[zh_CN]": "启用任务栏右键菜单",
 			"description": "Enable or disable the context menu on the empty area of the dock.",
 			"description[zh_CN]": "启用或禁用任务栏空白区域的右键菜单和触摸长按菜单。",
+			"permissions": "readwrite",
+			"visibility": "private"
+		},
+		"enableFashionMode": {
+			"value": false,
+			"serial": 0,
+			"flags": [],
+			"name": "Enable Fashion Mode",
+			"name[zh_CN]": "启用时尚模式",
+			"description": "Allow switching the dock to fashion mode. When disabled, the fashion mode entry is hidden from the dock context menu and the dock falls back to centered mode.",
+			"description[zh_CN]": "是否允许把任务栏切换到时尚模式。关闭时任务栏右键菜单里不显示时尚模式入口，已保存的时尚模式也会回退成居中模式。",
 			"permissions": "readwrite",
 			"visibility": "private"
 		}

--- a/panels/dock/dockpanel.cpp
+++ b/panels/dock/dockpanel.cpp
@@ -61,6 +61,19 @@ bool DockPanel::load()
 
 bool DockPanel::init()
 {
+    // Normalize legacy/hand-edited configurations before exporting the state
+    // to D-Bus or creating the QML panel.
+    if (!SETTINGS->fashionModeEnabled()
+        && SETTINGS->itemAlignment() == ItemAlignment::FashionAlignment) {
+        // 时尚模式没有放开时，已保存的时尚模式回退成居中模式
+        SETTINGS->setItemAlignment(ItemAlignment::CenterAlignment);
+    }
+
+    if (SETTINGS->itemAlignment() == ItemAlignment::FashionAlignment
+        && (SETTINGS->position() == Position::Left || SETTINGS->position() == Position::Right)) {
+        SETTINGS->setPosition(Position::Bottom);
+    }
+
     DockAdaptor* adaptor = new DockAdaptor(this);
     Q_UNUSED(adaptor)
     QDBusConnection::sessionBus().registerService("org.deepin.ds.Dock");
@@ -100,6 +113,7 @@ bool DockPanel::init()
     });
     connect(SETTINGS, &DockSettings::positionChanged, this, [this, dockDaemonAdaptor](){
         Q_EMIT positionChanged(position());
+        Q_EMIT fashionModeChanged();
         Q_EMIT dockDaemonAdaptor->PositionChanged(position());
         Q_EMIT dockDaemonAdaptor->FrontendWindowRectChanged(frontendWindowRect());
 
@@ -117,9 +131,34 @@ bool DockPanel::init()
     connect(SETTINGS, &DockSettings::dockSizeChanged, this, &DockPanel::dockSizeChanged);
     connect(SETTINGS, &DockSettings::hideModeChanged, this, &DockPanel::hideModeChanged);
     connect(SETTINGS, &DockSettings::itemAlignmentChanged, this, &DockPanel::itemAlignmentChanged);
+    connect(SETTINGS, &DockSettings::itemAlignmentChanged, this, [this](){
+        // 时尚模式没有放开时不允许切过去，把对齐方式改回居中
+        if (!fashionModeEnabled() && SETTINGS->itemAlignment() == ItemAlignment::FashionAlignment) {
+            SETTINGS->setItemAlignment(ItemAlignment::CenterAlignment);
+            return;
+        }
+
+        // Fashion mode only supports top/bottom positions. If the dock is
+        // currently on the left/right edge when the user switches to fashion
+        // mode, snap it to bottom so the layout stays valid and the value
+        // persisted for the control center is consistent.
+        if (SETTINGS->itemAlignment() == ItemAlignment::FashionAlignment
+            && (position() == Position::Left || position() == Position::Right)) {
+            setPosition(Position::Bottom);
+        }
+        Q_EMIT fashionModeChanged();
+    });
     connect(SETTINGS, &DockSettings::indicatorStyleChanged, this, &DockPanel::indicatorStyleChanged);
     connect(SETTINGS, &DockSettings::lockedChanged, this, &DockPanel::lockedChanged);
     connect(SETTINGS, &DockSettings::contextMenuEnabledChanged, this, &DockPanel::contextMenuEnabledChanged);
+    connect(SETTINGS, &DockSettings::fashionModeEnabledChanged, this, [this](bool enabled){
+        // 开关被关掉时，正处于时尚模式的任务栏要回退成居中模式
+        if (!enabled && SETTINGS->itemAlignment() == ItemAlignment::FashionAlignment) {
+            SETTINGS->setItemAlignment(ItemAlignment::CenterAlignment);
+        }
+        Q_EMIT fashionModeEnabledChanged(enabled);
+    });
+    connect(SETTINGS, &DockSettings::cardCurrentChanged, this, &DockPanel::cardCurrentChanged);
 
     connect(SETTINGS, &DockSettings::dockSizeChanged, this, [this, dockDaemonAdaptor](){
         Q_EMIT dockDaemonAdaptor->WindowSizeEfficientChanged(dockSize());
@@ -299,6 +338,23 @@ void DockPanel::setItemAlignment(const ItemAlignment& alignment)
     SETTINGS->setItemAlignment(alignment);
 }
 
+bool DockPanel::fashionMode()
+{
+    const auto dockPosition = position();
+    return itemAlignment() == FashionAlignment
+        && (dockPosition == Top || dockPosition == Bottom);
+}
+
+QString DockPanel::cardCurrent() const
+{
+    return SETTINGS->cardCurrent();
+}
+
+void DockPanel::setCardCurrent(const QString &cardCurrent)
+{
+    SETTINGS->setCardCurrent(cardCurrent);
+}
+
 IndicatorStyle DockPanel::indicatorStyle()
 {
     return SETTINGS->indicatorStyle();
@@ -429,6 +485,11 @@ bool DockPanel::locked() const
 bool DockPanel::contextMenuEnabled() const
 {
     return SETTINGS->contextMenuEnabled();
+}
+
+bool DockPanel::fashionModeEnabled() const
+{
+    return SETTINGS->fashionModeEnabled();
 }
 
 void DockPanel::setLocked(bool newLocked)

--- a/panels/dock/dockpanel.h
+++ b/panels/dock/dockpanel.h
@@ -30,12 +30,15 @@ class DockPanel : public DS_NAMESPACE::DPanel, public QDBusContext
     Q_PROPERTY(HideMode hideMode READ hideMode WRITE setHideMode NOTIFY hideModeChanged FINAL)
     Q_PROPERTY(Position position READ position WRITE setPosition NOTIFY positionChanged FINAL)
     Q_PROPERTY(ItemAlignment itemAlignment READ itemAlignment WRITE setItemAlignment NOTIFY itemAlignmentChanged FINAL)
+    Q_PROPERTY(bool fashionMode READ fashionMode NOTIFY fashionModeChanged FINAL)
     Q_PROPERTY(IndicatorStyle indicatorStyle READ indicatorStyle WRITE setIndicatorStyle NOTIFY indicatorStyleChanged FINAL)
     Q_PROPERTY(bool showInPrimary READ showInPrimary WRITE setShowInPrimary NOTIFY showInPrimaryChanged FINAL)
     Q_PROPERTY(QString screenName READ screenName NOTIFY screenNameChanged FINAL)
     Q_PROPERTY(bool locked READ locked WRITE setLocked NOTIFY lockedChanged FINAL)
     Q_PROPERTY(bool isResizing READ isResizing WRITE setIsResizing NOTIFY isResizingChanged FINAL)
     Q_PROPERTY(bool contextMenuEnabled READ contextMenuEnabled NOTIFY contextMenuEnabledChanged FINAL)
+    Q_PROPERTY(bool fashionModeEnabled READ fashionModeEnabled NOTIFY fashionModeEnabledChanged FINAL)
+    Q_PROPERTY(QString cardCurrent READ cardCurrent WRITE setCardCurrent NOTIFY cardCurrentChanged FINAL)
 
     Q_PROPERTY(qreal devicePixelRatio READ devicePixelRatio NOTIFY devicePixelRatioChanged FINAL)
 
@@ -73,6 +76,14 @@ public:
     ItemAlignment itemAlignment();
     void setItemAlignment(const ItemAlignment& alignment);
 
+    bool fashionMode();
+
+    // The card shown in the card area, kept as "pluginId::itemKey" so it stays
+    // valid across restarts even when the card surfaces show up in a different
+    // order than before.
+    QString cardCurrent() const;
+    void setCardCurrent(const QString &cardCurrent);
+
     IndicatorStyle indicatorStyle();
     void setIndicatorStyle(const IndicatorStyle& style);
 
@@ -95,6 +106,9 @@ public:
     bool locked() const;
     void setLocked(bool newLocked);
     bool contextMenuEnabled() const;
+    // 时尚模式是否允许开启，对应 DConfig 的 enableFashionMode，默认关闭。
+    // 关闭时右键菜单不显示时尚模式入口，已保存的时尚模式也会回退成居中模式。
+    bool fashionModeEnabled() const;
 
     void setHideState(HideState newHideState);
     QScreen* dockScreen();
@@ -129,6 +143,8 @@ Q_SIGNALS:
     void beforePositionChanged(Position beforePosition);
     void positionChanged(Position position);
     void itemAlignmentChanged(ItemAlignment alignment);
+    void fashionModeChanged();
+    void cardCurrentChanged(const QString &cardCurrent);
     void indicatorStyleChanged(IndicatorStyle style);
     void showInPrimaryChanged(bool showInPrimary);
     void dockScreenChanged(QScreen *screen);
@@ -138,6 +154,7 @@ Q_SIGNALS:
     void devicePixelRatioChanged(qreal ratio);
     void lockedChanged(bool locked);
     void contextMenuEnabledChanged(bool enabled);
+    void fashionModeEnabledChanged(bool enabled);
 
     void contextDraggingChanged();
     void isResizingChanged(bool isResizing);

--- a/panels/dock/docksettings.cpp
+++ b/panels/dock/docksettings.cpp
@@ -25,9 +25,11 @@ const static QString keyDockSize                = "Dock_Size";
 const static QString keyItemAlignment           = "Item_Alignment";
 const static QString keyIndicatorStyle          = "Indicator_Style";
 const static QString keyPluginsVisible           = "Plugins_Visible";
+const static QString keyCardCurrent              = "cardCurrent";
 const static QString keyShowInPrimary           = "Show_In_Primary";
 const static QString keyLocked                  = "Locked";
 const static QString keyEnableContextMenu       = "enableContextMenu";
+const static QString keyEnableFashionMode       = "enableFashionMode";
 
 namespace dock {
 
@@ -86,6 +88,8 @@ static QString itemAlignment2String(const ItemAlignment& alignment)
             return "left";
         case ItemAlignment::CenterAlignment:
             return "center";
+        case ItemAlignment::FashionAlignment:
+            return "fashion";
     }
 
     return "center";
@@ -112,6 +116,8 @@ static ItemAlignment string2ItenAlignment(const QString& alignmentStr)
         return ItemAlignment::LeftAlignment;
     else if (alignmentStr == "center")
         return ItemAlignment::CenterAlignment;
+    else if (alignmentStr == "fashion")
+        return ItemAlignment::FashionAlignment;
 
     return ItemAlignment::CenterAlignment;
 }
@@ -151,6 +157,7 @@ DockSettings::DockSettings(QObject* parent)
     : QObject(parent)
     , m_dockConfig(DConfig::create("org.deepin.dde.shell", "org.deepin.ds.dock", QString(), this))
     , m_writeTimer(new QTimer(this))
+    , m_cardCurrentWriteTimer(new QTimer(this))
     , m_dockSize(dock::DEFAULT_DOCK_SIZE)
     , m_hideMode(dock::KeepShowing)
     , m_dockPosition(dock::Bottom)
@@ -161,6 +168,13 @@ DockSettings::DockSettings(QObject* parent)
 {
     m_writeTimer->setSingleShot(true);
     m_writeTimer->setInterval(1000);
+    m_cardCurrentWriteTimer->setSingleShot(true);
+    m_cardCurrentWriteTimer->setInterval(1000);
+    connect(m_cardCurrentWriteTimer, &QTimer::timeout, this, [this](){
+        if (m_dockConfig) {
+            m_dockConfig->setValue(keyCardCurrent, m_cardCurrent);
+        }
+    });
     qCInfo(dockSettingsLog) << "EventLogger initialized";
     init();
 }
@@ -174,9 +188,11 @@ void DockSettings::init()
         m_alignment = string2ItenAlignment(m_dockConfig->value(keyItemAlignment).toString());
         m_style = string2IndicatorStyle(m_dockConfig->value(keyIndicatorStyle).toString());
         m_pluginsVisible = m_dockConfig->value(keyPluginsVisible).toMap();
+        m_cardCurrent = m_dockConfig->value(keyCardCurrent).toString();
         m_showInPrimary = m_dockConfig->value(keyShowInPrimary).toBool();
         m_locked = m_dockConfig->value(keyLocked).toBool();
         m_contextMenuEnabled = m_dockConfig->value(keyEnableContextMenu, true).toBool();
+        m_fashionModeEnabled = m_dockConfig->value(keyEnableFashionMode, false).toBool();
 
         // Log dock config on startup - merge shell_pos and shell_dock_mode into one log entry
         logDockConfig(m_dockPosition, m_alignment, QStringLiteral("on startup"));
@@ -210,6 +226,13 @@ void DockSettings::init()
             } else if (keyPluginsVisible == key) {
                 auto pluginsVisible = m_dockConfig->value(keyPluginsVisible).toMap();
                 setPluginsVisible(pluginsVisible);
+            } else if (keyCardCurrent == key) {
+                auto cardCurrent = m_dockConfig->value(keyCardCurrent).toString();
+                if (cardCurrent == m_cardCurrent) return;
+                // Set the value directly, going through setCardCurrent() would
+                // write the value we have just read back to the config.
+                m_cardCurrent = cardCurrent;
+                Q_EMIT cardCurrentChanged(m_cardCurrent);
             } else if (keyShowInPrimary == key) {
                 auto showInPrimary = m_dockConfig->value(keyShowInPrimary).toBool();
                 if (showInPrimary == m_showInPrimary) return;
@@ -225,6 +248,11 @@ void DockSettings::init()
                 if (enabled == m_contextMenuEnabled) return;
                 m_contextMenuEnabled = enabled;
                 Q_EMIT contextMenuEnabledChanged(m_contextMenuEnabled);
+            } else if (keyEnableFashionMode == key) {
+                const auto enabled = m_dockConfig->value(keyEnableFashionMode, false).toBool();
+                if (enabled == m_fashionModeEnabled) return;
+                m_fashionModeEnabled = enabled;
+                Q_EMIT fashionModeEnabledChanged(m_fashionModeEnabled);
             }
         });
     } else {
@@ -319,6 +347,23 @@ void DockSettings::setPluginsVisible(const QVariantMap & pluginsVisible)
     Q_EMIT pluginsVisibleChanged(m_pluginsVisible);
 }
 
+QString DockSettings::cardCurrent() const
+{
+    return m_cardCurrent;
+}
+
+void DockSettings::setCardCurrent(const QString &cardCurrent)
+{
+    if (m_cardCurrent == cardCurrent) {
+        return;
+    }
+
+    m_cardCurrent = cardCurrent;
+    Q_EMIT cardCurrentChanged(m_cardCurrent);
+    // The value changes on every card switch (wheel/swipe), write it lazily.
+    m_cardCurrentWriteTimer->start();
+}
+
 void DockSettings::setShowInPrimary(bool newShowInPrimary)
 {
     if (m_showInPrimary == newShowInPrimary) {
@@ -342,6 +387,11 @@ bool DockSettings::locked() const
 bool DockSettings::contextMenuEnabled() const
 {
     return m_contextMenuEnabled;
+}
+
+bool DockSettings::fashionModeEnabled() const
+{
+    return m_fashionModeEnabled;
 }
 
 void DockSettings::setLocked(bool newLocked)

--- a/panels/dock/docksettings.h
+++ b/panels/dock/docksettings.h
@@ -26,9 +26,11 @@ class DockSettings : public QObject
     Q_PROPERTY(ItemAlignment itemAlignment READ itemAlignment WRITE setItemAlignment NOTIFY itemAlignmentChanged FINAL)
     Q_PROPERTY(IndicatorStyle indicatorStyle READ indicatorStyle WRITE setIndicatorStyle NOTIFY indicatorStyleChanged FINAL)
     Q_PROPERTY(QVariantMap pluginsVisible READ pluginsVisible WRITE setPluginsVisible NOTIFY pluginsVisibleChanged FINAL)
+    Q_PROPERTY(QString cardCurrent READ cardCurrent WRITE setCardCurrent NOTIFY cardCurrentChanged FINAL)
     Q_PROPERTY(bool showInPrimary READ showInPrimary WRITE setShowInPrimary NOTIFY showInPrimaryChanged FINAL)
     Q_PROPERTY(bool locked READ locked WRITE setLocked NOTIFY lockedChanged FINAL)
     Q_PROPERTY(bool contextMenuEnabled READ contextMenuEnabled NOTIFY contextMenuEnabledChanged FINAL)
+    Q_PROPERTY(bool fashionModeEnabled READ fashionModeEnabled NOTIFY fashionModeEnabledChanged FINAL)
 
 public:
     static DockSettings* instance();
@@ -39,9 +41,12 @@ public:
     ItemAlignment itemAlignment();
     IndicatorStyle indicatorStyle();
     QVariantMap pluginsVisible();
+    QString cardCurrent() const;
     bool showInPrimary() const;
     bool locked() const;
     bool contextMenuEnabled() const;
+    // 时尚模式是否允许开启，由 DConfig 的 enableFashionMode 控制，默认关闭
+    bool fashionModeEnabled() const;
 
     void setDockSize(const uint& size);
     void setHideMode(const HideMode& mode);
@@ -49,6 +54,7 @@ public:
     void setItemAlignment(const ItemAlignment& alignment);
     void setIndicatorStyle(const IndicatorStyle& style);
     void setPluginsVisible(const QVariantMap & pluginsVisible);
+    void setCardCurrent(const QString &cardCurrent);
     void setShowInPrimary(bool newShowInPrimary);
     void setLocked(bool newLocked);
 
@@ -75,14 +81,19 @@ Q_SIGNALS:
     void itemAlignmentChanged(ItemAlignment alignment);
     void indicatorStyleChanged(IndicatorStyle style);
     void pluginsVisibleChanged(const QVariantMap &pluginsVisible);
+    void cardCurrentChanged(const QString &cardCurrent);
 
     void showInPrimaryChanged(bool showInPrimary);
     void lockedChanged(bool locked);
     void contextMenuEnabledChanged(bool enabled);
+    void fashionModeEnabledChanged(bool enabled);
 
 private:
     QScopedPointer<DConfig> m_dockConfig;
     QTimer* m_writeTimer;
+    // The current card changes on every wheel/swipe event, debounce the writes
+    // separately so they cannot delay the other settings in m_writeJob.
+    QTimer* m_cardCurrentWriteTimer;
     QList<WriteJob> m_writeJob;
 
     uint m_dockSize;
@@ -91,8 +102,10 @@ private:
     ItemAlignment m_alignment;
     IndicatorStyle m_style;
     QVariantMap m_pluginsVisible;
+    QString m_cardCurrent;
     bool m_showInPrimary;
     bool m_locked;
     bool m_contextMenuEnabled;
+    bool m_fashionModeEnabled = false;
 };
 }

--- a/panels/dock/package/main.qml
+++ b/panels/dock/package/main.qml
@@ -19,13 +19,47 @@ Window {
     id: dock
     property int positionForAnimation: Panel.position
     property bool useColumnLayout: positionForAnimation % 2
-    property int dockCenterPartCount: dockCenterPartModel.count
 
+    property alias fashionDock: fashionDockState
+
+    QtObject {
+        id: fashionDockState
+
+        readonly property bool enabled: !dock.useColumnLayout
+            && Panel.itemAlignment === Dock.FashionAlignment
+            && (dock.positionForAnimation === Dock.Bottom || dock.positionForAnimation === Dock.Top)
+        readonly property int floatingMargin: 8
+        readonly property int backgroundRadius: {
+            const verticalPadding = Math.max(6, Math.round(dock.dockSize * 0.16))
+            return Math.round((dock.dockSize + verticalPadding * 2) / 4)
+        }
+        readonly property real contentWidth: {
+            if (!enabled) {
+                return 0
+            }
+
+            let width = gridLayout.implicitWidth
+            if (dockRightPart.visible) {
+                if (width > 0) {
+                    width += gridLayout.columnSpacing
+                }
+                width += dockRightPart.implicitWidth
+            }
+            return width
+        }
+    }
+    property int dockCenterPartCount: dockCenterPartModel.count
     readonly property int dockRawCenterSpace: {
         if (useColumnLayout) {
             return Screen.height - dockLeftPart.implicitHeight - dockRightPart.implicitHeight;
         } else {
-            return Screen.width - dockLeftPart.implicitWidth - dockRightPart.implicitWidth;
+            let space = Screen.width - dockLeftPart.implicitWidth - dockRightPart.implicitWidth;
+            if (fashionDock.enabled && gridLayout) {
+                // 时尚模式下，dockRightPart 在 gridLayout 右侧，之间需要扣除 dockSpacing
+                // 同时保留左右悬浮间距，避免窗口铺满屏幕后圆角边框被屏幕边缘裁剪。
+                space -= Math.ceil(gridLayout.columnSpacing) * 2 + fashionDock.floatingMargin * 2;
+            }
+            return Math.max(0, space);
         }
     }
 
@@ -45,7 +79,14 @@ Window {
     property real dockItemIconSize: dockItemMaxSize * 9 / 14
 
     // NOTE: -1 means not set its size, follow the platform size
-    width: positionForAnimation === Dock.Top || positionForAnimation === Dock.Bottom ? -1 : dockSize
+    width: {
+        if (fashionDock.enabled) {
+            const maximumWidth = Math.max(1, Screen.width - fashionDock.floatingMargin * 2)
+            return Math.max(1, Math.round(Math.min(fashionDock.contentWidth, maximumWidth)))
+        }
+
+        return positionForAnimation === Dock.Top || positionForAnimation === Dock.Bottom ? -1 : dockSize
+    }
     height: positionForAnimation === Dock.Left || positionForAnimation === Dock.Right ? -1 : dockSize
     color: "transparent"
     flags: Qt.WindowDoesNotAcceptFocus
@@ -68,14 +109,25 @@ Window {
         MenuHelper.openMenu(dockMenuLoader.item)
     }
 
-    DLayerShellWindow.anchors: position2Anchors(positionForAnimation)
+    DLayerShellWindow.anchors: fashionDock.enabled
+        ? (positionForAnimation === Dock.Top ? DLayerShellWindow.AnchorTop : DLayerShellWindow.AnchorBottom)
+        : position2Anchors(positionForAnimation)
+    DLayerShellWindow.topMargin: fashionDock.enabled && positionForAnimation === Dock.Top
+        ? fashionDock.floatingMargin
+        : 0
+
+    DLayerShellWindow.bottomMargin: fashionDock.enabled && positionForAnimation === Dock.Bottom
+        ? fashionDock.floatingMargin
+        : 0
     DLayerShellWindow.layer: DLayerShellWindow.LayerTop
-    DLayerShellWindow.exclusionZone: Panel.hideMode === Dock.KeepShowing ? Applet.dockSize : 0
+    DLayerShellWindow.exclusionZone: Panel.hideMode === Dock.KeepShowing
+        ? Applet.dockSize + (fashionDock.enabled ? fashionDock.floatingMargin : 0)
+        : 0
     DLayerShellWindow.scope: "dde-shell/dock"
     DLayerShellWindow.keyboardInteractivity: DLayerShellWindow.KeyboardInteractivityNone
 
     D.DWindow.enabled: true
-    D.DWindow.windowRadius: 0
+    D.DWindow.windowRadius: fashionDock.enabled ? fashionDock.backgroundRadius : 0
     //TODO：由于windoweffect处理有BUG，导致动画结束后一致保持无阴影，无borderwidth状态。 无法恢复到最初的阴影和边框
     //D.DWindow.windowEffect: hideShowAnimation.running ? D.PlatformHandle.EffectNoShadow | D.PlatformHandle.EffectNoBorder : 0
     
@@ -91,11 +143,20 @@ Window {
     D.DWindow.borderColor: D.DTK.themeType === D.ApplicationHelper.DarkType ? Qt.rgba(0, 0, 0, dock.blendColorAlpha(0.6) + 20 / 255) : Qt.rgba(0, 0, 0, 0.15)
     D.ColorSelector.family: D.Palette.CrystalColor
 
+    // 指示器样式只跟任务栏尺寸相关，三种模式保持一致：
+    // 拉到最小尺寸时用高效模式的指示器（应用图标带背景），其他尺寸用时尚模式的圆点指示器。
     onDockSizeChanged: {
         if (dock.dockSize === Dock.MIN_DOCK_SIZE) {
             Panel.indicatorStyle = Dock.Efficient
         } else {
             Panel.indicatorStyle = Dock.Fashion
+        }
+    }
+    Behavior on width {
+        enabled: fashionDock.enabled && !dock.isDragging
+        NumberAnimation {
+            duration: 200
+            easing.type: Easing.OutQuad
         }
     }
 
@@ -108,7 +169,7 @@ Window {
     PropertyAnimation {
         id: hideShowAnimation;
         // Currently, Wayland (Treeland) doesn't support StyledBehindWindowBlur inside the window, thus we keep using the window size approach on Wayland
-        property bool useTransformBasedAnimation: Qt.platform.pluginName === "xcb"
+        property bool useTransformBasedAnimation: Qt.platform.pluginName === "xcb" && !fashionDock.enabled
         property bool hiding: false
         target: useTransformBasedAnimation ? dockTransform : dock;
         property: {
@@ -136,7 +197,7 @@ Window {
 
     Connections {
         target: dockTransform
-        enabled: Qt.platform.pluginName === "xcb" && hideShowAnimation.running
+        enabled: hideShowAnimation.useTransformBasedAnimation && hideShowAnimation.running
         
         function onXChanged() {
             if (dock.useColumnLayout) {
@@ -153,7 +214,7 @@ Window {
 
     Connections {
         target: dock
-        enabled: Qt.platform.pluginName !== "xcb" && hideShowAnimation.running
+        enabled: !hideShowAnimation.useTransformBasedAnimation && hideShowAnimation.running
         
         function onWidthChanged() {
             if (dock.useColumnLayout) {
@@ -181,7 +242,7 @@ Window {
 
     SequentialAnimation {
         id: dockAnimation
-        property bool useTransformBasedAnimation: Qt.platform.pluginName === "xcb"
+        property bool useTransformBasedAnimation: Qt.platform.pluginName === "xcb" && !fashionDock.enabled
         property bool isShowing: false
         property bool isPositionChanging: false
         property var target: useTransformBasedAnimation ? dockTransform : dock
@@ -326,9 +387,18 @@ Window {
                     prop: "itemAlignment"
                     value: Dock.CenterAlignment
                 }
+                EnumPropertyMenuItem {
+                    name: qsTr("Fashion Mode")
+                    prop: "itemAlignment"
+                    value: Dock.FashionAlignment
+                    // 时尚模式尚未放开，由 DConfig 的 enableFashionMode 控制入口是否显示
+                    visible: Panel.fashionModeEnabled
+                }
             }
             MutuallyExclusiveMenu {
                 title: qsTr("Position")
+                // Fashion mode only allows top/bottom. Hide the left/right items
+                // from the context menu so the user can only pick supported edges.
                 EnumPropertyMenuItem {
                     name: qsTr("Top")
                     prop: "position"
@@ -343,11 +413,13 @@ Window {
                     name: qsTr("Left")
                     prop: "position"
                     value: Dock.Left
+                    visible: !fashionDock.enabled
                 }
                 EnumPropertyMenuItem {
                     name: qsTr("Right")
                     prop: "position"
                     value: Dock.Right
+                    visible: !fashionDock.enabled
                 }
             }
             MutuallyExclusiveMenu {
@@ -414,7 +486,7 @@ Window {
         D.StyledBehindWindowBlur {
             control: parent
             anchors.fill: parent
-            cornerRadius: 0
+            cornerRadius: fashionDock.enabled ? fashionDock.backgroundRadius : 0
             blendColor: {
                 if (valid) {
                     return DStyle.Style.control.selectColor(undefined,
@@ -500,7 +572,7 @@ Window {
         //此处为边距区域的点击实践特殊处理。
         MouseArea {                                                                                                                                     
             id: leftMarginArea                                                                                                                          
-            width: useColumnLayout ? parent.width : gridLayout.columnSpacing                                                                            
+            width: useColumnLayout ? parent.width : (fashionDock.enabled ? 0 : gridLayout.columnSpacing)
             height: useColumnLayout ? gridLayout.rowSpacing : parent.height                                                                             
             anchors.left: parent.left
             anchors.top: parent.top
@@ -519,16 +591,24 @@ Window {
         // TODO: remove GridLayout and use delegatechosser manager all items
         GridLayout {
             id: gridLayout
-            anchors.fill: parent
+            anchors {
+                fill: parent
+                rightMargin: fashionDock.enabled && dockRightPart.visible
+                    ? dockRightPart.implicitWidth + Math.ceil(gridLayout.columnSpacing)
+                    : 0
+            }
             columns: 1
             rows: 1
             flow: useColumnLayout ? GridLayout.LeftToRight : GridLayout.TopToBottom
             property real itemMargin: Math.max((dockItemIconSize / 48 * 10))
-            columnSpacing: dockLeftPartModel.count > 0 ? 10 : itemMargin
+            columnSpacing: fashionDock.enabled
+                ? dockItemIconSize
+                : (dockLeftPartModel.count > 0 ? 10 : itemMargin)
             rowSpacing: columnSpacing
 
             Item {
                 id: leftMargin
+                visible: !fashionDock.enabled
                 implicitWidth: 0
                 implicitHeight: 0
             }
@@ -562,8 +642,13 @@ Window {
                 Layout.maximumHeight: useColumnLayout ? dockRawCenterSpace : -1
                 onXChanged: dockCenterPartPosChanged()
                 onYChanged: dockCenterPartPosChanged()
-                Layout.leftMargin: !useColumnLayout && Panel.itemAlignment === Dock.CenterAlignment ?
-                    Math.max(0, (dock.width - dockCenterPart.implicitWidth) / 2 - (dockLeftPart.implicitWidth + 20) + Math.min((dock.width - dockCenterPart.implicitWidth) / 2 - (dockRightPart.implicitWidth + 20), 0)) : 0
+                Layout.leftMargin: {
+                    if (!useColumnLayout && fashionDock.enabled) {
+                        return dockLeftPart.visible ? 0 : Math.max(10, Math.round(dockItemIconSize) / 3)
+                    }
+                    return !useColumnLayout && Panel.itemAlignment === Dock.CenterAlignment ?
+                        Math.max(0, (dock.width - dockCenterPart.implicitWidth) / 2 - (dockLeftPart.implicitWidth + 20) + Math.min((dock.width - dockCenterPart.implicitWidth) / 2 - (dockRightPart.implicitWidth + 20), 0)) : 0
+                }
                 Layout.topMargin: useColumnLayout && Panel.itemAlignment === Dock.CenterAlignment ?
                     Math.max(0, (dock.height - dockCenterPart.implicitHeight) / 2 - (dockLeftPart.implicitHeight + 20) + Math.min((dock.height - dockCenterPart.implicitHeight) / 2 - (dockRightPart.implicitHeight + 20), 0)) : 0
 
@@ -597,8 +682,9 @@ Window {
             }
 
             Item {
-                Layout.fillWidth: true
-                Layout.fillHeight: true
+                Layout.fillWidth: !fashionDock.enabled
+                Layout.fillHeight: !fashionDock.enabled
+                visible: !fashionDock.enabled
             }
         }
 
@@ -879,6 +965,12 @@ Window {
 
         DockCompositor.dockSize = Qt.binding(function(){
             return Qt.size(Panel.frontendWindowRect.width, Panel.frontendWindowRect.height)
+        })
+
+        // 插件需要知道任务栏是否处于时尚模式，例如时间日期插件在时尚模式下
+        // 把时间和日期并排显示成一行
+        DockCompositor.fashionMode = Qt.binding(function(){
+            return Panel.fashionMode
         })
 
         DockCompositor.panelScale = Qt.binding(function(){

--- a/panels/dock/pluginmanagerextension.cpp
+++ b/panels/dock/pluginmanagerextension.cpp
@@ -253,6 +253,21 @@ bool PluginSurface::isItemActive() const
     return m_isItemActive;
 }
 
+int PluginSurface::cardOrder() const
+{
+    return m_cardOrder;
+}
+
+void PluginSurface::setCardOrder(int order)
+{
+    if (m_cardOrder == order) {
+        return;
+    }
+
+    m_cardOrder = order;
+    Q_EMIT cardOrderChanged();
+}
+
 void PluginSurface::updatePluginGeometry(const QRect &geometry)
 {
     m_itemPosition = geometry.topLeft();
@@ -652,6 +667,9 @@ void PluginManager::plugin_manager_v1_request_message(Resource *resource, const 
         // todo
     } else if (msgType == dock::MSG_ITEM_ACTIVE_STATE) {
         dstPlugin->setItemActive(rootObj.value(dock::MSG_DATA).toBool());
+    } else if (msgType == dock::MSG_CARD_ORDER) {
+        dstPlugin->setCardOrder(rootObj.value(dock::MSG_DATA)
+                                    .toInt(std::numeric_limits<int>::max()));
     } else if (msgType == dock::MSG_UPDATE_TOOLTIPS_VISIBLE) {
 
     }
@@ -676,6 +694,7 @@ void PluginManager::plugin_manager_v1_create_plugin(Resource *resource, const QS
     Q_EMIT pluginSurfaceCreated(plugin);
 
     sendEventMsg(resource, dockSizeMsg());
+    sendEventMsg(resource, fashionModeMsg());
     sendEventMsg(resource, popupMinHeightMsg());
 }
 
@@ -808,6 +827,20 @@ void PluginManager::setDockSize(const QSize &newDockSize)
     emit dockSizeChanged();
 }
 
+bool PluginManager::fashionMode() const
+{
+    return m_fashionMode;
+}
+
+void PluginManager::setFashionMode(bool newFashionMode)
+{
+    if (m_fashionMode == newFashionMode)
+        return;
+    m_fashionMode = newFashionMode;
+    sendEventMsg(fashionModeMsg());
+    emit fashionModeChanged();
+}
+
 void PluginManager::removePluginSurface(PluginSurface *plugin)
 {
     Q_EMIT pluginSurfaceDestroyed(plugin);
@@ -870,6 +903,14 @@ QString PluginManager::dockSizeMsg() const
     QJsonObject obj;
     obj[dock::MSG_TYPE] = dock::MSG_DOCK_PANEL_SIZE_CHANGED;
     obj[dock::MSG_DATA] = sizeData;
+    return toJson(obj);
+}
+
+QString PluginManager::fashionModeMsg() const
+{
+    QJsonObject obj;
+    obj[dock::MSG_TYPE] = dock::MSG_DOCK_FASHION_MODE;
+    obj[dock::MSG_DATA] = m_fashionMode;
     return toJson(obj);
 }
 

--- a/panels/dock/pluginmanagerextension_p.h
+++ b/panels/dock/pluginmanagerextension_p.h
@@ -15,6 +15,7 @@
 #include <QtWaylandCompositor/QWaylandSurface>
 
 #include <cstdint>
+#include <limits>
 
 #include "qwayland-server-fractional-scale-v1.h"
 #include "qwayland-server-plugin-manager-v1.h"
@@ -60,6 +61,7 @@ class PluginManager : public QWaylandCompositorExtensionTemplate<PluginManager>,
     Q_PROPERTY(uint32_t dockPosition READ dockPosition WRITE setDockPosition)
     Q_PROPERTY(uint32_t dockColorTheme READ dockColorTheme WRITE setDockColorTheme)
     Q_PROPERTY(QSize dockSize READ dockSize WRITE setDockSize NOTIFY dockSizeChanged FINAL)
+    Q_PROPERTY(bool fashionMode READ fashionMode WRITE setFashionMode NOTIFY fashionModeChanged FINAL)
 
 public:
     PluginManager(QWaylandCompositor *compositor = nullptr);
@@ -88,6 +90,9 @@ public:
     QSize dockSize() const;
     void setDockSize(const QSize &newDockSize);
 
+    bool fashionMode() const;
+    void setFashionMode(bool newFashionMode);
+
     void removePluginSurface(PluginSurface *plugin);
 
     //处理鼠标焦点给到相应插件
@@ -102,6 +107,7 @@ Q_SIGNALS:
     void pluginSurfaceDestroyed(PluginSurface*);
     void messageRequest(PluginSurface *, const QString &msg);
     void dockSizeChanged();
+    void fashionModeChanged();
     void requestShutdown(const QString &type);
     // Signal emitted when XEmbed window move is requested
     // Parameters: wid (window ID), pluginId, itemKey, dx, dy, anchorWindow (the window containing the plugin item)
@@ -125,6 +131,7 @@ private:
     void sendEventMsg(const QString &msg);
     void sendEventMsg(Resource *target, const QString &msg);
     QString dockSizeMsg() const;
+    QString fashionModeMsg() const;
     QString popupMinHeightMsg() const;
     using PluginSurfaceCallback = std::function<void(Resource *)>;
     void foreachPluginSurface(PluginSurfaceCallback callback);
@@ -141,6 +148,7 @@ private:
     uint32_t m_dockPosition = 0;
     uint32_t m_dockColorTheme = 0;
     QSize m_dockSize;
+    bool m_fashionMode = false;
     int m_popupMinHeight = 0;
     
     // Map of pending XEmbed callbacks: wid -> callback info
@@ -160,6 +168,7 @@ class PluginSurface : public QWaylandShellSurfaceTemplate<PluginSurface>, public
     Q_PROPERTY(int height READ height NOTIFY heightChanged)
     Q_PROPERTY(int width READ width NOTIFY widthChanged)
     Q_PROPERTY(bool isItemActive WRITE setItemActive READ isItemActive NOTIFY itemActiveChanged)
+    Q_PROPERTY(int cardOrder READ cardOrder NOTIFY cardOrderChanged)
     Q_PROPERTY(QString dccIcon READ dccIcon CONSTANT)
     Q_PROPERTY(int margins READ margins WRITE setMargins NOTIFY marginsChanged FINAL)
     QML_ELEMENT
@@ -195,6 +204,12 @@ public:
     void setItemActive(bool isActive);
     bool isItemActive() const;
 
+    // Sort order of a card surface, reported by the plugin.  Smaller comes
+    // first; cards sharing a value keep the order their surfaces were created
+    // in.  Until a plugin reports its order the card sorts last.
+    int cardOrder() const;
+    void setCardOrder(int order);
+
     Q_INVOKABLE void updatePluginGeometry(const QRect &geometry);
     Q_INVOKABLE void setGlobalPos(const QPoint &pos);
     Q_INVOKABLE void setAnchorWindow(QQuickWindow *window);
@@ -209,6 +224,7 @@ public:
 
 signals:
     void itemActiveChanged();
+    void cardOrderChanged();
     void heightChanged();
     void widthChanged();
     void recvMouseEvent(QEvent::Type type);
@@ -239,6 +255,7 @@ private:
     uint32_t m_sizePolicy;
 
     bool m_isItemActive = false;
+    int m_cardOrder = std::numeric_limits<int>::max();
     int m_margins = 0;
     int m_height;
     int m_width;

--- a/panels/dock/showdesktop/package/showdesktop.qml
+++ b/panels/dock/showdesktop/package/showdesktop.qml
@@ -13,11 +13,12 @@ AppletItem {
     id: showdesktop
     readonly property int showDesktopWidth: 10
     property bool useColumnLayout: Panel.position % 2
-    property int dockSize: Panel.rootObject.dockItemMaxSize
+    readonly property bool fashionMode: Panel.fashionMode
     property int dockOrder: 30
-    property bool shouldVisible: Applet.visible
-    implicitWidth: useColumnLayout ? Panel.rootObject.dockSize : showDesktopWidth
-    implicitHeight: useColumnLayout ? showDesktopWidth : Panel.rootObject.dockSize
+    property bool shouldVisible: Applet.visible && !fashionMode
+    visible: shouldVisible
+    implicitWidth: shouldVisible ? (useColumnLayout ? Panel.rootObject.dockSize : showDesktopWidth) : 0
+    implicitHeight: shouldVisible ? (useColumnLayout ? showDesktopWidth : Panel.rootObject.dockSize) : 0
 
     PanelToolTip {
         id: toolTip

--- a/panels/dock/taskmanager/package/TaskManager.qml
+++ b/panels/dock/taskmanager/package/TaskManager.qml
@@ -14,6 +14,7 @@ ContainmentItem {
     id: taskmanager
     property bool useColumnLayout: Panel.rootObject.useColumnLayout
     property int dockOrder: 16
+    readonly property bool fashionMode: Panel.fashionMode
 
     Accessible.role: Accessible.Grouping
     Accessible.name: qsTr("Task Manager")
@@ -24,7 +25,9 @@ ContainmentItem {
         return Panel.rootObject.dockRawCenterSpace - otherOccupied;
     }
 
-    readonly property real remainingSpacesForTaskManager: calcRemainingSpace(Panel.rootObject.dockItemMaxSize)
+    property real remainingSpacesForTaskManager: fashionMode
+        ? 0
+        : calcRemainingSpace(Panel.rootObject.dockItemMaxSize)
     readonly property int appTitleSpacing: Math.max(10, Math.round(Panel.rootObject.dockItemMaxSize * 9 / 14) / 3)
     // Start padding for the app container so that the visual gap
     // (multitask icon right edge → first app icon left edge) = appTitleSpacing.
@@ -40,25 +43,32 @@ ContainmentItem {
     readonly property real startPadding: Math.max(0, appTitleSpacing - (Panel.rootObject.dockItemMaxSize * (multitaskViewIconRatio - iconWidthToMaxSizeRatio) / 2))
 
     implicitWidth: {
-        // In column layout the width is fixed to the dock size, so do not
-        // depend on appContainer.implicitWidth (the delegates read this
-        // implicitWidth back, which would cause a binding loop).
+        // In column layout the width is the cross axis: it is fixed to the dock
+        // size, so do not depend on appContainer.implicitWidth (the delegates
+        // read this implicitWidth back, which would cause a binding loop).
         if (useColumnLayout)
             return Panel.rootObject.dockSize
-        let extra = startPadding
-        let w = appContainer.implicitWidth + extra
+        let w = appContainer.implicitWidth + startPadding
+        // Fashion mode hugs its content instead of filling the dock, and
+        // remainingSpacesForTaskManager is 0 there, so skip the clamping.
+        if (fashionMode)
+            return w
         return Panel.itemAlignment === Dock.LeftAlignment ? Math.max(remainingSpacesForTaskManager, w) : Math.min(remainingSpacesForTaskManager, w)
     }
     implicitHeight: {
-        // In row layout the height is fixed to the dock size, so do not
-        // depend on appContainer.implicitHeight (the delegates read this
-        // implicitHeight back, which would cause a binding loop).
+        // In row layout the height is the cross axis: it is fixed to the dock
+        // size, so do not depend on appContainer.implicitHeight (the delegates
+        // read this implicitHeight back, which would cause a binding loop).
         if (!useColumnLayout)
             return Panel.rootObject.dockSize
-        let extra = startPadding
-        let h = appContainer.implicitHeight + extra
+        let h = appContainer.implicitHeight + startPadding
+        // See implicitWidth: fashion mode sizes to its content.
+        if (fashionMode)
+            return h
         return Panel.itemAlignment === Dock.LeftAlignment ? Math.max(remainingSpacesForTaskManager, h) : Math.min(remainingSpacesForTaskManager, h)
     }
+
+    onFashionModeChanged: taskmanager.Applet.setFashionMode(fashionMode)
     // Helper function to find the current index of an app by its appId in the visualModel
     function findAppIndex(appId) {
         for (let i = 0; i < visualModel.items.count; i++) {
@@ -92,7 +102,7 @@ ContainmentItem {
 
     TextCalculator {
         id: textCalculator
-        enabled: taskmanager.Applet.windowSplit && (Panel.position == Dock.Bottom || Panel.position == Dock.Top)
+        enabled: !fashionMode && taskmanager.Applet.windowSplit && (Panel.position == Dock.Bottom || Panel.position == Dock.Top)
         dataModel: taskmanager.Applet.dataModel
         iconSize: Panel.rootObject.dockSize * 9 / 14
         spacing: Math.max(10, Math.round(textCalculator.iconSize) / 3)
@@ -346,6 +356,7 @@ ContainmentItem {
     }
 
     Component.onCompleted: {
+        taskmanager.Applet.setFashionMode(fashionMode)
         Panel.rootObject.dockItemMaxSize = Qt.binding(function(){
             const dockSize = Panel.rootObject.dockSize;
             const appCount = visualModel.count;

--- a/panels/dock/taskmanager/taskmanager.cpp
+++ b/panels/dock/taskmanager/taskmanager.cpp
@@ -153,6 +153,7 @@ TaskManager::TaskManager(QObject *parent)
     connect(Settings, &TaskManagerSettings::allowedForceQuitChanged, this, &TaskManager::allowedForceQuitChanged);
     connect(Settings, &TaskManagerSettings::showAttentionAnimationChanged, this, &TaskManager::showAttentionAnimationChanged);
     connect(Settings, &TaskManagerSettings::windowSplitChanged, this, &TaskManager::windowSplitChanged);
+    connect(Settings, &TaskManagerSettings::fashionModeChanged, this, &TaskManager::fashionModeChanged);
 }
 
 bool TaskManager::load()
@@ -477,6 +478,16 @@ bool TaskManager::RequestUndock(QString appID)
 bool TaskManager::windowSplit()
 {
     return Settings->isWindowSplit();
+}
+
+void TaskManager::setFashionMode(bool fashionMode)
+{
+    Settings->setFashionMode(fashionMode);
+}
+
+bool TaskManager::fashionMode()
+{
+    return Settings->fashionMode();
 }
 
 bool TaskManager::windowFullscreen()

--- a/panels/dock/taskmanager/taskmanager.h
+++ b/panels/dock/taskmanager/taskmanager.h
@@ -26,6 +26,7 @@ class TaskManager : public DS_NAMESPACE::DContainment, public AbstractTaskManage
     Q_PROPERTY(bool windowFullscreen READ windowFullscreen NOTIFY windowFullscreenChanged)
     Q_PROPERTY(bool allowForceQuit READ allowForceQuit NOTIFY allowedForceQuitChanged)
     Q_PROPERTY(bool showAttentionAnimation READ showAttentionAnimation NOTIFY showAttentionAnimationChanged)
+    Q_PROPERTY(bool fashionMode READ fashionMode NOTIFY fashionModeChanged)
 
 public:
     enum Roles {
@@ -80,6 +81,9 @@ public:
     bool windowFullscreen();
     bool allowForceQuit();
     bool showAttentionAnimation();
+    // Synced from QML (Panel.fashionMode); the window split is not applied in fashion mode.
+    Q_INVOKABLE void setFashionMode(bool fashionMode);
+    bool fashionMode();
 
     Q_INVOKABLE void requestActivate(const QModelIndex &index) const override;
     Q_INVOKABLE void requestNewInstance(const QModelIndex &index, const QString &action = QString()) const override;
@@ -113,6 +117,7 @@ Q_SIGNALS:
     void windowFullscreenChanged(bool);
     void allowedForceQuitChanged();
     void showAttentionAnimationChanged();
+    void fashionModeChanged();
 
 private Q_SLOTS:
     void handleWindowAdded(QPointer<AbstractWindow> window);

--- a/panels/dock/taskmanager/taskmanagersettings.cpp
+++ b/panels/dock/taskmanager/taskmanagersettings.cpp
@@ -96,15 +96,37 @@ bool TaskManagerSettings::showAttentionAnimation() const
     return m_showAttentionAnimation;
 }
 
-bool TaskManagerSettings::isWindowSplit()
+bool TaskManagerSettings::windowSplitValue() const
 {
     return m_windowSplit;
+}
+
+bool TaskManagerSettings::isWindowSplit()
+{
+    // The window split (noTaskGrouping) is not applied in fashion mode.
+    return m_windowSplit && !m_fashionMode;
 }
 
 void TaskManagerSettings::setWindowSplit(bool split)
 {
     m_windowSplit = split;
     m_taskManagerDconfig->setValue(TASKMANAGER_WINDOWSPLIT_KEY, m_windowSplit);
+}
+
+void TaskManagerSettings::setFashionMode(bool fashionMode)
+{
+    if (m_fashionMode == fashionMode)
+        return;
+
+    m_fashionMode = fashionMode;
+    // Notify consumers (models, QML) so the effective split state is re-evaluated.
+    Q_EMIT windowSplitChanged();
+    Q_EMIT fashionModeChanged();
+}
+
+bool TaskManagerSettings::fashionMode() const
+{
+    return m_fashionMode;
 }
 
 bool TaskManagerSettings::cgroupsBasedGrouping() const

--- a/panels/dock/taskmanager/taskmanagersettings.h
+++ b/panels/dock/taskmanager/taskmanagersettings.h
@@ -28,8 +28,15 @@ public:
 
     bool showAttentionAnimation() const;
 
+    // The DConfig value of "noTaskGrouping" (window split option in control center).
+    bool windowSplitValue() const;
+    // The effective split state: the DConfig value is not applied in fashion mode.
     bool isWindowSplit();
     void setWindowSplit(bool split);
+
+    // Fashion mode (Item_Alignment == "fashion") disables the window split feature.
+    void setFashionMode(bool fashionMode);
+    bool fashionMode() const;
 
     bool cgroupsBasedGrouping() const;
     QStringList cgroupsBasedGroupingSkipIds() const;
@@ -56,6 +63,7 @@ Q_SIGNALS:
     void allowedForceQuitChanged();
     void showAttentionAnimationChanged();
     void windowSplitChanged();
+    void fashionModeChanged();
     void dockedItemsChanged();
     void dockedElementsChanged();
     void dockedApplicationsEnabledChanged(bool enabled);
@@ -66,6 +74,7 @@ private:
     bool m_allowForceQuit;
     bool m_showAttentionAnimation;
     bool m_windowSplit;
+    bool m_fashionMode = false;
     bool m_cgroupsBasedGrouping;
     bool m_dockedApplicationsEnabled;
     QStringList m_dockedElements;

--- a/panels/dock/tray/package/tray.qml
+++ b/panels/dock/tray/package/tray.qml
@@ -152,6 +152,8 @@ AppletItem {
             return true
         if (DockCompositor.findSurfaceFromModel(DockCompositor.fixedPluginSurfaces, surfaceId))
             return true
+        if (DockCompositor.findSurfaceFromModel(DockCompositor.cardPluginSurfaces, surfaceId))
+            return true
         return false
     }
 


### PR DESCRIPTION
1. Implement fashion dock mode as a new item alignment style with floating window appearance, rounded corners, and content-based sizing
2. Add new plugin type `Card` for card-style plugins displayed in the dock
3. Create CardLeftDockArea component supporting multiple card plugins with swipe navigation, wheel switching, and page indicators
4. Add card sorting mechanism allowing plugins to report their display order
5. Add card current position persistence across dock restarts
6. Implement fashion mode propagation to plugins and task manager
7. Add fashion mode enable/disable configuration with fallback to centered mode
8. Disable window split functionality in fashion mode
9. Update context menu to reflect fashion mode constraints

Log: Added fashion dock mode with card plugin area, including sorting, persistence, and plugin communication support

Influence:
1. Test switching between centered and fashion dock modes via context menu
2. Verify fashion mode disables left/right position options
3. Test card plugin display, sorting, and swapping between multiple cards
4. Test card persistence across dock restarts
5. Verify fashion mode correctly hides show desktop button
6. Test that window split is not applied in fashion mode
7. Verify fashion mode disabled via DConfig returns to centered mode
8. Test plugin communication of fashion mode state

feat: 添加时尚模式任务栏及卡片插件支持

1. 实现时尚模式任务栏，采用新的对齐方式，支持悬浮窗口、圆角和自适应内容 宽度
2. 添加“卡片”类型插件，用于在任务栏展示卡片样式组件
3. 创建卡片区域组件，支持多卡片滑动切换、滚轮切换和页面指示器
4. 添加卡片排序机制，插件可上报显示顺序
5. 添加卡片当前位置持久化，重启后恢复
6. 实现时尚模式状态向插件和任务管理器的通知
7. 增加时尚模式开关配置，关闭时回退至居中模式
8. 时尚模式下禁用窗口分屏功能
9. 更新右键菜单以适配时尚模式限制

Log: 新增时尚模式任务栏和卡片插件区域，包含排序、状态持久化及插件通信
支持

Influence:
1. 测试通过右键菜单在居中模式和时尚模式之间切换
2. 验证时尚模式下左/右位置选项被隐藏
3. 测试卡片插件的显示、排序，以及多卡片之间的切换
4. 测试任务栏重启后卡片位置恢复
5. 验证时尚模式下显示桌面图标被隐藏
6. 测试时尚模式下窗口分屏功能无效
7. 验证通过 DConfig 关闭时尚模式后回退至居中模式
8. 测试插件接收时尚模式状态通知

PMS: TASK-392671

## Summary by Sourcery

Introduce fashion dock mode and card plugin support with persistent navigation, plugin integration, and mode-specific behavior.

New Features:
- Add a fashion dock mode with floating, rounded, content-sized presentation and configuration-controlled availability.
- Support card-style dock plugins with ordered display, vertical swipe and wheel navigation, page indicators, and popup handling.
- Persist the selected card across dock restarts and communicate fashion-mode state to dock plugins and the task manager.

Bug Fixes:
- Fall back to centered alignment when fashion mode is disabled or unavailable.
- Prevent unsupported left/right positioning and window splitting while fashion mode is active.
- Hide the show-desktop control in fashion mode.

Enhancements:
- Update dock context-menu options to reflect fashion-mode constraints and supported positions.

Build:
- Include the new card dock area package in the dock build.