### PR TITLE
fix(notification): prevent bubble window from taking focus

### DIFF
--- a/panels/notification/bubble/package/main.qml
+++ b/panels/notification/bubble/package/main.qml
@@ -76,6 +76,7 @@ Window {
     DLayerShellWindow.rightMargin: windowMargin(1)
     DLayerShellWindow.bottomMargin: windowMargin(2)
     DLayerShellWindow.exclusionZone: -1
+    flags: Qt.WindowDoesNotAcceptFocus
     palette: DTK.palette
     ColorSelector.family: Palette.CrystalColor
     // DWindow.windowEffect: PlatformHandle.EffectNoBorder | PlatformHandle.EffectNoShadow


### PR DESCRIPTION
## Summary

The notification banner window steals keyboard focus from the active window when a notification pops up. Add `Qt.WindowDoesNotAcceptFocus` so the banner never grabs focus, matching the dock and OSD windows which already use this flag.

- Add `Qt.WindowDoesNotAcceptFocus` to the bubble window flags
- The banner remains interactive (hover/click close, action buttons) — the flag only suppresses focus

## Log

Notification banner window no longer takes focus

## Influence

Active window keeps focus when a banner appears

PMS: BUG-375861

## Summary by Sourcery

Bug Fixes:
- Prevent notification banner windows from stealing focus from the active application when they appear.