### PR TITLE
fix(dock): support Qt 6.10 filter invalidation

### DIFF
--- a/panels/dock/taskmanager/hoverpreviewproxymodel.cpp
+++ b/panels/dock/taskmanager/hoverpreviewproxymodel.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2025-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -22,7 +22,11 @@ void HoverPreviewProxyModel::setFilter(QString filter, enum FilterMode mode)
     m_filter = filter;
     m_filterMode = mode;
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
+    endFilterChange(Direction::Both);
+#else
     invalidateFilter();
+#endif
 }
 
 void HoverPreviewProxyModel::clearFilter()

--- a/panels/dock/tray/ksortfilterproxymodel.cpp
+++ b/panels/dock/tray/ksortfilterproxymodel.cpp
@@ -246,7 +246,11 @@ void KSortFilterProxyModel::componentComplete()
 
 void KSortFilterProxyModel::invalidateFilter()
 {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
+    QSortFilterProxyModel::endFilterChange(QSortFilterProxyModel::Direction::Both);
+#else
     QSortFilterProxyModel::invalidateFilter();
+#endif
 }
 
 #include "moc_ksortfilterproxymodel.cpp"


### PR DESCRIPTION
Support the Qt 6.10 filter-change API in the tray and hover preview models by using endFilterChange(Direction::Both) when available. Retain invalidateFilter() for older Qt versions.

Preserve lazy proxy initialization, filter callback timing, and model signals by invalidating directly without beginFilterChange(). Keep setter ordering and the tray model's public invalidateFilter() slot unchanged.

Log: Support Qt 6.10 in dock proxy models

## Summary by Sourcery

Support Qt 6.10 filter invalidation in dock proxy models while preserving compatibility with older Qt versions.

New Features:
- Add Qt 6.10-compatible filter invalidation to the dock tray and hover preview proxy models.

Bug Fixes:
- Maintain filter updates for older Qt versions through the existing invalidation behavior.

Chores:
- Update copyright years in the hover preview proxy model.