### PR TITLE
feat: adapt taskmanager to v2 toplevel protocol

### DIFF
--- a/panels/dock/taskmanager/CMakeLists.txt
+++ b/panels/dock/taskmanager/CMakeLists.txt
@@ -90,7 +90,7 @@ add_library(dock-taskmanager SHARED ${DBUS_INTERFACES}
 
 qt_generate_wayland_protocol_client_sources(dock-taskmanager
     FILES
-        ${TREELAND_PROTOCOLS_DATA_DIR}/treeland-foreign-toplevel-manager-v1.xml
+        ${TREELAND_PROTOCOLS_DATA_DIR}/treeland-foreign-toplevel-manager-unstable-v2.xml
         ${WaylandProtocols_DATADIR}/staging/ext-foreign-toplevel-list/ext-foreign-toplevel-list-v1.xml
 )
 

--- a/panels/dock/taskmanager/treelandwindow.cpp
+++ b/panels/dock/taskmanager/treelandwindow.cpp
@@ -17,9 +17,9 @@
 Q_LOGGING_CATEGORY(waylandwindowLog, "org.deepin.dde.shell.dock.taskmanager.treelandwindow")
 
 namespace dock {
-ForeignToplevelHandle::ForeignToplevelHandle(struct ::treeland_foreign_toplevel_handle_v1 *object)
-    : QWaylandClientExtensionTemplate<ForeignToplevelHandle>(2)
-    , QtWayland::treeland_foreign_toplevel_handle_v1(object)
+ForeignToplevelHandle::ForeignToplevelHandle(struct ::treeland_foreign_toplevel_handle_v2 *object)
+    : QWaylandClientExtensionTemplate<ForeignToplevelHandle>(1)
+    , QtWayland::treeland_foreign_toplevel_handle_v2(object)
     , m_pid(0)
     , m_isReady(false)
     , m_identifier(0)
@@ -64,7 +64,7 @@ bool ForeignToplevelHandle::isReady() const
     return m_isReady;
 }
 
-void ForeignToplevelHandle::treeland_foreign_toplevel_handle_v1_pid(uint32_t pid)
+void ForeignToplevelHandle::treeland_foreign_toplevel_handle_v2_pid(uint32_t pid)
 {
     if (pid == m_pid) return;
 
@@ -72,7 +72,7 @@ void ForeignToplevelHandle::treeland_foreign_toplevel_handle_v1_pid(uint32_t pid
     Q_EMIT pidChanged();
 }
 
-void ForeignToplevelHandle::treeland_foreign_toplevel_handle_v1_title(const QString &title)
+void ForeignToplevelHandle::treeland_foreign_toplevel_handle_v2_title(const QString &title)
 {
     if (title == m_title) return;
 
@@ -80,7 +80,7 @@ void ForeignToplevelHandle::treeland_foreign_toplevel_handle_v1_title(const QStr
     Q_EMIT titleChanged();
 }
 
-void ForeignToplevelHandle::treeland_foreign_toplevel_handle_v1_app_id(const QString &app_id)
+void ForeignToplevelHandle::treeland_foreign_toplevel_handle_v2_app_id(const QString &app_id)
 {
     if (app_id == m_appId) return;
     m_appId = app_id;
@@ -88,13 +88,13 @@ void ForeignToplevelHandle::treeland_foreign_toplevel_handle_v1_app_id(const QSt
     Q_EMIT appidChanged();
 }
 
-void ForeignToplevelHandle::treeland_foreign_toplevel_handle_v1_identifier(uint32_t identifier)
+void ForeignToplevelHandle::treeland_foreign_toplevel_handle_v2_identifier(uint32_t identifier)
 {
     if (identifier == m_identifier) return;
     m_identifier = identifier;
 }
 
-void ForeignToplevelHandle::treeland_foreign_toplevel_handle_v1_state(wl_array *state)
+void ForeignToplevelHandle::treeland_foreign_toplevel_handle_v2_state(wl_array *state)
 {
     m_states.clear();
     const uint32_t* items = reinterpret_cast<const uint32_t*>(state->data);
@@ -107,14 +107,14 @@ void ForeignToplevelHandle::treeland_foreign_toplevel_handle_v1_state(wl_array *
     Q_EMIT stateChanged();
 }
 
-void ForeignToplevelHandle::treeland_foreign_toplevel_handle_v1_done()
+void ForeignToplevelHandle::treeland_foreign_toplevel_handle_v2_done()
 {
     if (!m_isReady) {
         m_isReady = true;
         Q_EMIT handlerIsReady();
     }
 }
-void ForeignToplevelHandle::treeland_foreign_toplevel_handle_v1_closed()
+void ForeignToplevelHandle::treeland_foreign_toplevel_handle_v2_closed()
 {
     destroy();
     Q_EMIT handlerIsDeleted();
@@ -230,7 +230,7 @@ void TreeLandWindow::setWindowIconGeometry(const QWindow* baseWindow, const QRec
     if (waylandWindow->surface() == nullptr || gemeotry.isEmpty())
         return;
 
-    m_foreignToplevelHandle->set_rectangle(waylandWindow->surface(), gemeotry.x(), gemeotry.y(), gemeotry.width(), gemeotry.height());
+    m_foreignToplevelHandle->set_icon_geometry(waylandWindow->surface(), gemeotry.x(), gemeotry.y(), gemeotry.width(), gemeotry.height());
 }
 
 bool TreeLandWindow::isReady()

--- a/panels/dock/taskmanager/treelandwindow.h
+++ b/panels/dock/taskmanager/treelandwindow.h
@@ -5,7 +5,7 @@
 #pragma once
 
 #include "abstractwindow.h"
-#include "qwayland-treeland-foreign-toplevel-manager-v1.h"
+#include "qwayland-treeland-foreign-toplevel-manager-unstable-v2.h"
 
 #include <cstdint>
 #include <sys/types.h>
@@ -14,12 +14,12 @@
 #include <QtWaylandClient/QWaylandClientExtension>
 
 namespace dock {
-class ForeignToplevelHandle : public QWaylandClientExtensionTemplate<ForeignToplevelHandle>, public QtWayland::treeland_foreign_toplevel_handle_v1
+class ForeignToplevelHandle : public QWaylandClientExtensionTemplate<ForeignToplevelHandle>, public QtWayland::treeland_foreign_toplevel_handle_v2
 {
     Q_OBJECT
 
 public:
-    explicit ForeignToplevelHandle(struct ::treeland_foreign_toplevel_handle_v1 *object);
+    explicit ForeignToplevelHandle(struct ::treeland_foreign_toplevel_handle_v2 *object);
     ~ForeignToplevelHandle();
     bool isReady() const;
     uint32_t id() const;
@@ -40,13 +40,13 @@ Q_SIGNALS:
     void stateChanged();
 
 protected:
-    void treeland_foreign_toplevel_handle_v1_pid(uint32_t pid) override;
-    void treeland_foreign_toplevel_handle_v1_title(const QString &title) override;
-    void treeland_foreign_toplevel_handle_v1_app_id(const QString &app_id) override;
-    void treeland_foreign_toplevel_handle_v1_identifier(uint32_t identifier) override;
-    void treeland_foreign_toplevel_handle_v1_state(wl_array *state) override;
-    void treeland_foreign_toplevel_handle_v1_done() override;
-    void treeland_foreign_toplevel_handle_v1_closed() override;
+    void treeland_foreign_toplevel_handle_v2_pid(uint32_t pid) override;
+    void treeland_foreign_toplevel_handle_v2_title(const QString &title) override;
+    void treeland_foreign_toplevel_handle_v2_app_id(const QString &app_id) override;
+    void treeland_foreign_toplevel_handle_v2_identifier(uint32_t identifier) override;
+    void treeland_foreign_toplevel_handle_v2_state(wl_array *state) override;
+    void treeland_foreign_toplevel_handle_v2_done() override;
+    void treeland_foreign_toplevel_handle_v2_closed() override;
 
 private:
     uint32_t m_pid;
@@ -65,11 +65,11 @@ class TreeLandWindow : public AbstractWindow
     Q_OBJECT
 
     enum WindowState {
-        Active      = QtWayland::treeland_foreign_toplevel_handle_v1::state_activated,
-        Maximized   = QtWayland::treeland_foreign_toplevel_handle_v1::state_maximized,
-        Minimized   = QtWayland::treeland_foreign_toplevel_handle_v1::state_minimized,
-        Fullscreen  = QtWayland::treeland_foreign_toplevel_handle_v1::state_fullscreen,
-        Attention   = QtWayland::treeland_foreign_toplevel_handle_v1::state_attention
+        Active      = QtWayland::treeland_foreign_toplevel_handle_v2::state_activated,
+        Maximized   = QtWayland::treeland_foreign_toplevel_handle_v2::state_maximized,
+        Minimized   = QtWayland::treeland_foreign_toplevel_handle_v2::state_minimized,
+        Fullscreen  = QtWayland::treeland_foreign_toplevel_handle_v2::state_fullscreen,
+        Attention   = QtWayland::treeland_foreign_toplevel_handle_v2::state_attention
     };
 
 public:

--- a/panels/dock/taskmanager/treelandwindowmonitor.cpp
+++ b/panels/dock/taskmanager/treelandwindowmonitor.cpp
@@ -19,18 +19,18 @@
 
 namespace dock {
 ForeignToplevelManager::ForeignToplevelManager(TreeLandWindowMonitor* monitor)
-    : QWaylandClientExtensionTemplate<ForeignToplevelManager>(2)
+    : QWaylandClientExtensionTemplate<ForeignToplevelManager, &QtWayland::treeland_foreign_toplevel_manager_v2::destroy>(1)
     , m_monitor(monitor)
 {
 }
 
-void ForeignToplevelManager::treeland_foreign_toplevel_manager_v1_toplevel(struct ::treeland_foreign_toplevel_handle_v1 *toplevel)
+void ForeignToplevelManager::treeland_foreign_toplevel_manager_v2_toplevel(struct ::treeland_foreign_toplevel_handle_v2 *toplevel)
 {
     ForeignToplevelHandle* handle = new ForeignToplevelHandle(toplevel);
     connect(handle, &ForeignToplevelHandle::handlerIsReady, m_monitor, &TreeLandWindowMonitor::handleForeignToplevelHandleAdded, Qt::UniqueConnection);
 }
 
-TreeLandDockPreviewContext::TreeLandDockPreviewContext(struct ::treeland_dock_preview_context_v1 *context)
+TreeLandDockPreviewContext::TreeLandDockPreviewContext(struct ::treeland_dock_preview_context_v2 *context)
     : QWaylandClientExtensionTemplate<TreeLandDockPreviewContext>(1)
     , m_isPreviewEntered(false)
     , m_isDockMouseAreaEnter(false)
@@ -66,12 +66,12 @@ void TreeLandDockPreviewContext::hideWindowsPreview()
     m_hideTimer->start();
 }
 
-void TreeLandDockPreviewContext::treeland_dock_preview_context_v1_enter()
+void TreeLandDockPreviewContext::treeland_dock_preview_context_v2_enter()
 {
     m_isPreviewEntered = true;
 }
 
-void TreeLandDockPreviewContext::treeland_dock_preview_context_v1_leave()
+void TreeLandDockPreviewContext::treeland_dock_preview_context_v2_leave()
 {
     m_isPreviewEntered = false;
     m_hideTimer->start();

--- a/panels/dock/taskmanager/treelandwindowmonitor.h
+++ b/panels/dock/taskmanager/treelandwindowmonitor.h
@@ -6,7 +6,7 @@
 
 #include "treelandwindow.h"
 #include "abstractwindowmonitor.h"
-#include "qwayland-treeland-foreign-toplevel-manager-v1.h"
+#include "qwayland-treeland-foreign-toplevel-manager-unstable-v2.h"
 
 #include <QHash>
 #include <QList>
@@ -16,7 +16,7 @@
 #include <QtWaylandClient/QWaylandClientExtension>
 
 namespace dock {
-class ForeignToplevelManager : public QWaylandClientExtensionTemplate<ForeignToplevelManager>, public QtWayland::treeland_foreign_toplevel_manager_v1
+class ForeignToplevelManager : public QWaylandClientExtensionTemplate<ForeignToplevelManager, &QtWayland::treeland_foreign_toplevel_manager_v2::destroy>, public QtWayland::treeland_foreign_toplevel_manager_v2
 {
     Q_OBJECT
 public:
@@ -26,18 +26,18 @@ Q_SIGNALS:
     void newForeignToplevelHandle(ForeignToplevelHandle *handle);
 
 protected:
-    void treeland_foreign_toplevel_manager_v1_toplevel(struct ::treeland_foreign_toplevel_handle_v1 *toplevel) override;
+    void treeland_foreign_toplevel_manager_v2_toplevel(struct ::treeland_foreign_toplevel_handle_v2 *toplevel) override;
 
 private:
     TreeLandWindowMonitor* m_monitor;
 };
 
-class TreeLandDockPreviewContext : public QWaylandClientExtensionTemplate<TreeLandDockPreviewContext>, public QtWayland::treeland_dock_preview_context_v1
+class TreeLandDockPreviewContext : public QWaylandClientExtensionTemplate<TreeLandDockPreviewContext>, public QtWayland::treeland_dock_preview_context_v2
 {
     Q_OBJECT
 
 public:
-    explicit TreeLandDockPreviewContext(struct ::treeland_dock_preview_context_v1 *);
+    explicit TreeLandDockPreviewContext(struct ::treeland_dock_preview_context_v2 *);
     ~TreeLandDockPreviewContext();
     void showWindowsPreview(QByteArray windowsId, int32_t previewXoffset, int32_t previewYoffset, uint32_t direction);
     void hideWindowsPreview();
@@ -48,8 +48,8 @@ Q_SIGNALS:
     void closed();
 
 protected:
-    virtual void treeland_dock_preview_context_v1_enter() override;
-    virtual void treeland_dock_preview_context_v1_leave() override;
+    virtual void treeland_dock_preview_context_v2_enter() override;
+    virtual void treeland_dock_preview_context_v2_leave() override;
     friend class TreeLandWindowMonitor;
 
 private:


### PR DESCRIPTION
## Summary

Adapt the dock taskmanager module from `treeland-foreign-toplevel-manager-v1` to `treeland-foreign-toplevel-manager-unstable-v2` protocol.

## Changes (5 files, 39 insertions, 39 deletions)

1. **CMakeLists.txt**: Protocol XML reference updated from v1 to unstable-v2
2. **treelandwindow.h / treelandwindow.cpp**: All Wayland class, namespace, and method references renamed from v1 to v2; constructor version changed from 2 to 1; `set_rectangle` request renamed to `set_icon_geometry`
3. **treelandwindowmonitor.h / treelandwindowmonitor.cpp**: `ForeignToplevelManager` and `TreeLandDockPreviewContext` class/namespace/method references updated from v1 to v2; manager constructor version changed from 2 to 1

## Multica Issue

[DDE-230](https://agentapi-dev.uniontech.com/issues/01a0842b-c3d1-78fe-a86b-155308fa55f4)

## Summary by Sourcery

Migrate the dock task manager from the Treeland foreign toplevel manager v1 protocol to unstable v2.

New Features:
- Update the dock task manager to use the Treeland foreign toplevel manager unstable v2 protocol.

Enhancements:
- Align task window handling, monitoring, preview contexts, and icon geometry requests with the v2 Wayland protocol API.

Build:
- Generate Wayland client bindings from the unstable v2 protocol definition.