### PR TITLE
style: adjust icon offset to use hover background spacing

### DIFF
--- a/panels/dock/taskmanager/package/AppItem.qml
+++ b/panels/dock/taskmanager/package/AppItem.qml
@@ -215,10 +215,10 @@ Item {
                         switch (Panel.position) {
                         case Dock.Top:
                         case Dock.Bottom:
-                            return (root.height - icon.height) / 2
+                            return hoverBackground.verticalSpacing
                         case Dock.Left:
                         case Dock.Right:
-                            return (root.width - icon.width) / 2
+                            return hoverBackground.horizontalSpacing
                         }
                     }
 


### PR DESCRIPTION
1. Replace manual icon position calculation with configured hover background spacing values
2. Fix positioning inconsistency when icon and tooltip backgrounds have different margins

Log: Adjusted icon offset calculation in task manager for dock panel

Influence:
1. Verify icon alignment in all dock panel positions (top, bottom, left, right)
2. Test icon positioning with different hover background configurations
3. Confirm icon remains centered relative to hover background

style: 调整图标偏移以使用悬停背景间距

1. 将手动图标位置计算替换为配置的悬停背景间距值
2. 修复图标和提示背景边距不一致时的定位问题

Log: 调整任务管理器停靠面板中的图标偏移计算

Influence:
1. 验证停靠面板所有方向（上、下、左、右）的图标对齐情况
2. 测试不同悬停背景配置下的图标定位
3. 确认图标相对于悬停背景始终居中显示

PMS: BUG-375531

## Summary by Sourcery

Bug Fixes:
- Align task manager icons consistently with the configured hover background spacing across all dock panel orientations.