### PR TITLE
fix: migrate treeland output protocol v1 to v2

### DIFF
--- a/panels/notification/osd/brightness/CMakeLists.txt
+++ b/panels/notification/osd/brightness/CMakeLists.txt
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-find_package(TreelandProtocols REQUIRED)
+find_package(TreelandProtocols 0.6 REQUIRED)
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(WaylandClient REQUIRED IMPORTED_TARGET wayland-client)
 
@@ -16,7 +16,7 @@ add_library(osd-brightness SHARED
 qt_generate_wayland_protocol_client_sources(osd-brightness
     NO_INCLUDE_CORE_ONLY
     FILES
-        ${TREELAND_PROTOCOLS_DATA_DIR}/treeland-output-manager-v1.xml
+        ${TREELAND_PROTOCOLS_DATA_DIR}/treeland-output-manager-unstable-v2.xml
 )
 
 target_link_libraries(osd-brightness PRIVATE

--- a/panels/notification/osd/brightness/treelandbrightness.cpp
+++ b/panels/notification/osd/brightness/treelandbrightness.cpp
@@ -4,7 +4,7 @@
 
 #include "treelandbrightness.h"
 
-#include "wayland-treeland-output-manager-v1-client-protocol.h"
+#include "wayland-treeland-output-manager-unstable-v2-client-protocol.h"
 
 #include <QGuiApplication>
 #include <QScreen>
@@ -13,9 +13,9 @@
 
 namespace osd {
 
-TreelandColorControl::TreelandColorControl(struct ::treeland_output_color_control_v1 *object, QObject *parent)
+TreelandColorControl::TreelandColorControl(struct ::treeland_output_picture_control_v2 *object, QObject *parent)
     : QObject(parent)
-    , QtWayland::treeland_output_color_control_v1(object)
+    , QtWayland::treeland_output_picture_control_v2(object)
 {
 }
 
@@ -31,14 +31,14 @@ double TreelandColorControl::brightness() const
     return m_brightness;
 }
 
-void TreelandColorControl::treeland_output_color_control_v1_brightness(wl_fixed_t brightness)
+void TreelandColorControl::treeland_output_picture_control_v2_brightness(wl_fixed_t brightness)
 {
     m_brightness = wl_fixed_to_double(brightness);
     Q_EMIT brightnessChanged(m_brightness);
 }
 
 TreelandBrightness::TreelandBrightness(QObject *parent)
-    : QWaylandClientExtensionTemplate<TreelandBrightness>(treeland_output_manager_v1_interface.version)
+    : QWaylandClientExtensionTemplate<TreelandBrightness>(treeland_output_manager_v2_interface.version)
 {
     setParent(parent);
     connect(this, &TreelandBrightness::activeChanged, this, &TreelandBrightness::refresh);
@@ -76,7 +76,7 @@ void TreelandBrightness::refresh()
         return;
     }
 
-    auto *raw = get_color_control(output);
+    auto *raw = get_picture_control(output);
     if (!raw) {
         return;
     }

--- a/panels/notification/osd/brightness/treelandbrightness.h
+++ b/panels/notification/osd/brightness/treelandbrightness.h
@@ -4,23 +4,23 @@
 
 #pragma once
 
-#include "qwayland-treeland-output-manager-v1.h"
+#include "qwayland-treeland-output-manager-unstable-v2.h"
 
 #include <QObject>
 #include <QPointer>
 #include <QtWaylandClient/QWaylandClientExtension>
 
 struct wl_output;
-struct treeland_output_color_control_v1;
+struct treeland_output_picture_control_v2;
 
 namespace osd {
 
-class TreelandColorControl : public QObject, public QtWayland::treeland_output_color_control_v1
+class TreelandColorControl : public QObject, public QtWayland::treeland_output_picture_control_v2
 {
     Q_OBJECT
 
 public:
-    explicit TreelandColorControl(struct ::treeland_output_color_control_v1 *object, QObject *parent = nullptr);
+    explicit TreelandColorControl(struct ::treeland_output_picture_control_v2 *object, QObject *parent = nullptr);
     ~TreelandColorControl() override;
 
     double brightness() const;
@@ -29,18 +29,18 @@ Q_SIGNALS:
     void brightnessChanged(double brightness);
 
 protected:
-    void treeland_output_color_control_v1_brightness(wl_fixed_t brightness) override;
+    void treeland_output_picture_control_v2_brightness(wl_fixed_t brightness) override;
 
 private:
     double m_brightness = 0.0;
 };
 
 // Read-only Treeland brightness provider for the OSD. It binds a single
-// treeland_output_color_control_v1 to the primary wl_output and caches the
+// treeland_output_picture_control_v2 to the primary wl_output and caches the
 // brightness reported by the compositor. It never commits brightness changes;
 // dde-shortcut-tool is responsible for adjusting brightness, and this provider
 // only reflects the resulting value.
-class TreelandBrightness : public QWaylandClientExtensionTemplate<TreelandBrightness>, public QtWayland::treeland_output_manager_v1
+class TreelandBrightness : public QWaylandClientExtensionTemplate<TreelandBrightness>, public QtWayland::treeland_output_manager_v2
 {
     Q_OBJECT
 

--- a/shell/CMakeLists.txt
+++ b/shell/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 find_package(Dtk${DTK_VERSION_MAJOR} COMPONENTS Widget REQUIRED)
 find_package(Qt${QT_VERSION_MAJOR} ${REQUIRED_QT_VERSION} REQUIRED COMPONENTS Widgets Gui WaylandClient)
-find_package(TreelandProtocols REQUIRED)
+find_package(TreelandProtocols 0.6 REQUIRED)
 pkg_check_modules(WaylandClient REQUIRED IMPORTED_TARGET wayland-client)
 
 if (NOT DEFINED SYSTEMD_USER_UNIT_DIR)
@@ -30,7 +30,7 @@ add_executable(dde-shell
 
 qt_generate_wayland_protocol_client_sources(dde-shell
     FILES
-        ${TREELAND_PROTOCOLS_DATA_DIR}/treeland-output-manager-v1.xml
+        ${TREELAND_PROTOCOLS_DATA_DIR}/treeland-output-manager-unstable-v2.xml
 )
 
 target_compile_definitions(dde-shell

--- a/shell/treelandoutputwatcher.cpp
+++ b/shell/treelandoutputwatcher.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "treelandoutputwatcher.h"
-#include "wayland-treeland-output-manager-v1-client-protocol.h"
+#include "wayland-treeland-output-manager-unstable-v2-client-protocol.h"
 
 #include <QGuiApplication>
 #include <QScreen>
@@ -11,7 +11,7 @@
 #include <qpa/qwindowsysteminterface.h>
 
 TreelandOutputWatcher::TreelandOutputWatcher(QObject *parent)
-    : QWaylandClientExtensionTemplate<TreelandOutputWatcher>(treeland_output_manager_v1_interface.version)
+    : QWaylandClientExtensionTemplate<TreelandOutputWatcher>(treeland_output_manager_v2_interface.version)
 {
     setParent(parent);
 }
@@ -21,13 +21,14 @@ TreelandOutputWatcher::~TreelandOutputWatcher()
     destroy();
 }
 
-void TreelandOutputWatcher::treeland_output_manager_v1_primary_output(const QString &output_name)
+void TreelandOutputWatcher::treeland_output_manager_v2_primary_output(struct ::wl_output *output)
 {
-    if (qApp->primaryScreen()->name() == output_name)
+    if (!output)
         return;
 
     for (auto screen : qApp->screens()) {
-        if (screen->name() == output_name) {
+        auto *waylandScreen = screen->nativeInterface<QNativeInterface::QWaylandScreen>();
+        if (waylandScreen && waylandScreen->output() == output) {
             QWindowSystemInterface::handlePrimaryScreenChanged(screen->handle());
             return;
         }

--- a/shell/treelandoutputwatcher.h
+++ b/shell/treelandoutputwatcher.h
@@ -4,10 +4,12 @@
 
 #pragma once
 
-#include "qwayland-treeland-output-manager-v1.h"
+#include "qwayland-treeland-output-manager-unstable-v2.h"
 #include <QtWaylandClient/QWaylandClientExtension>
 
-class TreelandOutputWatcher : public QWaylandClientExtensionTemplate<TreelandOutputWatcher>, public QtWayland::treeland_output_manager_v1
+struct wl_output;
+
+class TreelandOutputWatcher : public QWaylandClientExtensionTemplate<TreelandOutputWatcher>, public QtWayland::treeland_output_manager_v2
 {
     Q_OBJECT
 public:
@@ -15,5 +17,5 @@ public:
     ~TreelandOutputWatcher();
 
 protected:
-    void treeland_output_manager_v1_primary_output(const QString &output_name) override;
+    void treeland_output_manager_v2_primary_output(struct ::wl_output *output) override;
 };


### PR DESCRIPTION
## Treeland output 协议 v2 适配

将 dde-shell 中两处 treeland output v1 协议消费者迁移到 v2（纯协议消费者迁移，无逻辑变更）。

### 改动文件（6 个）

| 文件 | 改动 |
|---|---|
| `shell/CMakeLists.txt` | `find_package(TreelandProtocols 0.6 REQUIRED)`；XML 引用 → `treeland-output-manager-unstable-v2.xml` |
| `shell/treelandoutputwatcher.h` | include → `qwayland-treeland-output-manager-unstable-v2.h`；基类 → `treeland_output_manager_v2`；override 签名 `QString` → `struct ::wl_output*`；新增 `struct wl_output;` 前置声明 |
| `shell/treelandoutputwatcher.cpp` | include → `…-unstable-v2-client-protocol.h`；接口版本 → `treeland_output_manager_v2_interface.version`；`primary_output` 改为 null 早返回 + 遍历 `qApp->screens()` 通过 `QNativeInterface::QWaylandScreen::output()` 反查 QScreen |
| `panels/notification/osd/brightness/CMakeLists.txt` | 同上版本约束 + XML 引用（保留 `NO_INCLUDE_CORE_ONLY`） |
| `panels/notification/osd/brightness/treelandbrightness.h` | 全部符号 `color_control_v1` → `picture_control_v2`；`treeland_output_manager_v1` → `v2`；本地类名 `TreelandColorControl` 保留不变 |
| `panels/notification/osd/brightness/treelandbrightness.cpp` | 全部符号更名；`get_color_control` → `get_picture_control`；接口版本更新 |

### 关键说明

- **构建依赖**：treeland-protocols ≥ 0.6（v2 XML 由 master 提供，尚未发 tag）
- **无 `#include <QNativeInterface>`**：Qt6 不为该命名空间生成转发头文件，`QWaylandScreen` 通过 `<QScreen>` 传递性引入
- **null 处理**：v2 `primary_output` 事件 `allow-null="true"`，实现中 null 早返回
- **顺带修复**：v1 代码 `qApp->primaryScreen()->name()` 在 `primaryScreen()` 返回 null 时会崩溃；v2 版本增加了 null 防护

Ref: DDE-232

## Summary by Sourcery

Migrate Treeland output consumers to protocol v2 while preserving existing output and brightness behavior.

Bug Fixes:
- Prevent crashes when no primary screen is available and safely handle null primary-output events.

Enhancements:
- Migrate shell output tracking and brightness monitoring from the Treeland output protocol v1 to the unstable v2 protocol.
- Identify the primary screen using its Wayland output object and update brightness handling for v2 picture controls.

Build:
- Require TreelandProtocols 0.6 and generate clients from the Treeland output manager unstable v2 protocol.