### PR TITLE
fix: 修复4K 225%缩放下切换深色模式时插件面板图标偶现黑色（DDE-225）

### DIFF
--- a/panels/dock/pluginmanagerextension.cpp
+++ b/panels/dock/pluginmanagerextension.cpp
@@ -483,6 +483,18 @@ void PluginPopup::plugin_popup_set_cursor(Resource *resource, int32_t cursor_sha
 PluginManager::PluginManager(QWaylandCompositor *compositor)
     : QWaylandCompositorExtensionTemplate(compositor)
 {
+    m_themeNotifyTimer = new QTimer(this);
+    m_themeNotifyTimer->setSingleShot(true);
+    m_themeNotifyTimer->setInterval(0);
+    connect(m_themeNotifyTimer, &QTimer::timeout, this, [this]() {
+        foreachPluginSurface([this](Resource *source) {
+            send_color_theme_changed(source->handle, m_dockColorTheme);
+            auto theme = DGuiApplicationHelper::instance()->applicationTheme();
+            send_theme_changed(source->handle, theme->themeName(), theme->iconThemeName());
+            send_active_color_changed(source->handle, theme->activeColor().name(), theme->darkActiveColor().name());
+        });
+    });
+
     auto theme = DGuiApplicationHelper::instance()->applicationTheme();
     QObject::connect(theme, &DPlatformTheme::fontNameChanged, this, &PluginManager::onFontChanged);
     QObject::connect(theme, &DPlatformTheme::fontPointSizeChanged, this, &PluginManager::onFontChanged);
@@ -609,12 +621,7 @@ void PluginManager::setDockColorTheme(uint32_t type)
         return;
 
     m_dockColorTheme = type;
-    foreach (PluginSurface *plugin, m_pluginSurfaces) {
-        Resource *target = resourceMap().value(plugin->surface()->waylandClient());
-        if (target) {
-            send_color_theme_changed(target->handle, m_dockColorTheme);
-        }
-    }
+    scheduleThemeNotify();
 }
 
 void PluginManager::setEmbedPanelMinHeight(int height)
@@ -824,10 +831,7 @@ void PluginManager::onFontChanged()
 
 void PluginManager::onActiveColorChanged()
 {
-    foreachPluginSurface([this](Resource *source) {
-        auto theme = DGuiApplicationHelper::instance()->applicationTheme();
-        send_active_color_changed(source->handle, theme->activeColor().name(), theme->darkActiveColor().name());
-    });
+    scheduleThemeNotify();
 }
 
 PluginSurface* PluginManager::findPluginSurface(const QString &pluginId, const QString &itemKey) const
@@ -842,10 +846,7 @@ PluginSurface* PluginManager::findPluginSurface(const QString &pluginId, const Q
 
 void PluginManager::onThemeChanged()
 {
-    foreachPluginSurface([this](Resource *source) {
-        auto theme = DGuiApplicationHelper::instance()->applicationTheme();
-        send_theme_changed(source->handle, theme->themeName(), theme->iconThemeName());
-    });
+    scheduleThemeNotify();
 }
 
 void PluginManager::foreachPluginSurface(PluginSurfaceCallback callback)
@@ -856,6 +857,12 @@ void PluginManager::foreachPluginSurface(PluginSurfaceCallback callback)
             callback(target);
         }
     }
+}
+
+void PluginManager::scheduleThemeNotify()
+{
+    if (m_themeNotifyTimer)
+        m_themeNotifyTimer->start();
 }
 
 QString PluginManager::dockSizeMsg() const

--- a/panels/dock/pluginmanagerextension.cpp
+++ b/panels/dock/pluginmanagerextension.cpp
@@ -487,9 +487,9 @@ PluginManager::PluginManager(QWaylandCompositor *compositor)
     m_themeNotifyTimer->setSingleShot(true);
     m_themeNotifyTimer->setInterval(0);
     connect(m_themeNotifyTimer, &QTimer::timeout, this, [this]() {
-        foreachPluginSurface([this](Resource *source) {
+        auto theme = DGuiApplicationHelper::instance()->applicationTheme();
+        foreachPluginSurface([this, theme](Resource *source) {
             send_color_theme_changed(source->handle, m_dockColorTheme);
-            auto theme = DGuiApplicationHelper::instance()->applicationTheme();
             send_theme_changed(source->handle, theme->themeName(), theme->iconThemeName());
             send_active_color_changed(source->handle, theme->activeColor().name(), theme->darkActiveColor().name());
         });

--- a/panels/dock/pluginmanagerextension_p.h
+++ b/panels/dock/pluginmanagerextension_p.h
@@ -6,6 +6,7 @@
 
 #include <QMap>
 #include <QPointer>
+#include <QTimer>
 #include <QQuickWindow>
 #include <QtWaylandCompositor/QWaylandCompositor>
 #include <QtWaylandCompositor/QWaylandQuickExtension>
@@ -128,6 +129,7 @@ private:
     QString popupMinHeightMsg() const;
     using PluginSurfaceCallback = std::function<void(Resource *)>;
     void foreachPluginSurface(PluginSurfaceCallback callback);
+    void scheduleThemeNotify();
     PluginSurface* findPluginSurface(const QString &pluginId, const QString &itemKey) const;
 
 private:
@@ -146,6 +148,7 @@ private:
     // Map of pending XEmbed callbacks: wid -> callback info
     // Supports multiple concurrent requests from different clients
     QMap<uint32_t, PendingXEmbedCallback> m_pendingXEmbedCallbacks;
+    QTimer *m_themeNotifyTimer = nullptr;
 };
 
 class PluginSurface : public QWaylandShellSurfaceTemplate<PluginSurface>, public QtWaylandServer::plugin


### PR DESCRIPTION
## 修复说明

4K 屏幕、225% 缩放下切换深色模式时，插件面板中图标偶现未切换成功、显示为黑色。

### 根因
主题切换时三路 Wayland 事件非原子化发送，触发多次重绘竞态；高 DPI 分数缩放下图标渲染时序问题导致图标偶现黑色。

### 修改内容
- 修复主题切换事件的发送时序，确保原子化通知
- 优化图标刷新逻辑，避免竞态条件下的错误渲染

### 关联
- PMS: https://pms.uniontech.com/bug-view-339969.html
- Multica Issue: [DDE-225](https://agentapi-dev.uniontech.com/issues/01a07ed1-d053-766c-a5de-48cc1b4e98ff)

## Summary by Sourcery

确保插件面板在主题切换时及时且一致地刷新图标与颜色状态。

Bug Fixes:
- 修复高 DPI 分数缩放下切换深色模式时插件面板图标偶现显示为黑色的问题。

Enhancements:
- 统一并延迟插件主题相关通知，确保颜色、主题和活动色变更以一致的时序发送，避免重复重绘竞态。