### PR TITLE
fix(dde-apps): support GCC 16 meta-object compilation

### DIFF
--- a/applets/dde-apps/appgroupmanager.h
+++ b/applets/dde-apps/appgroupmanager.h
@@ -14,6 +14,8 @@
 #include <QStandardItemModel>
 
 class ItemsPage;
+Q_MOC_INCLUDE("itemspage.h")
+
 namespace apps {
 // To make it easier to access in QML
 struct ItemPosition


### PR DESCRIPTION
Tell moc to include itemspage.h for the ItemsPage* return type of AppGroupManager::groupPages(). Without its definition, Qt probes the forward-declared type in a SFINAE context before the combined MOC translation unit defines it. GCC 16 diagnoses this with -Wsfinae-incomplete, and the project's -Werror setting turns the warning into a build failure.

Q_MOC_INCLUDE keeps the ordinary header's forward declaration while making the type complete for generated metadata.

Log: Fix dde-apps builds with GCC 16

## Summary by Sourcery

Bug Fixes:
- Fix dde-apps builds with GCC 16 by ensuring Qt meta-object compilation sees the complete ItemsPage type.