### PR TITLE
fix: correct tray drag hover index handling

### DIFF
--- a/panels/dock/tray/package/TrayContainer.qml
+++ b/panels/dock/tray/package/TrayContainer.qml
@@ -151,6 +151,7 @@ Item {
         onEntered: function (dragEvent) {
             dragExited = false
             isDropped = false
+            dropHoverIndex = -1
             surfaceId = dragEvent.getDataAsString("text/x-dde-shell-tray-dnd-surfaceId")
             source = dragEvent.getDataAsString("text/x-dde-shell-tray-dnd-source")
             console.log(surfaceId, source)
@@ -170,12 +171,11 @@ Item {
             let currentItemIndex = dropIdx.index
             let isBefore = dropIdx.isBefore            
             let isStash = dragEvent.getDataAsString("text/x-dde-shell-tray-dnd-sectionType") === "stashed"
-            dropHoverIndex = dropIdx.index
-            
             // 检查当前悬停位置是否是禁止拖拽的插件
             let modelIndex = DDT.TraySortOrderModel.getModelIndexByVisualIndex(currentItemIndex)
             let sectionType = root.model.data(modelIndex, DDT.TraySortOrderModel.SectionTypeRole)
             if (sectionType === "fixed") {
+                dropHoverIndex = -1
                 dragEvent.accepted = false
                 return
             }
@@ -192,7 +192,14 @@ Item {
             }
             
             // 根据 ActionShowStashDelegate 的显示状态动态改变条件
-            let shouldAllowDrop = showStashActionVisible ? (dropHoverIndex !== 0) : (dropHoverIndex !== -1)
+            let shouldAllowDrop = showStashActionVisible ? (currentItemIndex !== 0) : (currentItemIndex !== -1)
+            let isApplicationTray = surfaceId.startsWith("application-tray")
+            if (!shouldAllowDrop && !isApplicationTray) {
+                dropHoverIndex = -1
+                dragEvent.accepted = false
+                return
+            }
+            dropHoverIndex = currentItemIndex
 
             if (shouldAllowDrop && (isStash || source === "quickPanel")) {
                 // 收纳区或快捷面板拖拽：使用暂存机制
@@ -204,8 +211,6 @@ Item {
                     DDT.TraySortOrderModel.dropToDockTray(surfaceId, Math.floor(currentItemIndex), isBefore)
                 }
                 dropTrayTimer.start()
-            } else if (!surfaceId.startsWith("application-tray")){
-                dragEvent.accepted = false
             }
         }
         
@@ -235,10 +240,12 @@ Item {
                 }
             }
             DDT.TraySortOrderModel.actionsAlwaysVisible = false
+            dropHoverIndex = -1
         }
 
         onExited: function () {
             dragExited = true
+            dropHoverIndex = -1
             DDT.TraySortOrderModel.clearStagedDrop()
             // Hide action icons when drag leaves tray without dropping
             if (!isDropped) {


### PR DESCRIPTION
1. Reset dropHoverIndex to -1 on drag enter and exit events
2. Move dropHoverIndex assignment to after validation checks
3. Use currentItemIndex instead of dropHoverIndex for drop allowance logic
4. Reject drops on fixed section plugins and non-application-tray items that shouldn't be dropped
5. Remove redundant surfaceId check in the else branch
6. Ensure dropHoverIndex is cleared after drag completion and exit

Influence:
1. Test dragging items into the system tray and verify hover indicator appears correctly
2. Verify that dropping on fixed section plugins is rejected
3. Test drag behavior with application-tray items vs other tray items
4. Verify stash action visibility toggle affects drop behavior correctly
5. Test dragging from quick panel and stashed area
6. Confirm hover index resets properly when drag enters, exits, or completes
7. Test edge cases with index 0 and -1 positions

fix: 修复托盘拖拽悬停索引处理问题

1. 在拖拽进入和退出事件中将 dropHoverIndex 重置为 -1
2. 将 dropHoverIndex 赋值移到验证检查之后
3. 使用 currentItemIndex 替代 dropHoverIndex 判断是否允许放置
4. 拒绝对固定区域插件和不应放置的非应用托盘项的放置操作
5. 移除 else 分支中冗余的 surfaceId 检查
6. 确保拖拽完成和退出后清除 dropHoverIndex

Influence:
1. 测试将项目拖入系统托盘，验证悬停指示器正确显示
2. 验证对固定区域插件的放置被正确拒绝
3. 测试应用托盘项与其他托盘项的拖拽行为差异
4. 验证收纳操作可见性切换对放置行为的正确影响
5. 测试从快捷面板和收纳区拖拽
6. 确认拖拽进入、退出或完成时悬停索引正确重置
7. 测试索引 0 和 -1 位置的边界情况

PMS: BUG-301129

## Summary by Sourcery

Fix tray drag-and-drop validation and hover state handling to provide accurate indicators and reject unsupported drop targets.

Bug Fixes:
- Correct tray drag-and-drop hover index handling and reset behavior across drag entry, exit, and completion.
- Reject invalid drops on fixed sections and unsupported non-application tray items while preserving valid application-tray drops.

Enhancements:
- Use the current hovered item position for drop validation and dynamically respect stash action visibility.