### PR TITLE
fix(shell): track delayed Treeland primary output

### DIFF
--- a/shell/treelandoutputwatcher.cpp
+++ b/shell/treelandoutputwatcher.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -14,6 +14,8 @@ TreelandOutputWatcher::TreelandOutputWatcher(QObject *parent)
     : QWaylandClientExtensionTemplate<TreelandOutputWatcher>(treeland_output_manager_v1_interface.version)
 {
     setParent(parent);
+
+    connect(qApp, &QGuiApplication::screenAdded, this, &TreelandOutputWatcher::onScreenAdded);
 }
 
 TreelandOutputWatcher::~TreelandOutputWatcher()
@@ -21,15 +23,31 @@ TreelandOutputWatcher::~TreelandOutputWatcher()
     destroy();
 }
 
+void TreelandOutputWatcher::onScreenAdded(QScreen *)
+{
+    if (!m_pendingPrimaryName.isEmpty())
+        applyPrimary(m_pendingPrimaryName);
+}
+
 void TreelandOutputWatcher::treeland_output_manager_v1_primary_output(const QString &output_name)
 {
-    if (qApp->primaryScreen()->name() == output_name)
+    applyPrimary(output_name);
+}
+
+void TreelandOutputWatcher::applyPrimary(const QString &output_name)
+{
+    if (qApp->primaryScreen() && qApp->primaryScreen()->name() == output_name) {
+        m_pendingPrimaryName.clear();
         return;
+    }
 
     for (auto screen : qApp->screens()) {
         if (screen->name() == output_name) {
+            m_pendingPrimaryName.clear();
             QWindowSystemInterface::handlePrimaryScreenChanged(screen->handle());
             return;
         }
     }
+
+    m_pendingPrimaryName = output_name;
 }

--- a/shell/treelandoutputwatcher.h
+++ b/shell/treelandoutputwatcher.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -6,6 +6,9 @@
 
 #include "qwayland-treeland-output-manager-v1.h"
 #include <QtWaylandClient/QWaylandClientExtension>
+#include <QString>
+
+class QScreen;
 
 class TreelandOutputWatcher : public QWaylandClientExtensionTemplate<TreelandOutputWatcher>, public QtWayland::treeland_output_manager_v1
 {
@@ -16,4 +19,10 @@ public:
 
 protected:
     void treeland_output_manager_v1_primary_output(const QString &output_name) override;
+
+private:
+    void onScreenAdded(QScreen *);
+    void applyPrimary(const QString &output_name);
+
+    QString m_pendingPrimaryName;
 };


### PR DESCRIPTION
PMS: https://pms.uniontech.com/task-view-395387.html

## Problem
Treeland may send primary_output before Qt has created the matching QScreen when switching from single screen to extended mode. The old code dropped that event, leaving dde-shell dock on the previous primary screen.

## Solution
Cache the pending output name and retry when QGuiApplication::screenAdded is emitted.

## Verification
- cmake --build build --target dde-shell -j$(nproc)
- dpkg-buildpackage -us -uc -b

## Summary by Sourcery

Handle Treeland primary-output events that arrive before Qt creates the matching screen.

Bug Fixes:
- Ensure delayed Treeland primary-output notifications are applied when the corresponding Qt screen becomes available, preventing the dock from remaining on the previous primary screen.

Enhancements:
- Refactor primary-screen handling to share immediate and deferred output application logic.